### PR TITLE
chore(deploy): switch from Netlify to Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 .cache
 dist
 
+# Vercel
+.vercel
+
 # Node dependencies
 node_modules
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ npm run build        # production build (Nitro server + SPA)
 
 ## Deploy
 
-### Netlify (recommended)
+### Vercel (recommended)
 
-`netlify.toml` is preconfigured: `npm run build` produces the Nitro server, and
-the `/api/*` routes (the TMDB proxy) deploy as serverless functions. Set the
-`NUXT_*` environment variables in the Netlify dashboard.
+Zero-config: import the repo in Vercel and it auto-detects Nuxt, runs `nuxt build`,
+and Nitro's Vercel preset ships the static SPA plus serverless functions for the
+`/api/*` routes (the TMDB proxy). No `vercel.json` needed.
+
+Set the env vars under **Project → Settings → Environment Variables** — the same
+`NUXT_*` keys as `.env.example`: the public `NUXT_PUBLIC_FIREBASE_*` config and the
+server-only `NUXT_TMDB_API_KEY`. (Node 22 is picked up from `engines` in package.json.)
 
 ### Firebase (rules & indexes)
 

--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -2,7 +2,7 @@
 import type { Suggestion } from '#shared/types/suggestion'
 
 const props = defineProps<{ suggestion: Suggestion, voteLocked?: boolean }>()
-const emit = defineEmits<{ vote: []; unvote: []; remove: [] }>()
+const emit = defineEmits<{ vote: [], unvote: [], remove: [] }>()
 
 const { user } = useAuth()
 const { posterUrl } = useTmdb()

--- a/firebase.json
+++ b/firebase.json
@@ -2,19 +2,5 @@
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
-  },
-  "hosting": {
-    "public": "dist",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
   }
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,0 @@
-[build]
-  command = "npm run build"
-  publish = "dist"
-
-[build.environment]
-  NODE_VERSION = "22"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,13 +2,11 @@
 export default defineNuxtConfig({
   modules: ['@nuxt/ui', '@nuxt/eslint'],
 
-  devtools: { enabled: true },
-
   // Client-rendered SPA: Firebase auth is client-only. Nitro still serves /api/*
   // routes (e.g. the TMDB proxy) as serverless functions when deployed.
   ssr: false,
 
-  css: ['~/assets/css/main.css'],
+  devtools: { enabled: true },
 
   app: {
     head: {
@@ -22,11 +20,17 @@ export default defineNuxtConfig({
     }
   },
 
+  css: ['~/assets/css/main.css'],
+
   runtimeConfig: {
-    // Server-only — never shipped to the browser. Override via NUXT_TMDB_API_KEY.
+    // Server-only — never shipped to the browser. Nitro overrides this from
+    // NUXT_TMDB_API_KEY at runtime.
     tmdbApiKey: '',
     public: {
-      // Firebase web config is public by design. Override via NUXT_PUBLIC_FIREBASE_*.
+      // Firebase web config is public by design. Nitro injects these from the
+      // NUXT_PUBLIC_FIREBASE_* environment variables into the served HTML at
+      // request time — so they must be set in the deploy environment (Vercel),
+      // not just locally. Defaults are intentionally empty.
       firebase: {
         apiKey: '',
         authDomain: '',


### PR DESCRIPTION
## Scope

Switch deployment from Netlify to Vercel (the Netlify setup was removed).

## Implementation

- Remove `netlify.toml`. Vercel is **zero-config** for Nuxt: it auto-detects the
  framework, runs `nuxt build`, and Nitro's Vercel preset ships the static SPA plus
  serverless functions for the `/api/*` routes (the TMDB proxy). No `vercel.json` needed.
- Verified locally with `NITRO_PRESET=vercel npm run build` → produces
  `.vercel/output` with `config.json`, the static assets, and a function bundling
  `routes/api/movies/search.get.mjs` (the TMDB proxy). Node 22 comes from `engines`.
- Drop the now-unused Firebase **Hosting** block from `firebase.json` (Firebase is
  auth + Firestore only now); `firestore:rules` / `firestore:indexes` deploys unaffected.
- Gitignore `.vercel`; update the README deploy section.

## How to Test

- `NITRO_PRESET=vercel npm run build` succeeds and writes `.vercel/output`.
- Existing CI (lint/typecheck/test/build) is unaffected (default Node preset).

## Setup the repo owner must do (Vercel dashboard)

1. Import `benteen-screen` in Vercel (auto-detects Nuxt).
2. Add env vars under **Project → Settings → Environment Variables** — the same
   `NUXT_*` keys as `.env.example`: `NUXT_PUBLIC_FIREBASE_*` (public) and the
   server-only `NUXT_TMDB_API_KEY`.

## Invariants & Risk

Deploy-config only — no app, auth, rules, or data changes. The TMDB key stays
server-only (it runs in the Vercel function, never shipped to the client).
