### PR TITLE
feat: reconcile event-features into main (movie finder + admin bring list + race fix)

### DIFF
--- a/app/components/BringList.vue
+++ b/app/components/BringList.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import type { BringItem } from '#shared/types/bring'
 
-defineProps<{ items: BringItem[], doughs?: number }>()
+// `manage` = admin curation (add + remove items); otherwise it's the public
+// claim view (volunteer for an open slot, or unclaim your own).
+defineProps<{ items: BringItem[], doughs?: number, manage?: boolean }>()
 const emit = defineEmits<{
   add: [label: string]
   claim: [item: BringItem]
@@ -9,7 +11,7 @@ const emit = defineEmits<{
   remove: [item: BringItem]
 }>()
 
-const { myId, isAdmin } = useAuth()
+const { myId } = useAuth()
 const newItem = ref('')
 
 function add(): void {
@@ -46,10 +48,16 @@ function mine(item: BringItem): boolean {
             {{ item.user_id ? (item.bringer?.display_name ?? 'Someone') : 'Open — needs a volunteer' }}
           </p>
         </div>
-        <UButton v-if="!item.user_id" label="I'll bring it" size="xs" class="shrink-0" @click="emit('claim', item)" />
-        <UButton v-else-if="mine(item)" label="Unclaim" size="xs" color="neutral" variant="ghost" class="shrink-0" @click="emit('unclaim', item)" />
+
+        <!-- Public claim view -->
+        <template v-if="!manage">
+          <UButton v-if="!item.user_id" label="I'll bring it" size="xs" class="shrink-0" @click="emit('claim', item)" />
+          <UButton v-else-if="mine(item)" label="Unclaim" size="xs" color="neutral" variant="ghost" class="shrink-0" @click="emit('unclaim', item)" />
+        </template>
+
+        <!-- Admin curation: remove an item -->
         <UButton
-          v-if="mine(item) || isAdmin"
+          v-else
           icon="i-lucide-trash-2"
           size="xs"
           color="neutral"
@@ -61,11 +69,12 @@ function mine(item: BringItem): boolean {
       </li>
     </ul>
     <p v-else class="text-sm text-muted">
-      Nothing on the list yet — add what you're bringing.
+      {{ manage ? 'Nothing on the list yet — add what the group needs.' : 'Nothing to bring yet — the organizer will add items.' }}
     </p>
 
-    <div class="flex gap-2">
-      <UInput v-model="newItem" placeholder="e.g. toppings, drinks, a blanket…" class="flex-1" @keydown.enter="add" />
+    <!-- Add an item (admin only) -->
+    <div v-if="manage" class="flex gap-2">
+      <UInput v-model="newItem" placeholder="e.g. pepperoni, drinks, plates…" class="flex-1" @keydown.enter="add" />
       <UButton label="Add" icon="i-lucide-plus" :disabled="!newItem.trim()" @click="add" />
     </div>
   </div>

--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -7,7 +7,7 @@ const props = defineProps<{ event: MovieEvent | null }>()
 
 const eventId = computed(() => props.event?.id ?? null)
 const { myStatus, counts, setStatus } = useRsvp(eventId)
-const { items, addItem, claim, unclaim, remove } = useBringList(eventId)
+const { items, claim, unclaim } = useBringList(eventId)
 
 // One pizza dough per person who's "Going".
 const doughs = computed(() => counts.value.going)
@@ -35,12 +35,6 @@ function downloadIcs(): void {
   a.download = `${(props.event?.title || 'event').replace(/[^\w-]+/g, '-')}.ics`
   a.click()
   URL.revokeObjectURL(url)
-}
-
-async function onAdd(label: string): Promise<void> {
-  try {
-    await addItem(label)
-  } catch { /* surfaced via realtime state staying unchanged */ }
 }
 </script>
 
@@ -131,10 +125,8 @@ async function onAdd(label: string): Promise<void> {
           <BringList
             :items="items"
             :doughs="doughs"
-            @add="onAdd"
             @claim="claim"
             @unclaim="unclaim"
-            @remove="remove"
           />
         </div>
       </div>

--- a/app/components/MovieFinder.vue
+++ b/app/components/MovieFinder.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import type { TmdbMovie } from '#shared/types/movie'
+
+const open = defineModel<boolean>('open', { default: false })
+const props = defineProps<{ suggestedMovieIds: number[] }>()
+const emit = defineEmits<{ suggest: [movie: TmdbMovie], trailer: [movie: TmdbMovie] }>()
+
+const { posterUrl, discoverGems } = useTmdb()
+const toast = useToast()
+
+const movies = ref<TmdbMovie[]>([])
+const loading = ref(false)
+
+async function load(): Promise<void> {
+  loading.value = true
+  try {
+    movies.value = await discoverGems()
+  } catch {
+    toast.add({ title: 'Could not load picks — try again', color: 'error' })
+  } finally {
+    loading.value = false
+  }
+}
+
+// Fetch the first batch the first time the modal opens.
+watch(open, (isOpen) => {
+  if (isOpen && !movies.value.length) load()
+})
+
+function isSuggested(movie: TmdbMovie): boolean {
+  return props.suggestedMovieIds.includes(movie.id)
+}
+</script>
+
+<template>
+  <UModal
+    v-model:open="open"
+    title="Help me find a movie"
+    description="Critically acclaimed, lesser-known picks. Watch a trailer, then suggest one."
+    :ui="{ content: 'sm:max-w-3xl' }"
+  >
+    <template #body>
+      <div class="space-y-4">
+        <div class="flex justify-end">
+          <UButton
+            label="Shuffle"
+            icon="i-lucide-shuffle"
+            color="neutral"
+            variant="outline"
+            size="sm"
+            :loading="loading"
+            @click="load"
+          />
+        </div>
+
+        <div v-if="loading && !movies.length" class="grid sm:grid-cols-2 gap-3">
+          <USkeleton v-for="n in 4" :key="n" class="h-32 w-full" />
+        </div>
+
+        <div v-else-if="movies.length" class="grid sm:grid-cols-2 gap-3">
+          <UCard v-for="movie in movies" :key="movie.id" variant="subtle" :ui="{ body: 'p-3 sm:p-3' }">
+            <div class="flex gap-3">
+              <img
+                v-if="posterUrl(movie.poster_path, 'w185')"
+                :src="posterUrl(movie.poster_path, 'w185') ?? undefined"
+                :alt="movie.title"
+                class="h-32 w-22 rounded-md object-cover bg-elevated shrink-0"
+              >
+              <div class="min-w-0 flex-1 flex flex-col">
+                <h3 class="font-semibold leading-tight text-sm">
+                  {{ movie.title }}
+                  <span v-if="movie.release_date" class="text-muted font-normal">({{ movie.release_date.slice(0, 4) }})</span>
+                </h3>
+                <p v-if="movie.vote_average" class="text-xs text-muted mt-0.5 flex items-center gap-1">
+                  <UIcon name="i-lucide-star" class="text-amber-400" /> {{ movie.vote_average.toFixed(1) }}
+                </p>
+                <p v-if="movie.overview" class="text-xs text-muted mt-1 line-clamp-2">
+                  {{ movie.overview }}
+                </p>
+                <div class="flex gap-1.5 mt-auto pt-2">
+                  <UButton
+                    label="Trailer"
+                    icon="i-lucide-play"
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    @click="emit('trailer', movie)"
+                  />
+                  <UButton
+                    :label="isSuggested(movie) ? 'Suggested' : 'Suggest'"
+                    icon="i-lucide-plus"
+                    size="xs"
+                    :disabled="isSuggested(movie)"
+                    @click="emit('suggest', movie)"
+                  />
+                </div>
+              </div>
+            </div>
+          </UCard>
+        </div>
+
+        <p v-else class="text-sm text-muted text-center py-8">
+          No picks right now — hit Shuffle to try again.
+        </p>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/app/composables/useBringList.ts
+++ b/app/composables/useBringList.ts
@@ -18,6 +18,8 @@ export function useBringList(eventId: MaybeRefOrGetter<string | null | undefined
       return
     }
     const { data } = await supabase.from('bring_items').select(SELECT).eq('event_id', id).order('created_at')
+    // Drop a stale response: the selected event changed while this was in flight.
+    if (toValue(eventId) !== id) return
     // Supabase types the embedded `bringer` join as an array, but the FK is to a
     // single profile — assert to our `BringItem` (single bringer-or-null) shape.
     items.value = (data ?? []) as unknown as BringItem[]

--- a/app/composables/useRsvp.ts
+++ b/app/composables/useRsvp.ts
@@ -16,6 +16,8 @@ export function useRsvp(eventId: MaybeRefOrGetter<string | null | undefined>) {
       return
     }
     const { data } = await supabase.from('rsvps').select('user_id, status').eq('event_id', id)
+    // Drop a stale response: the selected event changed while this was in flight.
+    if (toValue(eventId) !== id) return
     rsvps.value = data ?? []
   }
 

--- a/app/composables/useSuggestions.ts
+++ b/app/composables/useSuggestions.ts
@@ -25,6 +25,8 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
       .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
       .eq('event_id', id)
       .eq('deleted', false)
+    // Drop a stale response: the selected event changed while this was in flight.
+    if (toValue(eventId) !== id) return
     suggestions.value = ((data ?? []) as unknown as Suggestion[]).sort((a, b) => {
       const diff = b.votes.length - a.votes.length
       return diff !== 0 ? diff : new Date(a.created_at).getTime() - new Date(b.created_at).getTime()

--- a/app/composables/useTmdb.ts
+++ b/app/composables/useTmdb.ts
@@ -18,5 +18,10 @@ export function useTmdb() {
     return await $fetch('/api/movies/videos', { query: { id: movieId } })
   }
 
-  return { searchMovies, posterUrl, getTrailer }
+  /** A fresh handful of critically acclaimed, lesser-known movies ("hidden gems"). */
+  async function discoverGems(): Promise<TmdbMovie[]> {
+    return await $fetch<TmdbMovie[]>('/api/movies/discover')
+  }
+
+  return { searchMovies, posterUrl, getTrailer, discoverGems }
 }

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { MovieEvent } from '#shared/types/event'
+import type { BringItem } from '#shared/types/bring'
 
 definePageMeta({ middleware: 'admin' })
 useSeoMeta({ title: 'Admin · BSOTG' })
@@ -14,6 +15,10 @@ const eventPendingDelete = ref<MovieEvent | null>(null)
 
 const selectedEventId = ref<string>()
 const { suggestions, setDeleted, voterNames } = useAdminSuggestions(selectedEventId)
+
+// Bring list + headcount for the selected event (admins curate; people claim on the event page).
+const { items: bringItems, addItem: addBringItem, remove: removeBringItem } = useBringList(selectedEventId)
+const { counts: rsvpCounts } = useRsvp(selectedEventId)
 
 // Upcoming events first (soonest first), then past events descending (oldest last).
 const sortedEvents = computed(() => sortEventsForAdmin(events.value))
@@ -73,6 +78,24 @@ async function confirmDelete(): Promise<void> {
     toast.add({ title: 'Could not delete event', color: 'error' })
   } finally {
     eventPendingDelete.value = null
+  }
+}
+
+async function onAddBring(label: string): Promise<void> {
+  try {
+    await addBringItem(label, undefined, false) // open slot anyone can claim
+    toast.add({ title: 'Added to bring list', icon: 'i-lucide-check', color: 'success' })
+  } catch {
+    toast.add({ title: 'Could not add item', color: 'error' })
+  }
+}
+
+async function onRemoveBring(item: BringItem): Promise<void> {
+  try {
+    await removeBringItem(item)
+    toast.add({ title: 'Item removed', color: 'neutral' })
+  } catch {
+    toast.add({ title: 'Could not remove item', color: 'error' })
   }
 }
 
@@ -220,6 +243,40 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
         </UCard>
       </section>
     </div>
+
+    <!-- Bring list management (for the selected event) -->
+    <section class="mt-8">
+      <div class="mb-4">
+        <h2 class="text-xl font-semibold">
+          Bring list
+        </h2>
+        <p class="text-sm text-muted">
+          Add what the group needs for this event — people claim items on the event page.
+        </p>
+      </div>
+
+      <USelectMenu
+        v-model="selectedEventId"
+        :items="eventOptions"
+        value-key="value"
+        :search-input="false"
+        placeholder="Select an event"
+        class="w-full sm:max-w-sm mb-4"
+      />
+
+      <div v-if="selectedEventId" class="max-w-xl">
+        <BringList
+          :items="bringItems"
+          :doughs="rsvpCounts.going"
+          manage
+          @add="onAddBring"
+          @remove="onRemoveBring"
+        />
+      </div>
+      <UCard v-else variant="subtle" class="text-center text-muted">
+        Select an event to manage its bring list.
+      </UCard>
+    </section>
 
     <!-- Create / edit modal -->
     <EventFormModal v-model:open="modalOpen" :event="editingEvent" @save="onSave" />

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -13,6 +13,7 @@ const eventIndex = ref(0)
 const initialized = ref(false)
 const eventInfoOpen = ref(false)
 const suggestOpen = ref(false)
+const finderOpen = ref(false)
 const trailerOpen = ref(false)
 const trailerMovie = ref<TmdbMovie | null>(null)
 
@@ -54,9 +55,12 @@ function nextEvent(): void {
   if (eventIndex.value < events.value.length - 1) eventIndex.value++
 }
 
-function openTrailer(suggestion: Suggestion): void {
-  trailerMovie.value = suggestion.tmdb_movie
+function openTrailerMovie(movie: TmdbMovie): void {
+  trailerMovie.value = movie
   trailerOpen.value = true
+}
+function openTrailer(suggestion: Suggestion): void {
+  openTrailerMovie(suggestion.tmdb_movie)
 }
 
 async function onSuggest(movie: TmdbMovie): Promise<void> {
@@ -226,6 +230,17 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
             icon="i-lucide-plus"
             @click="suggestOpen = true"
           />
+
+          <!-- Movie finder (all sizes) -->
+          <UButton
+            class="justify-center"
+            block
+            color="neutral"
+            variant="outline"
+            label="Help me find a movie"
+            icon="i-lucide-clapperboard"
+            @click="finderOpen = true"
+          />
         </aside>
 
         <!-- RIGHT: rankings -->
@@ -277,6 +292,13 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
         <SuggestSection :suggested-movie-ids="suggestedMovieIds" @suggest="onSuggest" />
       </template>
     </USlideover>
+
+    <MovieFinder
+      v-model:open="finderOpen"
+      :suggested-movie-ids="suggestedMovieIds"
+      @suggest="onSuggest"
+      @trailer="openTrailerMovie"
+    />
 
     <EventInfoModal v-model:open="eventInfoOpen" :event="currentEvent" />
     <TrailerModal v-model:open="trailerOpen" :movie="trailerMovie" />

--- a/server/api/movies/discover.get.ts
+++ b/server/api/movies/discover.get.ts
@@ -1,0 +1,66 @@
+import type { TmdbMovie } from '#shared/types/movie'
+
+interface TmdbDiscoverResponse {
+  results: Array<TmdbMovie & Record<string, unknown>>
+}
+
+// "Hidden gems": highly rated, but with a modest vote count so blockbusters
+// are filtered out. A random early page keeps each visit fresh.
+const VOTE_AVERAGE_MIN = 7
+const VOTE_COUNT_MIN = 300 // enough ratings to be credible
+const VOTE_COUNT_MAX = 4000 // but not a household name
+const MAX_PAGE = 15
+const RETURN_COUNT = 8
+
+function shuffle<T>(items: T[]): T[] {
+  const out = [...items]
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i], out[j]] = [out[j]!, out[i]!]
+  }
+  return out
+}
+
+/**
+ * Proxies TMDB Discover for critically acclaimed, lesser-known movies.
+ * The API key stays server-side (Product Invariant 2). Returns a shuffled,
+ * trimmed subset so each call surfaces a different handful of gems.
+ */
+export default defineEventHandler(async (event): Promise<TmdbMovie[]> => {
+  const { tmdbApiKey } = useRuntimeConfig(event)
+  if (!tmdbApiKey) {
+    throw createError({ statusCode: 500, statusMessage: 'TMDB API key is not configured' })
+  }
+
+  const page = Math.floor(Math.random() * MAX_PAGE) + 1
+
+  let data: TmdbDiscoverResponse
+  try {
+    data = await $fetch<TmdbDiscoverResponse>('https://api.themoviedb.org/3/discover/movie', {
+      query: {
+        'api_key': tmdbApiKey,
+        'include_adult': false,
+        'language': 'en-US',
+        'sort_by': 'vote_average.desc',
+        'vote_average.gte': VOTE_AVERAGE_MIN,
+        'vote_count.gte': VOTE_COUNT_MIN,
+        'vote_count.lte': VOTE_COUNT_MAX,
+        'page': page
+      }
+    })
+  } catch {
+    throw createError({ statusCode: 502, statusMessage: 'Failed to reach the movie database' })
+  }
+
+  return shuffle((data.results ?? []).filter(movie => Boolean(movie?.id && movie?.title)))
+    .slice(0, RETURN_COUNT)
+    .map(movie => ({
+      id: movie.id,
+      title: movie.title,
+      overview: movie.overview ?? '',
+      poster_path: movie.poster_path ?? null,
+      release_date: movie.release_date ?? '',
+      vote_average: movie.vote_average ?? 0,
+      popularity: movie.popularity ?? 0
+    }))
+})

--- a/test/BringList.nuxt.test.ts
+++ b/test/BringList.nuxt.test.ts
@@ -11,7 +11,7 @@ const items = [
   { id: 'b2', event_id: 'e1', label: 'Drinks', note: null, user_id: 'me', created_by: 'me', bringer: { display_name: 'Me' } }
 ]
 
-describe('BringList', () => {
+describe('BringList (public claim view)', () => {
   it('shows the pizza-dough count and every item label', async () => {
     const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
     expect(w.text()).toContain('2 pizza doughs needed')
@@ -33,11 +33,30 @@ describe('BringList', () => {
     expect(w.emitted('unclaim')?.[0]).toEqual([items[1]])
   })
 
-  it('emits add for a newly typed item', async () => {
+  it('has no add input — the list is admin-curated', async () => {
     const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
+    expect(w.find('input').exists()).toBe(false)
+  })
+})
+
+describe('BringList (admin manage view)', () => {
+  it('emits add for a newly typed item', async () => {
+    const w = await mountSuspended(BringList, { props: { items, doughs: 2, manage: true } })
     await w.find('input').setValue('Blanket')
     const addBtn = w.findAll('button').find(b => b.text().trim() === 'Add')
     await addBtn?.trigger('click')
     expect(w.emitted('add')?.[0]).toEqual(['Blanket'])
+  })
+
+  it('emits remove for an item', async () => {
+    const w = await mountSuspended(BringList, { props: { items, doughs: 2, manage: true } })
+    const removeBtn = w.findAll('button').find(b => b.attributes('aria-label') === 'Remove item')
+    await removeBtn?.trigger('click')
+    expect(w.emitted('remove')?.[0]).toEqual([items[0]])
+  })
+
+  it('shows no claim buttons in manage mode', async () => {
+    const w = await mountSuspended(BringList, { props: { items, doughs: 2, manage: true } })
+    expect(w.findAll('button').some(b => b.text().includes('I\'ll bring it'))).toBe(false)
   })
 })

--- a/test/useSuggestions-race.nuxt.test.ts
+++ b/test/useSuggestions-race.nuxt.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+// Deferred read responses keyed by event id, so we can resolve them out of order.
+const resolvers: Record<string, (rows: unknown[]) => void> = {}
+
+const supabase = {
+  from() {
+    let eventId = ''
+    const chain = {
+      select: () => chain,
+      eq: (col: string, val: string) => {
+        if (col === 'event_id') eventId = val
+        return chain
+      },
+      // `await`-ing the query registers a resolver for its event id.
+      then: (onFulfilled: (r: { data: unknown[] }) => unknown) =>
+        new Promise<{ data: unknown[] }>((resolve) => {
+          resolvers[eventId] = rows => resolve({ data: rows })
+        }).then(onFulfilled)
+    }
+    return chain
+  },
+  channel() {
+    const ch = { on: () => ch, subscribe: () => ch }
+    return ch
+  },
+  removeChannel() {}
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+mockNuxtImport('useState', () => () => ref('me'))
+
+const row = (id: string, eventId: string) => ({
+  id,
+  event_id: eventId,
+  user_id: 'u',
+  deleted: false,
+  created_at: '2026-01-01T00:00:00Z',
+  tmdb_movie: { id: 1, title: id },
+  votes: []
+})
+
+describe('useSuggestions stale-response guard', () => {
+  it('keeps the newly-selected event when an older request resolves last', async () => {
+    const eventId = ref('A')
+    const { suggestions } = useSuggestions(eventId) // immediate watcher → refresh('A') in flight
+    await nextTick()
+    eventId.value = 'B' // → refresh('B') in flight
+    await nextTick()
+
+    // 'B' resolves first, then the stale 'A' — 'A' must not overwrite 'B'.
+    resolvers.B?.([row('s-b', 'B')])
+    resolvers.A?.([row('s-a', 'A')])
+    await new Promise(resolve => setTimeout(resolve))
+
+    expect(suggestions.value.map(s => s.id)).toEqual(['s-b'])
+  })
+})


### PR DESCRIPTION
## Reconcile event-features → main

PR #44 was merged from an earlier commit of `event-features` (`895f7d8`), so three commits that landed on the branch afterward never reached `main`:

- **Movie finder** (`51ac3a8`) — `/api/movies/discover` + the "Help me find a movie" modal (was PR #45, merged into `event-features`, not `main`).
- **Admin-curated bring list** + **suggestion stale-event race fix** (`1872498`).

`main` is currently missing all three. This PR brings `event-features` up to `main`.

### Verification
Already green on `event-features`: typecheck ✅, tests ✅ (56), build ✅, lint ✅ (0 errors).

> No new code here — just the commits that the #44 merge timing left behind.
