### PR TITLE
feat(ui): mobile optimizations + consistent control sizing

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -3,6 +3,15 @@ export default defineAppConfig({
     colors: {
       primary: 'green',
       neutral: 'slate'
-    }
+    },
+    // Design-system control sizing (consistent + touch-friendly on mobile).
+    // Form controls are `lg` (~40px tap target); buttons default `md`, with
+    // primary CTAs opting up to `lg` and inline icon actions to `sm` per use.
+    input: { defaultVariants: { size: 'lg' } },
+    textarea: { defaultVariants: { size: 'lg' } },
+    select: { defaultVariants: { size: 'lg' } },
+    selectMenu: { defaultVariants: { size: 'lg' } },
+    inputMenu: { defaultVariants: { size: 'lg' } },
+    button: { defaultVariants: { size: 'md' } }
   }
 })

--- a/app/components/EventFormModal.vue
+++ b/app/components/EventFormModal.vue
@@ -60,9 +60,9 @@ function submit(): void {
     </template>
 
     <template #footer>
-      <div class="flex justify-end gap-2 w-full">
-        <UButton label="Cancel" color="neutral" variant="ghost" @click="open = false" />
-        <UButton :label="isEdit ? 'Save changes' : 'Add event'" :disabled="!canSave" @click="submit" />
+      <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 w-full">
+        <UButton label="Cancel" color="neutral" variant="ghost" class="justify-center" @click="open = false" />
+        <UButton :label="isEdit ? 'Save changes' : 'Add event'" class="justify-center" :disabled="!canSave" @click="submit" />
       </div>
     </template>
   </UModal>

--- a/app/components/MovieSearch.vue
+++ b/app/components/MovieSearch.vue
@@ -48,13 +48,12 @@ function year(movie: TmdbMovie): string {
       icon="i-lucide-search"
       :loading="loading"
       placeholder="Search for a movie to suggest…"
-      size="lg"
       class="w-full"
     />
 
     <ul
       v-if="results.length"
-      class="divide-y divide-default rounded-lg ring ring-default overflow-hidden"
+      class="divide-y divide-default rounded-lg ring ring-default overflow-hidden max-h-80 overflow-y-auto"
     >
       <li v-for="movie in results" :key="movie.id">
         <button

--- a/app/components/RichTextEditor.vue
+++ b/app/components/RichTextEditor.vue
@@ -48,13 +48,13 @@ const tools = computed<ToolButton[]>(() => {
 
 <template>
   <div class="rounded-lg ring ring-default focus-within:ring-2 focus-within:ring-primary overflow-hidden">
-    <div class="flex flex-wrap gap-0.5 border-b border-default p-1 bg-elevated/40">
+    <div class="flex flex-wrap gap-1 border-b border-default p-1.5 bg-elevated/40">
       <UButton
         v-for="tool in tools"
         :key="tool.label"
         :icon="tool.icon"
         :aria-label="tool.label"
-        size="xs"
+        size="sm"
         :color="tool.isActive() ? 'primary' : 'neutral'"
         :variant="tool.isActive() ? 'soft' : 'ghost'"
         @click="tool.run()"

--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -32,9 +32,9 @@ const tmdbUrl = computed(() => `https://www.themoviedb.org/movie/${movie.value.i
         v-if="poster"
         :src="poster"
         :alt="movie.title"
-        class="h-36 w-24 rounded-md object-cover bg-elevated shrink-0"
+        class="h-28 w-20 sm:h-36 sm:w-24 rounded-md object-cover bg-elevated shrink-0"
       >
-      <div v-else class="h-36 w-24 rounded-md bg-elevated shrink-0 flex items-center justify-center">
+      <div v-else class="h-28 w-20 sm:h-36 sm:w-24 rounded-md bg-elevated shrink-0 flex items-center justify-center">
         <UIcon name="i-lucide-film" class="size-8 text-muted" />
       </div>
 
@@ -49,7 +49,8 @@ const tmdbUrl = computed(() => `https://www.themoviedb.org/movie/${movie.value.i
             icon="i-lucide-trash-2"
             color="neutral"
             variant="ghost"
-            size="xs"
+            size="sm"
+            class="shrink-0 -mr-1 -mt-1"
             aria-label="Remove suggestion"
             @click="emit('remove')"
           />

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -76,11 +76,11 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
 
 <template>
   <UContainer class="py-8 max-w-4xl">
-    <div class="flex items-center justify-between mb-8">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-8">
       <h1 class="text-3xl font-bold">
         Admin
       </h1>
-      <UButton label="Add movie night" icon="i-lucide-plus" @click="openCreate" />
+      <UButton label="Add movie night" icon="i-lucide-plus" class="w-full sm:w-auto justify-center" @click="openCreate" />
     </div>
 
     <div class="grid gap-8 lg:grid-cols-2">
@@ -113,7 +113,7 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
                   icon="i-lucide-pencil"
                   color="neutral"
                   variant="ghost"
-                  size="xs"
+                  size="sm"
                   aria-label="Edit event"
                   @click="openEdit(event)"
                 />
@@ -121,7 +121,7 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
                   icon="i-lucide-trash-2"
                   color="error"
                   variant="ghost"
-                  size="xs"
+                  size="sm"
                   aria-label="Delete event"
                   @click="eventPendingDelete = event"
                 />
@@ -186,7 +186,7 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
                 icon="i-lucide-rotate-ccw"
                 color="neutral"
                 variant="outline"
-                size="xs"
+                size="sm"
                 class="shrink-0"
                 @click="toggleSuggestion(suggestion.id, false)"
               />
@@ -196,7 +196,7 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
                 icon="i-lucide-eye-off"
                 color="error"
                 variant="outline"
-                size="xs"
+                size="sm"
                 class="shrink-0"
                 @click="toggleSuggestion(suggestion.id, true)"
               />
@@ -220,9 +220,9 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
       @update:open="(value) => { if (!value) eventPendingDelete = null }"
     >
       <template #footer>
-        <div class="flex justify-end gap-2 w-full">
-          <UButton label="Cancel" color="neutral" variant="ghost" @click="eventPendingDelete = null" />
-          <UButton label="Delete" color="error" icon="i-lucide-trash-2" @click="confirmDelete" />
+        <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 w-full">
+          <UButton label="Cancel" color="neutral" variant="ghost" class="justify-center" @click="eventPendingDelete = null" />
+          <UButton label="Delete" color="error" icon="i-lucide-trash-2" class="justify-center" @click="confirmDelete" />
         </div>
       </template>
     </UModal>

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -213,7 +213,7 @@ async function onRemove(suggestion: typeof suggestions.value[number]): Promise<v
               v-if="selectedMovie.poster_path"
               :src="`https://image.tmdb.org/t/p/w500${selectedMovie.poster_path}`"
               :alt="selectedMovie.title"
-              class="h-40 w-28 rounded-md object-cover bg-elevated shrink-0"
+              class="h-32 w-24 sm:h-40 sm:w-28 rounded-md object-cover bg-elevated shrink-0"
             >
             <div class="min-w-0 flex-1">
               <h3 class="font-semibold text-lg">
@@ -229,10 +229,11 @@ async function onRemove(suggestion: typeof suggestions.value[number]): Promise<v
               <p v-if="selectedMovie.overview" class="text-sm text-muted mt-2 line-clamp-4">
                 {{ selectedMovie.overview }}
               </p>
-              <div class="flex gap-2 mt-4">
+              <div class="flex flex-col sm:flex-row gap-2 mt-4">
                 <UButton
                   label="Suggest this"
                   icon="i-lucide-plus"
+                  class="justify-center"
                   :disabled="alreadySuggested(selectedMovie.id)"
                   @click="onSuggest(selectedMovie)"
                 />
@@ -240,6 +241,7 @@ async function onRemove(suggestion: typeof suggestions.value[number]): Promise<v
                   label="Cancel"
                   color="neutral"
                   variant="ghost"
+                  class="justify-center"
                   @click="selectedMovie = null"
                 />
               </div>

--- a/app/pages/profile.vue
+++ b/app/pages/profile.vue
@@ -83,6 +83,7 @@ async function onDelete(): Promise<void> {
           color="error"
           variant="outline"
           icon="i-lucide-trash-2"
+          class="w-full sm:w-auto justify-center"
           @click="confirmOpen = true"
         />
       </div>
@@ -94,9 +95,9 @@ async function onDelete(): Promise<void> {
       description="This permanently deletes your account and sign-in. This action cannot be undone."
     >
       <template #footer>
-        <div class="flex justify-end gap-2 w-full">
-          <UButton label="Cancel" color="neutral" variant="ghost" @click="confirmOpen = false" />
-          <UButton label="Delete account" color="error" icon="i-lucide-trash-2" :loading="deleting" @click="onDelete" />
+        <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 w-full">
+          <UButton label="Cancel" color="neutral" variant="ghost" class="justify-center" @click="confirmOpen = false" />
+          <UButton label="Delete account" color="error" icon="i-lucide-trash-2" class="justify-center" :loading="deleting" @click="onDelete" />
         </div>
       </template>
     </UModal>


### PR DESCRIPTION
## Scope

Brings the **mobile optimizations + consistent control sizing** (originally #35)
to `main`. These were merged into `modernize-nuxt3` *after* #34 had already merged
that branch to `main`, so they got stranded off `main` and never reached production.
This PR lands them. Diff is purely the 8 UI files — the migration itself is already on main.

## Implementation

- **Design system** — Nuxt UI component `defaultVariants` in `app.config.ts`:
  form controls uniformly `lg` (touch-friendly), buttons `md`.
- **Mobile pass** — action/footer buttons stack full-width on mobile and go inline
  on `sm+`; inline icon actions bumped off `xs` to `sm` for real tap targets;
  responsive admin header; posters scale down on narrow screens; movie-search
  results scroll internally instead of pushing the page.

## How to Test

- `npm run typecheck`, `npm test` (19/19), `npm run build` — all green (verified on #35).
- Manual: open at ~375px; confirm buttons full-width where they stack, modals fit,
  icon controls comfortably tappable, forms use the larger consistent control size.

## Invariants & Risk

UI-only — no auth, Firestore rules, vote integrity, or data-flow changes.
