### PR TITLE
feat: event-day features — RSVP, bring list, posters, logistics, calendar

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -2,7 +2,8 @@ export default defineAppConfig({
   ui: {
     colors: {
       primary: 'green',
-      neutral: 'slate'
+      // `neutral` (true gray) instead of `slate` so dark mode reads black, not blue.
+      neutral: 'neutral'
     },
     // Design-system control sizing (consistent + touch-friendly on mobile).
     // Form controls are `lg` (~40px tap target); buttons default `md`, with

--- a/app/components/BringList.vue
+++ b/app/components/BringList.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import type { BringItem } from '#shared/types/bring'
+
+defineProps<{ items: BringItem[], doughs?: number }>()
+const emit = defineEmits<{
+  add: [label: string]
+  claim: [item: BringItem]
+  unclaim: [item: BringItem]
+  remove: [item: BringItem]
+}>()
+
+const { myId, isAdmin } = useAuth()
+const newItem = ref('')
+
+function add(): void {
+  const label = newItem.value.trim()
+  if (!label) return
+  emit('add', label)
+  newItem.value = ''
+}
+
+function mine(item: BringItem): boolean {
+  return Boolean(item.user_id) && item.user_id === myId.value
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div v-if="doughs !== undefined" class="text-sm font-medium flex items-center gap-1.5">
+      🍕 {{ doughs }} pizza dough{{ doughs === 1 ? '' : 's' }} needed
+      <span class="text-xs text-muted font-normal">(one per "Going")</span>
+    </div>
+
+    <ul v-if="items.length" class="divide-y divide-default rounded-lg ring ring-default overflow-hidden">
+      <li v-for="item in items" :key="item.id" class="flex items-center gap-2 p-3">
+        <UIcon
+          :name="item.user_id ? 'i-lucide-circle-check' : 'i-lucide-circle-dashed'"
+          :class="item.user_id ? 'text-primary' : 'text-muted'"
+          class="shrink-0"
+        />
+        <div class="min-w-0 flex-1">
+          <p class="font-medium truncate">
+            {{ item.label }}
+          </p>
+          <p class="text-xs text-muted truncate">
+            {{ item.user_id ? (item.bringer?.display_name ?? 'Someone') : 'Open — needs a volunteer' }}
+          </p>
+        </div>
+        <UButton v-if="!item.user_id" label="I'll bring it" size="xs" class="shrink-0" @click="emit('claim', item)" />
+        <UButton v-else-if="mine(item)" label="Unclaim" size="xs" color="neutral" variant="ghost" class="shrink-0" @click="emit('unclaim', item)" />
+        <UButton
+          v-if="mine(item) || isAdmin"
+          icon="i-lucide-trash-2"
+          size="xs"
+          color="neutral"
+          variant="ghost"
+          class="shrink-0"
+          aria-label="Remove item"
+          @click="emit('remove', item)"
+        />
+      </li>
+    </ul>
+    <p v-else class="text-sm text-muted">
+      Nothing on the list yet — add what you're bringing.
+    </p>
+
+    <div class="flex gap-2">
+      <UInput v-model="newItem" placeholder="e.g. toppings, drinks, a blanket…" class="flex-1" @keydown.enter="add" />
+      <UButton label="Add" icon="i-lucide-plus" :disabled="!newItem.trim()" @click="add" />
+    </div>
+  </div>
+</template>

--- a/app/components/EventFormModal.vue
+++ b/app/components/EventFormModal.vue
@@ -1,13 +1,33 @@
 <script setup lang="ts">
 import type { MovieEvent } from '#shared/types/event'
 
+interface SavePayload {
+  id?: string
+  title: string
+  description: string
+  date: Date
+  startTime: string | null
+  location: string | null
+  locationUrl: string | null
+  posterUrl: string | null
+}
+
 const open = defineModel<boolean>('open', { default: false })
 const props = defineProps<{ event?: MovieEvent | null }>()
-const emit = defineEmits<{ save: [payload: { id?: string, title: string, description: string, date: Date }] }>()
+const emit = defineEmits<{ save: [payload: SavePayload] }>()
+
+const toast = useToast()
+const { uploadPoster } = useEventAdmin()
 
 const title = ref('')
 const description = ref('')
 const dateStr = ref('')
+const startTime = ref('')
+const location = ref('')
+const locationUrl = ref('')
+const posterUrl = ref<string | null>(null)
+const uploading = ref(false)
+const fileInput = ref<HTMLInputElement | null>(null)
 
 const isEdit = computed(() => Boolean(props.event))
 const canSave = computed(() => title.value.trim().length > 0 && dateStr.value.length > 0)
@@ -20,12 +40,38 @@ watch(open, (isOpen) => {
     description.value = props.event.description ?? ''
     const date = toDate(props.event.event_date)
     dateStr.value = toInputDate(date ?? new Date())
+    startTime.value = props.event.start_time ?? ''
+    location.value = props.event.location ?? ''
+    locationUrl.value = props.event.location_url ?? ''
+    posterUrl.value = props.event.poster_url ?? null
   } else {
     title.value = ''
     description.value = ''
     dateStr.value = toInputDate(new Date())
+    startTime.value = ''
+    location.value = ''
+    locationUrl.value = ''
+    posterUrl.value = null
   }
 })
+
+async function onFileChange(e: Event): Promise<void> {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  if (!file.type.startsWith('image/')) {
+    toast.add({ title: 'Pick an image file', color: 'warning' })
+    return
+  }
+  uploading.value = true
+  try {
+    posterUrl.value = await uploadPoster(file)
+  } catch {
+    toast.add({ title: 'Poster upload failed', color: 'error' })
+  } finally {
+    uploading.value = false
+    if (fileInput.value) fileInput.value.value = ''
+  }
+}
 
 function submit(): void {
   if (!canSave.value) return
@@ -33,7 +79,11 @@ function submit(): void {
     id: props.event?.id,
     title: title.value.trim(),
     description: description.value,
-    date: new Date(`${dateStr.value}T00:00:00`)
+    date: new Date(`${dateStr.value}T00:00:00`),
+    startTime: startTime.value.trim() || null,
+    location: location.value.trim() || null,
+    locationUrl: locationUrl.value.trim() || null,
+    posterUrl: posterUrl.value
   })
   open.value = false
 }
@@ -53,6 +103,47 @@ function submit(): void {
         <UFormField label="Title" required>
           <UInput v-model="title" placeholder="e.g. Cult Classics Night" class="w-full" />
         </UFormField>
+
+        <div class="grid sm:grid-cols-2 gap-4">
+          <UFormField label="Start time" hint="optional">
+            <UInput v-model="startTime" placeholder="e.g. 7:30 PM" class="w-full" />
+          </UFormField>
+          <UFormField label="Location" hint="optional">
+            <UInput v-model="location" placeholder="e.g. Benteen Park" class="w-full" />
+          </UFormField>
+        </div>
+        <UFormField label="Map / location link" hint="optional">
+          <UInput v-model="locationUrl" type="url" placeholder="https://maps.google.com/…" class="w-full" />
+        </UFormField>
+
+        <UFormField label="Event poster" hint="optional">
+          <div class="flex items-center gap-3">
+            <div
+              v-if="posterUrl"
+              class="size-16 rounded-lg bg-cover bg-center ring ring-default shrink-0"
+              :style="{ backgroundImage: `url(${posterUrl})` }"
+            />
+            <div class="flex gap-2">
+              <UButton
+                :label="posterUrl ? 'Replace' : 'Upload poster'"
+                icon="i-lucide-image-up"
+                color="neutral"
+                variant="outline"
+                :loading="uploading"
+                @click="fileInput?.click()"
+              />
+              <UButton
+                v-if="posterUrl"
+                label="Remove"
+                color="neutral"
+                variant="ghost"
+                @click="posterUrl = null"
+              />
+            </div>
+            <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="onFileChange">
+          </div>
+        </UFormField>
+
         <UFormField label="Description">
           <RichTextEditor v-model="description" />
         </UFormField>
@@ -62,7 +153,7 @@ function submit(): void {
     <template #footer>
       <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 w-full">
         <UButton label="Cancel" color="neutral" variant="ghost" class="justify-center" @click="open = false" />
-        <UButton :label="isEdit ? 'Save changes' : 'Add event'" class="justify-center" :disabled="!canSave" @click="submit" />
+        <UButton :label="isEdit ? 'Save changes' : 'Add event'" class="justify-center" :disabled="!canSave || uploading" @click="submit" />
       </div>
     </template>
   </UModal>

--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -1,31 +1,142 @@
 <script setup lang="ts">
 import type { MovieEvent } from '#shared/types/event'
+import type { CalendarEvent } from '#shared/utils/calendar'
 
 const open = defineModel<boolean>('open', { default: false })
-defineProps<{ event: MovieEvent | null }>()
+const props = defineProps<{ event: MovieEvent | null }>()
+
+const eventId = computed(() => props.event?.id ?? null)
+const { myStatus, counts, setStatus } = useRsvp(eventId)
+const { items, addItem, claim, unclaim, remove } = useBringList(eventId)
+
+// One pizza dough per person who's "Going".
+const doughs = computed(() => counts.value.going)
+
+const calEvent = computed<CalendarEvent | null>(() => {
+  const e = props.event
+  if (!e) return null
+  const base = toDate(e.event_date)
+  if (!base) return null
+  return {
+    title: e.title,
+    start: applyTime(base, e.start_time),
+    location: e.location,
+    description: e.description
+  }
+})
+const googleUrl = computed(() => (calEvent.value ? googleCalendarUrl(calEvent.value) : '#'))
+
+function downloadIcs(): void {
+  if (!calEvent.value) return
+  const blob = new Blob([icsContent(calEvent.value)], { type: 'text/calendar;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `${(props.event?.title || 'event').replace(/[^\w-]+/g, '-')}.ics`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+async function onAdd(label: string): Promise<void> {
+  try {
+    await addItem(label)
+  } catch { /* surfaced via realtime state staying unchanged */ }
+}
 </script>
 
 <template>
-  <UModal v-model:open="open" :title="event?.title || 'Event'">
+  <UModal v-model:open="open" :title="event?.title || 'Event'" :ui="{ content: 'sm:max-w-2xl' }">
     <template #body>
-      <div v-if="event">
-        <div class="flex flex-wrap items-center gap-2 mb-4">
-          <UBadge
-            :color="isUpcoming(event.event_date) ? 'primary' : 'neutral'"
-            :variant="isUpcoming(event.event_date) ? 'solid' : 'subtle'"
-            :label="isUpcoming(event.event_date) ? 'Upcoming' : 'Past'"
-            icon="i-lucide-calendar"
-          />
-          <span class="text-muted">{{ formatDate(event.event_date) }}</span>
+      <div v-if="event" class="space-y-5">
+        <!-- Poster banner -->
+        <img
+          v-if="event.poster_url"
+          :src="event.poster_url"
+          :alt="`${event.title} poster`"
+          class="w-full max-h-72 object-cover rounded-lg ring ring-default"
+        >
+
+        <!-- Date / status / logistics -->
+        <div class="space-y-2">
+          <div class="flex flex-wrap items-center gap-2">
+            <UBadge
+              :color="isUpcoming(event.event_date) ? 'primary' : 'neutral'"
+              :variant="isUpcoming(event.event_date) ? 'solid' : 'subtle'"
+              :label="isUpcoming(event.event_date) ? 'Upcoming' : 'Past'"
+              icon="i-lucide-calendar"
+            />
+            <span class="text-muted">{{ formatDate(event.event_date) }}</span>
+            <span v-if="event.start_time" class="text-muted inline-flex items-center gap-1">
+              <UIcon name="i-lucide-clock" /> {{ event.start_time }}
+            </span>
+          </div>
+          <p v-if="event.location" class="text-muted inline-flex items-center gap-1.5">
+            <UIcon name="i-lucide-map-pin" class="shrink-0" />
+            <a
+              v-if="event.location_url"
+              :href="event.location_url"
+              target="_blank"
+              rel="noopener"
+              class="text-primary underline"
+            >{{ event.location }}</a>
+            <span v-else>{{ event.location }}</span>
+          </p>
         </div>
+
+        <!-- Add to calendar -->
+        <div v-if="isUpcoming(event.event_date)" class="flex flex-wrap gap-2">
+          <UButton
+            label="Google Calendar"
+            icon="i-lucide-calendar-plus"
+            color="neutral"
+            variant="outline"
+            size="sm"
+            :to="googleUrl"
+            target="_blank"
+          />
+          <UButton
+            label="Apple / .ics"
+            icon="i-lucide-download"
+            color="neutral"
+            variant="outline"
+            size="sm"
+            @click="downloadIcs"
+          />
+        </div>
+
+        <!-- Description -->
         <div
           v-if="event.description"
           class="text-muted [&_p]:my-2 [&_a]:text-primary [&_a]:underline [&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal [&_ol]:pl-5"
           v-html="sanitizeHtml(event.description)"
         />
-        <p v-else class="text-muted">
-          No description for this movie night.
-        </p>
+
+        <USeparator />
+
+        <!-- RSVP -->
+        <div>
+          <h3 class="text-sm font-semibold text-muted mb-2">
+            Are you coming?
+          </h3>
+          <RsvpControl :my-status="myStatus" :counts="counts" @set="setStatus" />
+        </div>
+
+        <USeparator />
+
+        <!-- Bring list -->
+        <div>
+          <h3 class="text-sm font-semibold text-muted mb-2">
+            Bring list
+          </h3>
+          <BringList
+            :items="items"
+            :doughs="doughs"
+            @add="onAdd"
+            @claim="claim"
+            @unclaim="unclaim"
+            @remove="remove"
+          />
+        </div>
       </div>
     </template>
   </UModal>

--- a/app/components/RsvpControl.vue
+++ b/app/components/RsvpControl.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { RsvpStatus } from '#shared/types/rsvp'
+
+defineProps<{ myStatus: RsvpStatus | null, counts: { going: number, maybe: number, no: number } }>()
+const emit = defineEmits<{ set: [status: RsvpStatus] }>()
+
+const options = [
+  { status: 'going' as const, label: 'Going', icon: 'i-lucide-check', color: 'primary' as const },
+  { status: 'maybe' as const, label: 'Maybe', icon: 'i-lucide-circle-help', color: 'warning' as const },
+  { status: 'no' as const, label: 'Can\'t', icon: 'i-lucide-x', color: 'neutral' as const }
+]
+</script>
+
+<template>
+  <div>
+    <div class="grid grid-cols-3 gap-2">
+      <UButton
+        v-for="o in options"
+        :key="o.status"
+        :label="o.label"
+        :icon="o.icon"
+        :color="myStatus === o.status ? o.color : 'neutral'"
+        :variant="myStatus === o.status ? 'solid' : 'outline'"
+        block
+        class="justify-center"
+        @click="emit('set', o.status)"
+      />
+    </div>
+    <p class="text-xs text-muted mt-2 text-center">
+      <span class="text-primary font-medium">{{ counts.going }} going</span>
+      · {{ counts.maybe }} maybe
+    </p>
+  </div>
+</template>

--- a/app/composables/useBringList.ts
+++ b/app/composables/useBringList.ts
@@ -1,0 +1,75 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { RealtimeChannel } from '@supabase/supabase-js'
+import type { Database } from '~/types/database.types'
+import type { BringItem } from '#shared/types/bring'
+
+const SELECT = 'id, event_id, label, note, user_id, created_by, bringer:profiles!bring_items_user_id_fkey(display_name)'
+
+/** Potluck "bring list" for an event: items + add/claim/unclaim/remove (realtime). */
+export function useBringList(eventId: MaybeRefOrGetter<string | null | undefined>) {
+  const supabase = useSupabaseClient<Database>()
+  const myId = useState<string | null>('my-id', () => null)
+  const items = ref<BringItem[]>([])
+
+  async function refresh(): Promise<void> {
+    const id = toValue(eventId)
+    if (!id) {
+      items.value = []
+      return
+    }
+    const { data } = await supabase.from('bring_items').select(SELECT).eq('event_id', id).order('created_at')
+    items.value = (data ?? []) as unknown as BringItem[]
+  }
+
+  let channel: RealtimeChannel | null = null
+  watch(() => toValue(eventId), (id) => {
+    if (channel) {
+      supabase.removeChannel(channel)
+      channel = null
+    }
+    refresh()
+    if (!id) return
+    channel = supabase
+      .channel(`bring-${crypto.randomUUID()}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'bring_items', filter: `event_id=eq.${id}` }, () => refresh())
+      .subscribe()
+  }, { immediate: true })
+  onUnmounted(() => {
+    if (channel) supabase.removeChannel(channel)
+  })
+
+  // created_by is omitted (DB defaults it to auth.uid()).
+  async function addItem(label: string, note?: string, claimSelf = true): Promise<void> {
+    const id = toValue(eventId)
+    if (!id || !label.trim()) return
+    const { error } = await supabase.from('bring_items').insert({
+      event_id: id,
+      label: label.trim(),
+      note: note?.trim() || null,
+      user_id: claimSelf ? myId.value : null
+    })
+    if (error) throw error
+    await refresh()
+  }
+
+  async function claim(item: BringItem): Promise<void> {
+    if (!myId.value) return
+    const { error } = await supabase.from('bring_items').update({ user_id: myId.value }).eq('id', item.id)
+    if (error) throw error
+    await refresh()
+  }
+
+  async function unclaim(item: BringItem): Promise<void> {
+    const { error } = await supabase.from('bring_items').update({ user_id: null }).eq('id', item.id)
+    if (error) throw error
+    await refresh()
+  }
+
+  async function remove(item: BringItem): Promise<void> {
+    const { error } = await supabase.from('bring_items').delete().eq('id', item.id)
+    if (error) throw error
+    await refresh()
+  }
+
+  return { items, addItem, claim, unclaim, remove }
+}

--- a/app/composables/useBringList.ts
+++ b/app/composables/useBringList.ts
@@ -18,6 +18,8 @@ export function useBringList(eventId: MaybeRefOrGetter<string | null | undefined
       return
     }
     const { data } = await supabase.from('bring_items').select(SELECT).eq('event_id', id).order('created_at')
+    // Supabase types the embedded `bringer` join as an array, but the FK is to a
+    // single profile — assert to our `BringItem` (single bringer-or-null) shape.
     items.value = (data ?? []) as unknown as BringItem[]
   }
 

--- a/app/composables/useEventAdmin.ts
+++ b/app/composables/useEventAdmin.ts
@@ -4,6 +4,23 @@ export interface EventInput {
   title: string
   description: string
   date: Date
+  startTime?: string | null
+  location?: string | null
+  locationUrl?: string | null
+  posterUrl?: string | null
+}
+
+/** Map the form's `EventInput` onto the event-table column shape. */
+function toRow(input: EventInput) {
+  return {
+    title: input.title,
+    description: input.description,
+    event_date: input.date.toISOString(),
+    start_time: input.startTime?.trim() || null,
+    location: input.location?.trim() || null,
+    location_url: input.locationUrl?.trim() || null,
+    poster_url: input.posterUrl?.trim() || null
+  }
 }
 
 /** Admin write actions for events. */
@@ -13,20 +30,14 @@ export function useEventAdmin() {
 
   async function createEvent(input: EventInput): Promise<void> {
     const { error } = await supabase.from('events').insert({
-      title: input.title,
-      description: input.description,
-      event_date: input.date.toISOString(),
+      ...toRow(input),
       created_by: user.value?.id ?? null
     })
     if (error) throw error
   }
 
   async function updateEvent(id: string, input: EventInput): Promise<void> {
-    const { error } = await supabase.from('events').update({
-      title: input.title,
-      description: input.description,
-      event_date: input.date.toISOString()
-    }).eq('id', id)
+    const { error } = await supabase.from('events').update(toRow(input)).eq('id', id)
     if (error) throw error
   }
 
@@ -35,5 +46,19 @@ export function useEventAdmin() {
     if (error) throw error
   }
 
-  return { createEvent, updateEvent, deleteEvent }
+  /** Upload a poster image to the public `event-posters` bucket; returns its public URL. */
+  async function uploadPoster(file: File): Promise<string> {
+    const ext = file.name.split('.').pop()?.toLowerCase() || 'jpg'
+    const path = `${crypto.randomUUID()}.${ext}`
+    const { error } = await supabase.storage.from('event-posters').upload(path, file, {
+      cacheControl: '3600',
+      upsert: false,
+      contentType: file.type || undefined
+    })
+    if (error) throw error
+    const { data } = supabase.storage.from('event-posters').getPublicUrl(path)
+    return data.publicUrl
+  }
+
+  return { createEvent, updateEvent, deleteEvent, uploadPoster }
 }

--- a/app/composables/useRsvp.ts
+++ b/app/composables/useRsvp.ts
@@ -56,7 +56,10 @@ export function useRsvp(eventId: MaybeRefOrGetter<string | null | undefined>) {
     } else {
       const { error } = await supabase
         .from('rsvps')
-        .upsert({ event_id: id, user_id: myId.value, status }, { onConflict: 'event_id,user_id' })
+        .upsert(
+          { event_id: id, user_id: myId.value, status, updated_at: new Date().toISOString() },
+          { onConflict: 'event_id,user_id' }
+        )
       if (error) throw error
     }
     await refresh()

--- a/app/composables/useRsvp.ts
+++ b/app/composables/useRsvp.ts
@@ -1,0 +1,66 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { RealtimeChannel } from '@supabase/supabase-js'
+import type { Database } from '~/types/database.types'
+import type { RsvpStatus } from '#shared/types/rsvp'
+
+/** RSVP state for an event: my status, live counts, and set/toggle. */
+export function useRsvp(eventId: MaybeRefOrGetter<string | null | undefined>) {
+  const supabase = useSupabaseClient<Database>()
+  const myId = useState<string | null>('my-id', () => null)
+  const rsvps = ref<{ user_id: string, status: string }[]>([])
+
+  async function refresh(): Promise<void> {
+    const id = toValue(eventId)
+    if (!id) {
+      rsvps.value = []
+      return
+    }
+    const { data } = await supabase.from('rsvps').select('user_id, status').eq('event_id', id)
+    rsvps.value = data ?? []
+  }
+
+  let channel: RealtimeChannel | null = null
+  watch(() => toValue(eventId), (id) => {
+    if (channel) {
+      supabase.removeChannel(channel)
+      channel = null
+    }
+    refresh()
+    if (!id) return
+    channel = supabase
+      .channel(`rsvps-${crypto.randomUUID()}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'rsvps', filter: `event_id=eq.${id}` }, () => refresh())
+      .subscribe()
+  }, { immediate: true })
+  onUnmounted(() => {
+    if (channel) supabase.removeChannel(channel)
+  })
+
+  const myStatus = computed<RsvpStatus | null>(() => {
+    const mine = rsvps.value.find(r => r.user_id === myId.value)
+    return (mine?.status as RsvpStatus | undefined) ?? null
+  })
+  const counts = computed(() => ({
+    going: rsvps.value.filter(r => r.status === 'going').length,
+    maybe: rsvps.value.filter(r => r.status === 'maybe').length,
+    no: rsvps.value.filter(r => r.status === 'no').length
+  }))
+
+  /** Set my status, or clear it if I tap the one I already have. */
+  async function setStatus(status: RsvpStatus): Promise<void> {
+    const id = toValue(eventId)
+    if (!id || !myId.value) return
+    if (myStatus.value === status) {
+      const { error } = await supabase.from('rsvps').delete().eq('event_id', id).eq('user_id', myId.value)
+      if (error) throw error
+    } else {
+      const { error } = await supabase
+        .from('rsvps')
+        .upsert({ event_id: id, user_id: myId.value, status }, { onConflict: 'event_id,user_id' })
+      if (error) throw error
+    }
+    await refresh()
+  }
+
+  return { rsvps, myStatus, counts, setStatus }
+}

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -15,15 +15,23 @@ const eventPendingDelete = ref<MovieEvent | null>(null)
 const selectedEventId = ref<string>()
 const { suggestions, setDeleted, voterNames } = useAdminSuggestions(selectedEventId)
 
+// Upcoming events first (soonest first), then past events descending (oldest last).
+const sortedEvents = computed(() => {
+  const ms = (e: MovieEvent) => new Date(e.event_date).getTime()
+  const upcoming = events.value.filter(e => isUpcoming(e.event_date)).sort((a, b) => ms(a) - ms(b))
+  const past = events.value.filter(e => !isUpcoming(e.event_date)).sort((a, b) => ms(b) - ms(a))
+  return [...upcoming, ...past]
+})
+
 const eventOptions = computed(() =>
-  events.value.map(event => ({
+  sortedEvents.value.map(event => ({
     label: `${formatDate(event.event_date, { dateStyle: 'medium' })} · ${event.title}`,
     value: event.id
   }))
 )
 
-// Default the moderation selector to the first event once data loads.
-watch(events, (list) => {
+// Default the moderation selector to the most relevant (next upcoming) event once data loads.
+watch(sortedEvents, (list) => {
   if (!selectedEventId.value && list.length) selectedEventId.value = list[0]!.id
 }, { immediate: true })
 
@@ -36,7 +44,16 @@ function openEdit(event: MovieEvent): void {
   modalOpen.value = true
 }
 
-async function onSave(payload: { id?: string, title: string, description: string, date: Date }): Promise<void> {
+async function onSave(payload: {
+  id?: string
+  title: string
+  description: string
+  date: Date
+  startTime: string | null
+  location: string | null
+  locationUrl: string | null
+  posterUrl: string | null
+}): Promise<void> {
   try {
     if (payload.id) {
       await updateEvent(payload.id, payload)
@@ -89,8 +106,8 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
         <h2 class="text-xl font-semibold mb-4">
           Events
         </h2>
-        <div v-if="events.length" class="space-y-3">
-          <UCard v-for="event in events" :key="event.id" variant="subtle">
+        <div v-if="sortedEvents.length" class="space-y-3">
+          <UCard v-for="event in sortedEvents" :key="event.id" variant="subtle">
             <div class="flex items-start justify-between gap-3">
               <div class="min-w-0">
                 <p class="text-sm text-muted">

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -16,12 +16,7 @@ const selectedEventId = ref<string>()
 const { suggestions, setDeleted, voterNames } = useAdminSuggestions(selectedEventId)
 
 // Upcoming events first (soonest first), then past events descending (oldest last).
-const sortedEvents = computed(() => {
-  const ms = (e: MovieEvent) => new Date(e.event_date).getTime()
-  const upcoming = events.value.filter(e => isUpcoming(e.event_date)).sort((a, b) => ms(a) - ms(b))
-  const past = events.value.filter(e => !isUpcoming(e.event_date)).sort((a, b) => ms(b) - ms(a))
-  return [...upcoming, ...past]
-})
+const sortedEvents = computed(() => sortEventsForAdmin(events.value))
 
 const eventOptions = computed(() =>
   sortedEvents.value.map(event => ({

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { TmdbMovie } from '#shared/types/movie'
 import type { Suggestion } from '#shared/types/suggestion'
+import type { RsvpStatus } from '#shared/types/rsvp'
 
 useSeoMeta({ title: 'Overview · BSOTG' })
 
@@ -19,6 +20,7 @@ const currentEvent = computed(() => events.value[eventIndex.value] ?? null)
 const currentEventId = computed(() => currentEvent.value?.id ?? null)
 
 const { suggestions, alreadySuggested, suggest, vote, unvote, removeSuggestion } = useSuggestions(currentEventId)
+const { myStatus, counts, setStatus } = useRsvp(currentEventId)
 
 const suggestedMovieIds = computed(() => suggestions.value.map(s => s.tmdb_movie.id))
 const maxVotes = computed(() => Math.max(1, ...suggestions.value.map(s => s.votes?.length ?? 0)))
@@ -26,6 +28,8 @@ const totalVotes = computed(() => suggestions.value.reduce((sum, s) => sum + (s.
 // Only surface a "leader" once votes exist — before that the order is just by date.
 const leadingTitle = computed(() => (totalVotes.value > 0 ? suggestions.value[0]?.tmdb_movie.title ?? null : null))
 const leadPoster = computed(() => (totalVotes.value > 0 ? posterUrl(suggestions.value[0]?.tmdb_movie.poster_path) : null))
+// Prefer the event's own poster; fall back to the current leader's movie poster.
+const cardBackdrop = computed(() => currentEvent.value?.poster_url || leadPoster.value)
 
 const eventOptions = computed(() =>
   events.value.map((event, index) => ({
@@ -90,6 +94,13 @@ async function onRemove(suggestion: Suggestion): Promise<void> {
     toast.add({ title: 'Could not remove suggestion', color: 'error' })
   }
 }
+async function onRsvp(status: RsvpStatus): Promise<void> {
+  try {
+    await setStatus(status)
+  } catch {
+    toast.add({ title: 'Could not update RSVP', color: 'error' })
+  }
+}
 </script>
 
 <template>
@@ -129,9 +140,9 @@ async function onRemove(suggestion: Suggestion): Promise<void> {
           <button type="button" class="w-full text-left group" @click="eventInfoOpen = true">
             <UCard variant="subtle" class="overflow-hidden group-hover:ring-2 group-hover:ring-primary/30 transition" :ui="{ body: 'relative' }">
               <div
-                v-if="leadPoster"
-                class="absolute inset-0 opacity-15 bg-cover bg-center"
-                :style="{ backgroundImage: `url(${leadPoster})` }"
+                v-if="cardBackdrop"
+                class="absolute inset-0 opacity-20 bg-cover bg-center"
+                :style="{ backgroundImage: `url(${cardBackdrop})` }"
               />
               <div class="relative">
                 <div class="flex flex-wrap items-center gap-2 mb-1">
@@ -153,6 +164,20 @@ async function onRemove(suggestion: Suggestion): Promise<void> {
               </div>
             </UCard>
           </button>
+
+          <!-- RSVP (upcoming only) -->
+          <UCard v-if="isUpcoming(currentEvent.event_date)" variant="subtle">
+            <h2 class="text-sm font-semibold text-muted mb-2">
+              Are you coming?
+            </h2>
+            <RsvpControl :my-status="myStatus" :counts="counts" @set="onRsvp" />
+            <p v-if="counts.going" class="text-xs text-muted mt-3 flex items-center gap-1.5 justify-center">
+              🍕 {{ counts.going }} pizza dough{{ counts.going === 1 ? '' : 's' }} needed —
+              <button type="button" class="text-primary underline" @click="eventInfoOpen = true">
+                bring list
+              </button>
+            </p>
+          </UCard>
 
           <!-- Stats -->
           <UCard variant="subtle">

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -12,9 +12,21 @@ export interface Database {
         Relationships: []
       }
       events: {
-        Row: { id: string, title: string, description: string, event_date: string, created_by: string | null, created_at: string }
-        Insert: { id?: string, title: string, description?: string, event_date: string, created_by?: string | null, created_at?: string }
-        Update: { id?: string, title?: string, description?: string, event_date?: string, created_by?: string | null, created_at?: string }
+        Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, created_by: string | null, created_at: string }
+        Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, created_by?: string | null, created_at?: string }
+        Update: { id?: string, title?: string, description?: string, event_date?: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, created_by?: string | null, created_at?: string }
+        Relationships: []
+      }
+      rsvps: {
+        Row: { event_id: string, user_id: string, status: string, updated_at: string }
+        Insert: { event_id: string, user_id?: string, status: string, updated_at?: string }
+        Update: { event_id?: string, user_id?: string, status?: string, updated_at?: string }
+        Relationships: []
+      }
+      bring_items: {
+        Row: { id: string, event_id: string, label: string, note: string | null, user_id: string | null, created_by: string | null, created_at: string }
+        Insert: { id?: string, event_id: string, label: string, note?: string | null, user_id?: string | null, created_by?: string | null, created_at?: string }
+        Update: { id?: string, event_id?: string, label?: string, note?: string | null, user_id?: string | null, created_by?: string | null, created_at?: string }
         Relationships: []
       }
       suggestions: {

--- a/app/utils/events.ts
+++ b/app/utils/events.ts
@@ -1,0 +1,13 @@
+import { isUpcoming } from './datetime'
+import type { MovieEvent } from '#shared/types/event'
+
+/**
+ * Admin ordering for the events list: upcoming events first (soonest first),
+ * then past events descending (most recent first → oldest last).
+ */
+export function sortEventsForAdmin(events: readonly MovieEvent[]): MovieEvent[] {
+  const ms = (e: MovieEvent): number => new Date(e.event_date).getTime()
+  const upcoming = events.filter(e => isUpcoming(e.event_date)).sort((a, b) => ms(a) - ms(b))
+  const past = events.filter(e => !isUpcoming(e.event_date)).sort((a, b) => ms(b) - ms(a))
+  return [...upcoming, ...past]
+}

--- a/shared/types/bring.ts
+++ b/shared/types/bring.ts
@@ -1,0 +1,10 @@
+/** A potluck "bring list" item. `user_id` null = an open slot anyone can claim. */
+export interface BringItem {
+  id: string
+  event_id: string
+  label: string
+  note: string | null
+  user_id: string | null
+  created_by: string | null
+  bringer: { display_name: string | null } | null
+}

--- a/shared/types/event.ts
+++ b/shared/types/event.ts
@@ -4,6 +4,10 @@ export interface MovieEvent {
   title: string
   description: string
   event_date: string
+  start_time: string | null
+  location: string | null
+  location_url: string | null
+  poster_url: string | null
   created_at: string
 }
 
@@ -11,4 +15,8 @@ export interface MovieEvent {
 export interface EventDraft {
   title: string
   description: string
+  start_time?: string | null
+  location?: string | null
+  location_url?: string | null
+  poster_url?: string | null
 }

--- a/shared/types/rsvp.ts
+++ b/shared/types/rsvp.ts
@@ -1,0 +1,7 @@
+export type RsvpStatus = 'going' | 'maybe' | 'no'
+
+export interface Rsvp {
+  event_id: string
+  user_id: string
+  status: RsvpStatus
+}

--- a/shared/utils/calendar.ts
+++ b/shared/utils/calendar.ts
@@ -1,0 +1,75 @@
+export interface CalendarEvent {
+  title: string
+  start: Date
+  durationMinutes?: number
+  location?: string | null
+  description?: string | null
+}
+
+const DEFAULT_DURATION = 180
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+/** UTC basic format: YYYYMMDDTHHMMSSZ */
+function toCalDate(d: Date): string {
+  return `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
+}
+
+function plain(html: string | null | undefined): string {
+  return (html ?? '').replace(/<[^>]*>/g, '').trim()
+}
+
+function endOf(e: CalendarEvent): Date {
+  return new Date(e.start.getTime() + (e.durationMinutes ?? DEFAULT_DURATION) * 60_000)
+}
+
+/**
+ * Apply a freeform "7:30 PM" / "19:30" style time onto a date (local tz).
+ * Returns a new Date; returns the date unchanged if the time can't be parsed.
+ */
+export function applyTime(date: Date, timeStr: string | null | undefined): Date {
+  if (!timeStr) return date
+  const m = timeStr.trim().match(/^(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$/i)
+  if (!m) return date
+  let h = Number(m[1])
+  const min = m[2] ? Number(m[2]) : 0
+  const ap = m[3]?.toLowerCase()
+  if (ap === 'pm' && h < 12) h += 12
+  if (ap === 'am' && h === 12) h = 0
+  if (h > 23 || min > 59) return date
+  const d = new Date(date)
+  d.setHours(h, min, 0, 0)
+  return d
+}
+
+/** "Add to Google Calendar" URL. */
+export function googleCalendarUrl(e: CalendarEvent): string {
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: e.title,
+    dates: `${toCalDate(e.start)}/${toCalDate(endOf(e))}`,
+    details: plain(e.description),
+    location: e.location ?? ''
+  })
+  return `https://calendar.google.com/calendar/render?${params.toString()}`
+}
+
+/** ICS file content (for Apple Calendar / Outlook / .ics download). */
+export function icsContent(e: CalendarEvent): string {
+  const esc = (s: string): string => s.replace(/[\\;,]/g, m => `\\${m}`).replace(/\n/g, '\\n')
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//BSOTG//Movie Night//EN',
+    'BEGIN:VEVENT',
+    `DTSTART:${toCalDate(e.start)}`,
+    `DTEND:${toCalDate(endOf(e))}`,
+    `SUMMARY:${esc(e.title)}`,
+    e.location ? `LOCATION:${esc(e.location)}` : '',
+    e.description ? `DESCRIPTION:${esc(plain(e.description))}` : '',
+    'END:VEVENT',
+    'END:VCALENDAR'
+  ].filter(Boolean).join('\r\n')
+}

--- a/shared/utils/calendar.ts
+++ b/shared/utils/calendar.ts
@@ -59,11 +59,17 @@ export function googleCalendarUrl(e: CalendarEvent): string {
 /** ICS file content (for Apple Calendar / Outlook / .ics download). */
 export function icsContent(e: CalendarEvent): string {
   const esc = (s: string): string => s.replace(/[\\;,]/g, m => `\\${m}`).replace(/\n/g, '\\n')
+  const slug = e.title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'event'
+  // RFC 5545 requires UID + DTSTAMP. We don't track a separate creation time, so
+  // the (stable) event start doubles as DTSTAMP — both are deterministic.
+  const stamp = toCalDate(e.start)
   return [
     'BEGIN:VCALENDAR',
     'VERSION:2.0',
     'PRODID:-//BSOTG//Movie Night//EN',
     'BEGIN:VEVENT',
+    `UID:${stamp}-${slug}@benteenscreenonthegreen.com`,
+    `DTSTAMP:${stamp}`,
     `DTSTART:${toCalDate(e.start)}`,
     `DTEND:${toCalDate(endOf(e))}`,
     `SUMMARY:${esc(e.title)}`,

--- a/supabase/migrations/20260616030000_event_day.sql
+++ b/supabase/migrations/20260616030000_event_day.sql
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- Event-day features: logistics fields, RSVPs, and a potluck "bring list".
+-- ============================================================================
+
+-- ---------- Event logistics + poster ----------
+alter table public.events add column if not exists start_time   text;  -- e.g. "7:30 PM"
+alter table public.events add column if not exists location     text;
+alter table public.events add column if not exists location_url text;  -- map link
+alter table public.events add column if not exists poster_url   text;  -- event poster image
+
+-- Public storage bucket for event posters; only admins may upload/replace.
+insert into storage.buckets (id, name, public)
+values ('event-posters', 'event-posters', true)
+on conflict (id) do nothing;
+
+create policy "event-posters: public read" on storage.objects
+  for select using (bucket_id = 'event-posters');
+create policy "event-posters: admin insert" on storage.objects
+  for insert to authenticated with check (bucket_id = 'event-posters' and public.is_admin());
+create policy "event-posters: admin update" on storage.objects
+  for update to authenticated using (bucket_id = 'event-posters' and public.is_admin());
+create policy "event-posters: admin delete" on storage.objects
+  for delete to authenticated using (bucket_id = 'event-posters' and public.is_admin());
+
+-- ---------- RSVPs ----------
+create table public.rsvps (
+  event_id   uuid not null references public.events (id) on delete cascade,
+  user_id    uuid not null default auth.uid() references public.profiles (id) on delete cascade,
+  status     text not null check (status in ('going', 'maybe', 'no')),
+  updated_at timestamptz not null default now(),
+  primary key (event_id, user_id)
+);
+
+-- ---------- Bring list (potluck) ----------
+-- Each row is something to bring; user_id null = an open slot anyone can claim.
+create table public.bring_items (
+  id         uuid primary key default gen_random_uuid(),
+  event_id   uuid not null references public.events (id) on delete cascade,
+  label      text not null,
+  note       text,
+  user_id    uuid references public.profiles (id) on delete set null,
+  created_by uuid default auth.uid() references public.profiles (id) on delete set null,
+  created_at timestamptz not null default now()
+);
+create index bring_items_event_id_idx on public.bring_items (event_id);
+
+-- ---------- RLS ----------
+alter table public.rsvps       enable row level security;
+alter table public.bring_items enable row level security;
+grant select, insert, update, delete on public.rsvps, public.bring_items to authenticated;
+
+-- rsvps: everyone sees the headcount; you manage only your own row.
+create policy "rsvps: read" on public.rsvps for select to authenticated using (true);
+create policy "rsvps: insert own" on public.rsvps for insert to authenticated with check (user_id = auth.uid());
+create policy "rsvps: update own" on public.rsvps for update to authenticated using (user_id = auth.uid()) with check (user_id = auth.uid());
+create policy "rsvps: delete own" on public.rsvps for delete to authenticated using (user_id = auth.uid());
+
+-- bring_items: read all; create as self; claim an open slot or edit your own; delete your own (or admin).
+create policy "bring: read" on public.bring_items for select to authenticated using (true);
+create policy "bring: create" on public.bring_items for insert to authenticated with check (created_by = auth.uid());
+create policy "bring: update" on public.bring_items for update to authenticated
+  using (created_by = auth.uid() or user_id = auth.uid() or user_id is null)
+  with check (created_by = auth.uid() or user_id = auth.uid() or user_id is null);
+create policy "bring: delete" on public.bring_items for delete to authenticated
+  using (created_by = auth.uid() or user_id = auth.uid() or public.is_admin());
+
+-- ---------- Realtime ----------
+alter publication supabase_realtime add table public.rsvps;
+alter publication supabase_realtime add table public.bring_items;

--- a/supabase/migrations/20260616030000_event_day.sql
+++ b/supabase/migrations/20260616030000_event_day.sql
@@ -9,8 +9,13 @@ alter table public.events add column if not exists location_url text;  -- map li
 alter table public.events add column if not exists poster_url   text;  -- event poster image
 
 -- Public storage bucket for event posters; only admins may upload/replace.
-insert into storage.buckets (id, name, public)
-values ('event-posters', 'event-posters', true)
+-- Restrict to raster images (no SVG → no scriptable upload) and cap the size.
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'event-posters', 'event-posters', true,
+  5242880, -- 5 MB
+  array['image/png', 'image/jpeg', 'image/webp', 'image/gif']
+)
 on conflict (id) do nothing;
 
 create policy "event-posters: public read" on storage.objects
@@ -56,11 +61,14 @@ create policy "rsvps: update own" on public.rsvps for update to authenticated us
 create policy "rsvps: delete own" on public.rsvps for delete to authenticated using (user_id = auth.uid());
 
 -- bring_items: read all; create as self; claim an open slot or edit your own; delete your own (or admin).
+-- A row may only ever be unclaimed or claimed by the acting user — you can never
+-- assign an item to another person's profile (the WITH CHECK is the boundary).
 create policy "bring: read" on public.bring_items for select to authenticated using (true);
-create policy "bring: create" on public.bring_items for insert to authenticated with check (created_by = auth.uid());
+create policy "bring: create" on public.bring_items for insert to authenticated
+  with check (created_by = auth.uid() and (user_id is null or user_id = auth.uid()));
 create policy "bring: update" on public.bring_items for update to authenticated
   using (created_by = auth.uid() or user_id = auth.uid() or user_id is null)
-  with check (created_by = auth.uid() or user_id = auth.uid() or user_id is null);
+  with check (user_id is null or user_id = auth.uid());
 create policy "bring: delete" on public.bring_items for delete to authenticated
   using (created_by = auth.uid() or user_id = auth.uid() or public.is_admin());
 

--- a/supabase/migrations/20260616030000_event_day.sql
+++ b/supabase/migrations/20260616030000_event_day.sql
@@ -16,7 +16,10 @@ values (
   5242880, -- 5 MB
   array['image/png', 'image/jpeg', 'image/webp', 'image/gif']
 )
-on conflict (id) do nothing;
+on conflict (id) do update set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
 
 create policy "event-posters: public read" on storage.objects
   for select using (bucket_id = 'event-posters');

--- a/test/BringList.nuxt.test.ts
+++ b/test/BringList.nuxt.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import BringList from '../app/components/BringList.vue'
+
+mockNuxtImport('useAuth', () => () => ({ myId: ref('me'), isAdmin: ref(false) }))
+
+const items = [
+  { id: 'b1', event_id: 'e1', label: 'Chips', note: null, user_id: null, created_by: 'x', bringer: null },
+  { id: 'b2', event_id: 'e1', label: 'Drinks', note: null, user_id: 'me', created_by: 'me', bringer: { display_name: 'Me' } }
+]
+
+describe('BringList', () => {
+  it('shows the pizza-dough count and every item label', async () => {
+    const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
+    expect(w.text()).toContain('2 pizza doughs needed')
+    expect(w.text()).toContain('Chips')
+    expect(w.text()).toContain('Drinks')
+  })
+
+  it('emits claim for an open item', async () => {
+    const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
+    const claimBtn = w.findAll('button').find(b => b.text().includes('I\'ll bring it'))
+    await claimBtn?.trigger('click')
+    expect(w.emitted('claim')?.[0]).toEqual([items[0]])
+  })
+
+  it('emits unclaim for an item I already own', async () => {
+    const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
+    const unclaimBtn = w.findAll('button').find(b => b.text().includes('Unclaim'))
+    await unclaimBtn?.trigger('click')
+    expect(w.emitted('unclaim')?.[0]).toEqual([items[1]])
+  })
+
+  it('emits add for a newly typed item', async () => {
+    const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
+    await w.find('input').setValue('Blanket')
+    const addBtn = w.findAll('button').find(b => b.text().trim() === 'Add')
+    await addBtn?.trigger('click')
+    expect(w.emitted('add')?.[0]).toEqual(['Blanket'])
+  })
+})

--- a/test/RsvpControl.nuxt.test.ts
+++ b/test/RsvpControl.nuxt.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import RsvpControl from '../app/components/RsvpControl.vue'
+
+const counts = { going: 3, maybe: 1, no: 0 }
+
+describe('RsvpControl', () => {
+  it('shows the going and maybe headcount', async () => {
+    const w = await mountSuspended(RsvpControl, { props: { myStatus: 'going', counts } })
+    expect(w.text()).toContain('3 going')
+    expect(w.text()).toContain('1 maybe')
+  })
+
+  it('emits set with the chosen status', async () => {
+    const w = await mountSuspended(RsvpControl, { props: { myStatus: null, counts } })
+    const maybeBtn = w.findAll('button').find(b => b.text().includes('Maybe'))
+    await maybeBtn?.trigger('click')
+    expect(w.emitted('set')?.[0]).toEqual(['maybe'])
+  })
+})

--- a/test/calendar.test.ts
+++ b/test/calendar.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import { applyTime, googleCalendarUrl, icsContent } from '../shared/utils/calendar'
+
+// A fixed UTC instant keeps the UTC-formatted output deterministic across timezones.
+const start = new Date('2026-07-04T23:00:00Z')
+
+describe('googleCalendarUrl', () => {
+  it('builds a TEMPLATE url with UTC start/end (default 3h) and stripped details', () => {
+    const url = new URL(googleCalendarUrl({
+      title: 'Movie Night',
+      start,
+      location: 'Benteen Park',
+      description: '<p>Bring a <b>blanket</b></p>'
+    }))
+    expect(url.searchParams.get('action')).toBe('TEMPLATE')
+    expect(url.searchParams.get('text')).toBe('Movie Night')
+    // 23:00Z + 180min → 02:00Z next day
+    expect(url.searchParams.get('dates')).toBe('20260704T230000Z/20260705T020000Z')
+    expect(url.searchParams.get('location')).toBe('Benteen Park')
+    expect(url.searchParams.get('details')).toBe('Bring a blanket')
+  })
+
+  it('honours a custom duration', () => {
+    const url = new URL(googleCalendarUrl({ title: 'X', start, durationMinutes: 60 }))
+    expect(url.searchParams.get('dates')).toBe('20260704T230000Z/20260705T000000Z')
+  })
+})
+
+describe('icsContent', () => {
+  it('produces a valid VEVENT with CRLF line breaks', () => {
+    const ics = icsContent({ title: 'Movie Night', start, location: 'Benteen Park' })
+    expect(ics).toContain('BEGIN:VCALENDAR')
+    expect(ics).toContain('BEGIN:VEVENT')
+    expect(ics).toContain('DTSTART:20260704T230000Z')
+    expect(ics).toContain('DTEND:20260705T020000Z')
+    expect(ics).toContain('SUMMARY:Movie Night')
+    expect(ics).toContain('LOCATION:Benteen Park')
+    expect(ics).toContain('END:VCALENDAR')
+    expect(ics).toContain('\r\n')
+  })
+
+  it('escapes special characters and strips html from the description', () => {
+    const ics = icsContent({ title: 'A; B, C', start, description: '<p>Line one</p>' })
+    expect(ics).toContain('SUMMARY:A\\; B\\, C')
+    expect(ics).toContain('DESCRIPTION:Line one')
+  })
+
+  it('omits optional lines when absent', () => {
+    const ics = icsContent({ title: 'Bare', start })
+    expect(ics).not.toContain('LOCATION:')
+    expect(ics).not.toContain('DESCRIPTION:')
+  })
+})
+
+describe('applyTime', () => {
+  const base = new Date(2026, 6, 4, 0, 0, 0, 0)
+
+  it('parses 12-hour times', () => {
+    expect(applyTime(base, '7:30 PM').getHours()).toBe(19)
+    expect(applyTime(base, '7:30 PM').getMinutes()).toBe(30)
+    expect(applyTime(base, '12:00 AM').getHours()).toBe(0)
+    expect(applyTime(base, '12 PM').getHours()).toBe(12)
+  })
+
+  it('parses 24-hour times', () => {
+    const d = applyTime(base, '19:45')
+    expect(d.getHours()).toBe(19)
+    expect(d.getMinutes()).toBe(45)
+  })
+
+  it('returns the date unchanged for empty or unparseable input', () => {
+    expect(applyTime(base, null).getTime()).toBe(base.getTime())
+    expect(applyTime(base, '').getTime()).toBe(base.getTime())
+    expect(applyTime(base, 'soon-ish').getTime()).toBe(base.getTime())
+    expect(applyTime(base, '99:99').getTime()).toBe(base.getTime())
+  })
+
+  it('does not mutate the input date', () => {
+    applyTime(base, '8:00 PM')
+    expect(base.getHours()).toBe(0)
+  })
+})

--- a/test/calendar.test.ts
+++ b/test/calendar.test.ts
@@ -50,6 +50,12 @@ describe('icsContent', () => {
     expect(ics).not.toContain('LOCATION:')
     expect(ics).not.toContain('DESCRIPTION:')
   })
+
+  it('includes a stable UID and DTSTAMP (RFC 5545 requires both)', () => {
+    const ics = icsContent({ title: 'Movie Night', start })
+    expect(ics).toMatch(/UID:20260704T230000Z-movie-night@/)
+    expect(ics).toContain('DTSTAMP:20260704T230000Z')
+  })
 })
 
 describe('applyTime', () => {

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { sortEventsForAdmin } from '../app/utils/events'
+
+const DAY = 86_400_000
+const at = (offsetDays: number): string => new Date(Date.now() + offsetDays * DAY).toISOString()
+const ev = (id: string, offsetDays: number) => ({
+  id,
+  title: id,
+  description: '',
+  event_date: at(offsetDays),
+  start_time: null,
+  location: null,
+  location_url: null,
+  poster_url: null,
+  created_at: at(0)
+})
+
+describe('sortEventsForAdmin', () => {
+  it('lists upcoming first (soonest first), then past descending (oldest last)', () => {
+    const input = [ev('past-old', -30), ev('future-far', 30), ev('past-recent', -2), ev('future-near', 2)]
+    expect(sortEventsForAdmin(input).map(e => e.id)).toEqual(['future-near', 'future-far', 'past-recent', 'past-old'])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [ev('a', 5), ev('b', -5)]
+    const snapshot = [...input]
+    sortEventsForAdmin(input)
+    expect(input).toEqual(snapshot)
+  })
+
+  it('returns an empty array when there are no events', () => {
+    expect(sortEventsForAdmin([])).toEqual([])
+  })
+})

--- a/test/useBringList.nuxt.test.ts
+++ b/test/useBringList.nuxt.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+interface InsertCall { payload: Record<string, unknown> }
+interface UpdateCall { payload: Record<string, unknown>, filters: Record<string, unknown> }
+interface DeleteCall { filters: Record<string, unknown> }
+const calls = {
+  inserts: [] as InsertCall[],
+  updates: [] as UpdateCall[],
+  deletes: [] as DeleteCall[]
+}
+
+const filteredChain = (record: (filters: Record<string, unknown>) => void) => {
+  const filters: Record<string, unknown> = {}
+  const chain = {
+    eq: (col: string, val: unknown) => {
+      filters[col] = val
+      return chain
+    },
+    then: (onFulfilled: (r: { error: null }) => unknown) => {
+      record(filters)
+      return Promise.resolve({ error: null }).then(onFulfilled)
+    }
+  }
+  return chain
+}
+
+const supabase = {
+  from() {
+    return {
+      select: () => ({ eq: () => ({ order: () => Promise.resolve({ data: [] }) }) }),
+      insert: (payload: Record<string, unknown>) => {
+        calls.inserts.push({ payload })
+        return Promise.resolve({ error: null })
+      },
+      update: (payload: Record<string, unknown>) =>
+        filteredChain(filters => calls.updates.push({ payload, filters })),
+      delete: () => filteredChain(filters => calls.deletes.push({ filters }))
+    }
+  },
+  channel() {
+    const ch = { on: () => ch, subscribe: () => ch }
+    return ch
+  },
+  removeChannel() {}
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+mockNuxtImport('useState', () => (key: string) => ref(key === 'my-id' ? 'me' : null))
+
+beforeEach(() => {
+  calls.inserts = []
+  calls.updates = []
+  calls.deletes = []
+})
+
+describe('useBringList', () => {
+  it('addItem inserts a label claimed by me, omitting created_by (the DB defaults it)', async () => {
+    const { addItem } = useBringList(ref('e1'))
+    await addItem('Chips')
+    expect(calls.inserts).toHaveLength(1)
+    expect(calls.inserts[0]!.payload).toEqual({ event_id: 'e1', label: 'Chips', note: null, user_id: 'me' })
+    expect(calls.inserts[0]!.payload).not.toHaveProperty('created_by')
+  })
+
+  it('addItem can leave a slot open (unclaimed)', async () => {
+    const { addItem } = useBringList(ref('e1'))
+    await addItem('Drinks', undefined, false)
+    expect(calls.inserts[0]!.payload).toMatchObject({ label: 'Drinks', user_id: null })
+  })
+
+  it('claim sets user_id to me on the row', async () => {
+    const { claim } = useBringList(ref('e1'))
+    await claim({ id: 'b1' } as never)
+    expect(calls.updates[0]).toEqual({ payload: { user_id: 'me' }, filters: { id: 'b1' } })
+  })
+
+  it('unclaim clears user_id', async () => {
+    const { unclaim } = useBringList(ref('e1'))
+    await unclaim({ id: 'b1' } as never)
+    expect(calls.updates[0]).toEqual({ payload: { user_id: null }, filters: { id: 'b1' } })
+  })
+
+  it('remove deletes the row by id', async () => {
+    const { remove } = useBringList(ref('e1'))
+    await remove({ id: 'b1' } as never)
+    expect(calls.deletes[0]!.filters).toEqual({ id: 'b1' })
+  })
+})

--- a/test/useRsvp.nuxt.test.ts
+++ b/test/useRsvp.nuxt.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+interface UpsertCall { payload: Record<string, unknown>, opts: unknown }
+interface DeleteCall { filters: Record<string, unknown> }
+const calls: { upserts: UpsertCall[], deletes: DeleteCall[] } = { upserts: [], deletes: [] }
+let rows: { user_id: string, status: string }[] = []
+
+// Minimal Supabase stub that records upserts/deletes and feeds refresh()/realtime.
+const supabase = {
+  from() {
+    return {
+      select: () => ({ eq: () => Promise.resolve({ data: rows }) }),
+      upsert: (payload: Record<string, unknown>, opts: unknown) => {
+        calls.upserts.push({ payload, opts })
+        return Promise.resolve({ error: null })
+      },
+      delete: () => {
+        const filters: Record<string, unknown> = {}
+        const chain = {
+          eq: (col: string, val: unknown) => {
+            filters[col] = val
+            return chain
+          },
+          then: (onFulfilled: (r: { error: null }) => unknown) => {
+            calls.deletes.push({ filters })
+            return Promise.resolve({ error: null }).then(onFulfilled)
+          }
+        }
+        return chain
+      }
+    }
+  },
+  channel() {
+    const ch = { on: () => ch, subscribe: () => ch }
+    return ch
+  },
+  removeChannel() {}
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+mockNuxtImport('useState', () => (key: string) => ref(key === 'my-id' ? 'me' : null))
+
+// Flush the immediate-watch refresh (a microtask) before asserting derived state.
+const tick = (): Promise<void> => new Promise(resolve => setTimeout(resolve))
+
+beforeEach(() => {
+  calls.upserts = []
+  calls.deletes = []
+  rows = []
+})
+
+describe('useRsvp', () => {
+  it('counts going/maybe/no and resolves my own status', async () => {
+    rows = [{ user_id: 'me', status: 'going' }, { user_id: 'a', status: 'going' }, { user_id: 'b', status: 'maybe' }]
+    const { counts, myStatus } = useRsvp(ref('e1'))
+    await tick()
+    expect(counts.value).toEqual({ going: 2, maybe: 1, no: 0 })
+    expect(myStatus.value).toBe('going')
+  })
+
+  it('setStatus upserts the new status with the composite conflict target', async () => {
+    const { setStatus } = useRsvp(ref('e1'))
+    await tick()
+    await setStatus('going')
+    expect(calls.upserts).toHaveLength(1)
+    expect(calls.upserts[0]!.payload).toMatchObject({ event_id: 'e1', user_id: 'me', status: 'going' })
+    expect(calls.upserts[0]!.opts).toEqual({ onConflict: 'event_id,user_id' })
+  })
+
+  it('setStatus clears my RSVP when I tap the status I already have', async () => {
+    rows = [{ user_id: 'me', status: 'going' }]
+    const { setStatus } = useRsvp(ref('e1'))
+    await tick()
+    await setStatus('going')
+    expect(calls.deletes).toHaveLength(1)
+    expect(calls.deletes[0]!.filters).toEqual({ event_id: 'e1', user_id: 'me' })
+    expect(calls.upserts).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Event-day features

Everything for actually running a movie night — RSVP, headcount, potluck, posters, logistics — plus the dark-mode fix.

### Features
- **RSVP + headcount** — Going / Maybe / Can't, with a live count. Surfaced on the overview left panel (upcoming events) and in the details modal.
- **Bring list (potluck)** — claimable items; anyone can add or claim an open slot. Shows **🍕 N pizza doughs needed** driven by the "Going" count (one dough per person).
- **Event poster** — admins can upload a poster in the add/edit modal. Used as the sidebar card backdrop and shown large at the top of the details modal.
- **Logistics** — start time, location, and a map link.
- **Add to Calendar** — Google Calendar link + `.ics` download from the details modal.
- **Dark mode** — true black neutral instead of slate (no blue tint).
- **Admin events sort** — upcoming first (soonest first), then past descending (oldest last). The moderation selector defaults to the next upcoming event.

### Data / infra
- New `rsvps` and `bring_items` tables with RLS (read-all headcount; you manage only your own rows) and realtime.
- `event-posters` storage bucket: public read, admin-only write.
- New event columns: `start_time`, `location`, `location_url`, `poster_url`.

> **Migration required:** apply `supabase/migrations/20260616030000_event_day.sql` in the Supabase SQL editor (or via the CLI) before this works against the live DB.

### Verification
- `npm run typecheck` ✅
- `npm test` ✅ (34 tests; new `test/calendar.test.ts` covers Google URL / ICS / time parsing)
- `npm run build` ✅
- `npm run lint` ✅ (0 errors)
