### PR TITLE
feat: "help me find a movie" — discover acclaimed hidden gems

### DIFF
--- a/app/components/MovieFinder.vue
+++ b/app/components/MovieFinder.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import type { TmdbMovie } from '#shared/types/movie'
+
+const open = defineModel<boolean>('open', { default: false })
+const props = defineProps<{ suggestedMovieIds: number[] }>()
+const emit = defineEmits<{ suggest: [movie: TmdbMovie], trailer: [movie: TmdbMovie] }>()
+
+const { posterUrl, discoverGems } = useTmdb()
+const toast = useToast()
+
+const movies = ref<TmdbMovie[]>([])
+const loading = ref(false)
+
+async function load(): Promise<void> {
+  loading.value = true
+  try {
+    movies.value = await discoverGems()
+  } catch {
+    toast.add({ title: 'Could not load picks — try again', color: 'error' })
+  } finally {
+    loading.value = false
+  }
+}
+
+// Fetch the first batch the first time the modal opens.
+watch(open, (isOpen) => {
+  if (isOpen && !movies.value.length) load()
+})
+
+function isSuggested(movie: TmdbMovie): boolean {
+  return props.suggestedMovieIds.includes(movie.id)
+}
+</script>
+
+<template>
+  <UModal
+    v-model:open="open"
+    title="Help me find a movie"
+    description="Critically acclaimed, lesser-known picks. Watch a trailer, then suggest one."
+    :ui="{ content: 'sm:max-w-3xl' }"
+  >
+    <template #body>
+      <div class="space-y-4">
+        <div class="flex justify-end">
+          <UButton
+            label="Shuffle"
+            icon="i-lucide-shuffle"
+            color="neutral"
+            variant="outline"
+            size="sm"
+            :loading="loading"
+            @click="load"
+          />
+        </div>
+
+        <div v-if="loading && !movies.length" class="grid sm:grid-cols-2 gap-3">
+          <USkeleton v-for="n in 4" :key="n" class="h-32 w-full" />
+        </div>
+
+        <div v-else-if="movies.length" class="grid sm:grid-cols-2 gap-3">
+          <UCard v-for="movie in movies" :key="movie.id" variant="subtle" :ui="{ body: 'p-3 sm:p-3' }">
+            <div class="flex gap-3">
+              <img
+                v-if="posterUrl(movie.poster_path, 'w185')"
+                :src="posterUrl(movie.poster_path, 'w185') ?? undefined"
+                :alt="movie.title"
+                class="h-32 w-22 rounded-md object-cover bg-elevated shrink-0"
+              >
+              <div class="min-w-0 flex-1 flex flex-col">
+                <h3 class="font-semibold leading-tight text-sm">
+                  {{ movie.title }}
+                  <span v-if="movie.release_date" class="text-muted font-normal">({{ movie.release_date.slice(0, 4) }})</span>
+                </h3>
+                <p v-if="movie.vote_average" class="text-xs text-muted mt-0.5 flex items-center gap-1">
+                  <UIcon name="i-lucide-star" class="text-amber-400" /> {{ movie.vote_average.toFixed(1) }}
+                </p>
+                <p v-if="movie.overview" class="text-xs text-muted mt-1 line-clamp-2">
+                  {{ movie.overview }}
+                </p>
+                <div class="flex gap-1.5 mt-auto pt-2">
+                  <UButton
+                    label="Trailer"
+                    icon="i-lucide-play"
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    @click="emit('trailer', movie)"
+                  />
+                  <UButton
+                    :label="isSuggested(movie) ? 'Suggested' : 'Suggest'"
+                    icon="i-lucide-plus"
+                    size="xs"
+                    :disabled="isSuggested(movie)"
+                    @click="emit('suggest', movie)"
+                  />
+                </div>
+              </div>
+            </div>
+          </UCard>
+        </div>
+
+        <p v-else class="text-sm text-muted text-center py-8">
+          No picks right now — hit Shuffle to try again.
+        </p>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/app/composables/useTmdb.ts
+++ b/app/composables/useTmdb.ts
@@ -18,5 +18,10 @@ export function useTmdb() {
     return await $fetch('/api/movies/videos', { query: { id: movieId } })
   }
 
-  return { searchMovies, posterUrl, getTrailer }
+  /** A fresh handful of critically acclaimed, lesser-known movies ("hidden gems"). */
+  async function discoverGems(): Promise<TmdbMovie[]> {
+    return await $fetch<TmdbMovie[]>('/api/movies/discover')
+  }
+
+  return { searchMovies, posterUrl, getTrailer, discoverGems }
 }

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -13,6 +13,7 @@ const eventIndex = ref(0)
 const initialized = ref(false)
 const eventInfoOpen = ref(false)
 const suggestOpen = ref(false)
+const finderOpen = ref(false)
 const trailerOpen = ref(false)
 const trailerMovie = ref<TmdbMovie | null>(null)
 
@@ -54,9 +55,12 @@ function nextEvent(): void {
   if (eventIndex.value < events.value.length - 1) eventIndex.value++
 }
 
-function openTrailer(suggestion: Suggestion): void {
-  trailerMovie.value = suggestion.tmdb_movie
+function openTrailerMovie(movie: TmdbMovie): void {
+  trailerMovie.value = movie
   trailerOpen.value = true
+}
+function openTrailer(suggestion: Suggestion): void {
+  openTrailerMovie(suggestion.tmdb_movie)
 }
 
 async function onSuggest(movie: TmdbMovie): Promise<void> {
@@ -226,6 +230,17 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
             icon="i-lucide-plus"
             @click="suggestOpen = true"
           />
+
+          <!-- Movie finder (all sizes) -->
+          <UButton
+            class="justify-center"
+            block
+            color="neutral"
+            variant="outline"
+            label="Help me find a movie"
+            icon="i-lucide-clapperboard"
+            @click="finderOpen = true"
+          />
         </aside>
 
         <!-- RIGHT: rankings -->
@@ -277,6 +292,13 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
         <SuggestSection :suggested-movie-ids="suggestedMovieIds" @suggest="onSuggest" />
       </template>
     </USlideover>
+
+    <MovieFinder
+      v-model:open="finderOpen"
+      :suggested-movie-ids="suggestedMovieIds"
+      @suggest="onSuggest"
+      @trailer="openTrailerMovie"
+    />
 
     <EventInfoModal v-model:open="eventInfoOpen" :event="currentEvent" />
     <TrailerModal v-model:open="trailerOpen" :movie="trailerMovie" />

--- a/server/api/movies/discover.get.ts
+++ b/server/api/movies/discover.get.ts
@@ -1,0 +1,66 @@
+import type { TmdbMovie } from '#shared/types/movie'
+
+interface TmdbDiscoverResponse {
+  results: Array<TmdbMovie & Record<string, unknown>>
+}
+
+// "Hidden gems": highly rated, but with a modest vote count so blockbusters
+// are filtered out. A random early page keeps each visit fresh.
+const VOTE_AVERAGE_MIN = 7
+const VOTE_COUNT_MIN = 300 // enough ratings to be credible
+const VOTE_COUNT_MAX = 4000 // but not a household name
+const MAX_PAGE = 15
+const RETURN_COUNT = 8
+
+function shuffle<T>(items: T[]): T[] {
+  const out = [...items]
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i], out[j]] = [out[j]!, out[i]!]
+  }
+  return out
+}
+
+/**
+ * Proxies TMDB Discover for critically acclaimed, lesser-known movies.
+ * The API key stays server-side (Product Invariant 2). Returns a shuffled,
+ * trimmed subset so each call surfaces a different handful of gems.
+ */
+export default defineEventHandler(async (event): Promise<TmdbMovie[]> => {
+  const { tmdbApiKey } = useRuntimeConfig(event)
+  if (!tmdbApiKey) {
+    throw createError({ statusCode: 500, statusMessage: 'TMDB API key is not configured' })
+  }
+
+  const page = Math.floor(Math.random() * MAX_PAGE) + 1
+
+  let data: TmdbDiscoverResponse
+  try {
+    data = await $fetch<TmdbDiscoverResponse>('https://api.themoviedb.org/3/discover/movie', {
+      query: {
+        'api_key': tmdbApiKey,
+        'include_adult': false,
+        'language': 'en-US',
+        'sort_by': 'vote_average.desc',
+        'vote_average.gte': VOTE_AVERAGE_MIN,
+        'vote_count.gte': VOTE_COUNT_MIN,
+        'vote_count.lte': VOTE_COUNT_MAX,
+        'page': page
+      }
+    })
+  } catch {
+    throw createError({ statusCode: 502, statusMessage: 'Failed to reach the movie database' })
+  }
+
+  return shuffle((data.results ?? []).filter(movie => Boolean(movie?.id && movie?.title)))
+    .slice(0, RETURN_COUNT)
+    .map(movie => ({
+      id: movie.id,
+      title: movie.title,
+      overview: movie.overview ?? '',
+      poster_path: movie.poster_path ?? null,
+      release_date: movie.release_date ?? '',
+      vote_average: movie.vote_average ?? 0,
+      popularity: movie.popularity ?? 0
+    }))
+})


### PR DESCRIPTION
## Help me find a movie 🎬

A "find me something to watch" button that surfaces **critically acclaimed, lesser-known** movies — watch the trailer, then suggest the pick straight into the current event.

> Stacked on #44 (event-day features). Base will retarget to `main` once #44 merges.

### What it does
- **New `/api/movies/discover` proxy** — TMDB Discover filtered to highly rated (`vote_average >= 7`) but lesser-known titles (300–4000 votes, so blockbusters drop out). Pulls a random early page and shuffles, so every visit is a fresh handful of gems. TMDB key stays server-side (Product Invariant 2).
- **MovieFinder modal** — poster, year, ⭐ rating, and synopsis for each pick. Buttons to **watch the trailer** (reuses the existing trailer modal) or **suggest** it into the current event (disabled if already suggested). **Shuffle** pulls a new batch.
- **"Help me find a movie"** button in the overview control panel.

### Verification
- `npm run typecheck` ✅
- `npm test` ✅ (34)
- `npm run build` ✅
- `npm run lint` ✅ (0 errors)
