### PR TITLE
fix(ui): mobile overflow + admin route guard + trailer size

### DIFF
--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -55,7 +55,7 @@ const highlight = computed(() => props.rank === 1 && voteCount.value > 0)
       <!-- content -->
       <div class="min-w-0 flex-1">
         <div class="flex items-start justify-between gap-2">
-          <h3 class="font-semibold leading-tight truncate">
+          <h3 class="font-semibold leading-tight truncate min-w-0 flex-1">
             {{ movie.title }}
             <span v-if="year" class="text-muted font-normal">({{ year }})</span>
           </h3>

--- a/app/components/TrailerModal.vue
+++ b/app/components/TrailerModal.vue
@@ -31,7 +31,7 @@ const embedUrl = computed(() =>
   <UModal
     v-model:open="open"
     :title="movie ? `${movie.title} — Trailer` : 'Trailer'"
-    :ui="{ content: 'sm:max-w-3xl' }"
+    :ui="{ content: 'sm:max-w-4xl' }"
   >
     <template #body>
       <div class="aspect-video w-full rounded-lg overflow-hidden bg-black flex items-center justify-center">

--- a/app/middleware/admin.ts
+++ b/app/middleware/admin.ts
@@ -3,16 +3,19 @@ import type { Database } from '~/types/database.types'
 /**
  * Route guard: require the admin role. UX only — RLS is the real authorization
  * boundary. (Global auth protection is handled by the Supabase module.)
+ *
+ * Uses getUser() (validates the token) rather than the cached useSupabaseUser()
+ * id — the cached id could be stale/mismatched, which made admins bounce here.
  */
 export default defineNuxtRouteMiddleware(async () => {
-  const user = useSupabaseUser()
-  if (!user.value) return navigateTo('/login')
-
   const supabase = useSupabaseClient<Database>()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return navigateTo('/login')
+
   const { data } = await supabase
     .from('profiles')
     .select('is_admin')
-    .eq('id', user.value.id)
+    .eq('id', user.id)
     .single()
 
   if (!data?.is_admin) return navigateTo('/overview')

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -29,7 +29,9 @@ const leadPoster = computed(() => (totalVotes.value > 0 ? posterUrl(suggestions.
 
 const eventOptions = computed(() =>
   events.value.map((event, index) => ({
-    label: `${formatDate(event.event_date, { dateStyle: 'medium' })} · ${event.title}`,
+    // Date only — the full (often long) title is shown on the event card below,
+    // and a long label here can blow out the row width on mobile.
+    label: formatDate(event.event_date, { dateStyle: 'medium' }),
     value: index
   }))
 )

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -202,7 +202,7 @@ async function onRemove(suggestion: Suggestion): Promise<void> {
         </aside>
 
         <!-- RIGHT: rankings -->
-        <section class="lg:col-span-2">
+        <section class="lg:col-span-2 min-w-0">
           <div class="flex items-center justify-between mb-4">
             <h2 class="text-xl font-semibold">
               Rankings


### PR DESCRIPTION
## Scope

Follow-up fixes for the merged overview redesign (#41) — these commits landed on
the already-merged branch, so re-opening them against `main`.

## Fixes

- **Admin pages bounced you back to /overview**: the `/admin` route guard still
  used the cached `useSupabaseUser().id` (the stale-id bug), so the profile lookup
  found no admin and redirected. Now uses `getUser()` (authoritative), matching the
  auth-profile plugin. Admin nav links were visible but the page wouldn't open.
- **Mobile horizontal overflow**: long movie titles couldn't truncate (a flex child
  needs `min-w-0`), pushing the rankings list past the viewport. Added
  `min-w-0 flex-1` to the title + `min-w-0` on the rankings column, and shortened
  the event selector label to the date only (the full title can blow out the row
  width; it's already shown on the event card below).
- **Trailer embed**: bumped to `sm:max-w-4xl` (bigger on tablet/desktop, unchanged
  on mobile where it was already right).

## How to Test

- lint / typecheck / 25 tests / build — all green (verified on the source commits).
- On a phone: rankings stay in-bounds; the Admin link opens the admin page.

## Invariants & Risk

UI + a route-guard change (now authoritative via getUser()); no schema/RLS/data changes.
