### PR TITLE
feat: admin command center — dashboard, stats, user blocking

### DIFF
--- a/app/components/PeopleList.vue
+++ b/app/components/PeopleList.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import type { Profile } from '#shared/types/user'
+
+const props = defineProps<{ people: Profile[] }>()
+const emit = defineEmits<{ block: [person: Profile], unblock: [person: Profile] }>()
+
+const query = ref('')
+const filtered = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q) return props.people
+  return props.people.filter(p =>
+    (p.display_name ?? '').toLowerCase().includes(q) || (p.email ?? '').toLowerCase().includes(q)
+  )
+})
+
+function initials(p: Profile): string {
+  return (p.display_name ?? p.email ?? '?').slice(0, 2).toUpperCase()
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <UInput v-model="query" icon="i-lucide-search" placeholder="Search members…" class="w-full sm:max-w-xs" />
+
+    <ul v-if="filtered.length" class="divide-y divide-default rounded-lg ring ring-default overflow-hidden">
+      <li
+        v-for="person in filtered"
+        :key="person.id"
+        class="flex items-center gap-3 p-3"
+        :class="person.blocked ? 'opacity-70' : ''"
+      >
+        <UAvatar
+          :src="person.avatar_url ?? undefined"
+          :alt="person.display_name ?? ''"
+          :text="initials(person)"
+          size="sm"
+          class="shrink-0"
+        />
+        <div class="min-w-0 flex-1">
+          <p class="font-medium truncate flex items-center gap-1.5">
+            {{ person.display_name ?? 'Unnamed' }}
+            <UBadge v-if="person.is_admin" label="Admin" color="primary" variant="subtle" size="xs" />
+            <UBadge v-if="person.blocked" label="Blocked" color="error" variant="subtle" size="xs" />
+          </p>
+          <p class="text-xs text-muted truncate">
+            {{ person.email ?? '—' }}
+          </p>
+        </div>
+        <!-- Admins can't be banned from the UI (demote via SQL first). -->
+        <UButton
+          v-if="person.blocked"
+          label="Unban"
+          icon="i-lucide-user-check"
+          color="neutral"
+          variant="outline"
+          size="xs"
+          class="shrink-0"
+          @click="emit('unblock', person)"
+        />
+        <UButton
+          v-else-if="!person.is_admin"
+          label="Ban"
+          icon="i-lucide-user-x"
+          color="error"
+          variant="outline"
+          size="xs"
+          class="shrink-0"
+          @click="emit('block', person)"
+        />
+      </li>
+    </ul>
+    <p v-else class="text-sm text-muted">
+      No members match.
+    </p>
+  </div>
+</template>

--- a/app/composables/useAdminPeople.ts
+++ b/app/composables/useAdminPeople.ts
@@ -1,0 +1,29 @@
+import type { Database } from '~/types/database.types'
+import type { Profile } from '#shared/types/user'
+
+/** Admin people directory: every profile + ban/unban (via the admin-gated RPC). */
+export function useAdminPeople() {
+  const supabase = useSupabaseClient<Database>()
+  const people = ref<Profile[]>([])
+  const pending = ref(true)
+
+  async function refresh(): Promise<void> {
+    const { data } = await supabase
+      .from('profiles')
+      .select('id, email, display_name, avatar_url, is_admin, blocked, created_at')
+      .order('display_name')
+    people.value = data ?? []
+    pending.value = false
+  }
+
+  onMounted(refresh)
+
+  /** Ban or unban a user. Authorization is enforced in the RPC (admin-only). */
+  async function setBlocked(id: string, value: boolean): Promise<void> {
+    const { error } = await supabase.rpc('admin_set_blocked', { target_id: id, value })
+    if (error) throw error
+    await refresh()
+  }
+
+  return { people, pending, setBlocked }
+}

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { MovieEvent } from '#shared/types/event'
 import type { BringItem } from '#shared/types/bring'
+import type { Profile } from '#shared/types/user'
 
 definePageMeta({ middleware: 'admin' })
 useSeoMeta({ title: 'Admin · BSOTG' })
@@ -8,6 +9,7 @@ useSeoMeta({ title: 'Admin · BSOTG' })
 const toast = useToast()
 const { events } = useEvents()
 const { createEvent, updateEvent, deleteEvent } = useEventAdmin()
+const { people, setBlocked } = useAdminPeople()
 
 const modalOpen = ref(false)
 const editingEvent = ref<MovieEvent | null>(null)
@@ -22,6 +24,7 @@ const { counts: rsvpCounts } = useRsvp(selectedEventId)
 
 // Upcoming events first (soonest first), then past events descending (oldest last).
 const sortedEvents = computed(() => sortEventsForAdmin(events.value))
+const selectedEvent = computed(() => sortedEvents.value.find(e => e.id === selectedEventId.value) ?? null)
 
 const eventOptions = computed(() =>
   sortedEvents.value.map(event => ({
@@ -30,7 +33,26 @@ const eventOptions = computed(() =>
   }))
 )
 
-// Default the moderation selector to the most relevant (next upcoming) event once data loads.
+const tabs = [
+  { label: 'Overview', icon: 'i-lucide-layout-dashboard', slot: 'overview' },
+  { label: 'Events', icon: 'i-lucide-calendar', slot: 'events' },
+  { label: 'People', icon: 'i-lucide-users', slot: 'people' },
+  { label: 'Suggestions', icon: 'i-lucide-clapperboard', slot: 'suggestions' },
+  { label: 'Bring list', icon: 'i-lucide-utensils', slot: 'bring' }
+]
+
+// --- Overview stats (for the focused event) ---
+const memberCount = computed(() => people.value.length)
+const blockedCount = computed(() => people.value.filter(p => p.blocked).length)
+const liveSuggestions = computed(() => suggestions.value.filter(s => !s.deleted))
+const selectedVoteCount = computed(() => liveSuggestions.value.reduce((n, s) => n + (s.votes?.length ?? 0), 0))
+const submitterIds = computed(() => new Set(liveSuggestions.value.map(s => s.user_id)))
+const yetToSubmit = computed(() => people.value.filter(p => !p.blocked && !submitterIds.value.has(p.id)))
+const YET_PREVIEW = 12
+const yetToSubmitPreview = computed(() => yetToSubmit.value.slice(0, YET_PREVIEW))
+const yetToSubmitMore = computed(() => Math.max(0, yetToSubmit.value.length - YET_PREVIEW))
+
+// Default the focused event to the next upcoming one once data loads.
 watch(sortedEvents, (list) => {
   if (!selectedEventId.value && list.length) selectedEventId.value = list[0]!.id
 }, { immediate: true })
@@ -107,23 +129,109 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
     toast.add({ title: 'Action failed', color: 'error' })
   }
 }
+
+async function onBlock(person: Profile): Promise<void> {
+  try {
+    await setBlocked(person.id, true)
+    toast.add({ title: `${person.display_name ?? 'User'} banned`, color: 'neutral' })
+  } catch {
+    toast.add({ title: 'Could not ban user', color: 'error' })
+  }
+}
+async function onUnblock(person: Profile): Promise<void> {
+  try {
+    await setBlocked(person.id, false)
+    toast.add({ title: `${person.display_name ?? 'User'} unbanned`, icon: 'i-lucide-check', color: 'success' })
+  } catch {
+    toast.add({ title: 'Could not unban user', color: 'error' })
+  }
+}
 </script>
 
 <template>
   <UContainer class="py-8 max-w-4xl">
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-8">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
       <h1 class="text-3xl font-bold">
         Admin
       </h1>
       <UButton label="Add movie night" icon="i-lucide-plus" class="w-full sm:w-auto justify-center" @click="openCreate" />
     </div>
 
-    <div class="grid gap-8 lg:grid-cols-2">
-      <!-- Events -->
-      <section>
-        <h2 class="text-xl font-semibold mb-4">
-          Events
-        </h2>
+    <UTabs :items="tabs" class="w-full" :ui="{ content: 'pt-6' }">
+      <!-- OVERVIEW -->
+      <template #overview>
+        <div class="space-y-6">
+          <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <UCard variant="subtle" :ui="{ body: 'text-center' }">
+              <p class="text-2xl font-bold">
+                {{ memberCount }}
+              </p>
+              <p class="text-xs text-muted">
+                members
+              </p>
+            </UCard>
+            <UCard variant="subtle" :ui="{ body: 'text-center' }">
+              <p class="text-2xl font-bold">
+                {{ events.length }}
+              </p>
+              <p class="text-xs text-muted">
+                events
+              </p>
+            </UCard>
+            <UCard variant="subtle" :ui="{ body: 'text-center' }">
+              <p class="text-2xl font-bold">
+                {{ rsvpCounts.going }}
+              </p>
+              <p class="text-xs text-muted">
+                going (next)
+              </p>
+            </UCard>
+            <UCard variant="subtle" :ui="{ body: 'text-center' }">
+              <p class="text-2xl font-bold" :class="blockedCount ? 'text-error' : ''">
+                {{ blockedCount }}
+              </p>
+              <p class="text-xs text-muted">
+                blocked
+              </p>
+            </UCard>
+          </div>
+
+          <UCard v-if="selectedEvent" variant="subtle">
+            <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
+              <h3 class="font-semibold">
+                {{ selectedEvent.title }}
+              </h3>
+              <span class="text-sm text-muted">{{ formatDate(selectedEvent.event_date) }}</span>
+            </div>
+            <div class="flex flex-wrap gap-4 text-sm">
+              <span><strong>{{ liveSuggestions.length }}</strong> <span class="text-muted">suggestions</span></span>
+              <span><strong>{{ selectedVoteCount }}</strong> <span class="text-muted">votes</span></span>
+              <span><strong>{{ rsvpCounts.going }}</strong> <span class="text-muted">going</span></span>
+              <span><strong>{{ yetToSubmit.length }}</strong> <span class="text-muted">yet to suggest</span></span>
+            </div>
+            <template v-if="yetToSubmit.length">
+              <USeparator class="my-3" />
+              <p class="text-xs text-muted mb-2">
+                Haven't suggested yet
+              </p>
+              <div class="flex flex-wrap gap-1">
+                <UBadge
+                  v-for="p in yetToSubmitPreview"
+                  :key="p.id"
+                  :label="p.display_name ?? p.email ?? 'Unknown'"
+                  color="neutral"
+                  variant="outline"
+                  size="xs"
+                />
+                <UBadge v-if="yetToSubmitMore" :label="`+${yetToSubmitMore} more`" color="neutral" variant="subtle" size="xs" />
+              </div>
+            </template>
+          </UCard>
+        </div>
+      </template>
+
+      <!-- EVENTS -->
+      <template #events>
         <div v-if="sortedEvents.length" class="space-y-3">
           <UCard v-for="event in sortedEvents" :key="event.id" variant="subtle">
             <div class="flex items-start justify-between gap-3">
@@ -167,21 +275,22 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
         <UCard v-else variant="subtle" class="text-center text-muted">
           No events yet. Add your first movie night.
         </UCard>
-      </section>
+      </template>
 
-      <!-- Suggestion moderation -->
-      <section>
-        <h2 class="text-xl font-semibold mb-4">
-          Suggestions
-        </h2>
+      <!-- PEOPLE -->
+      <template #people>
+        <PeopleList :people="people" @block="onBlock" @unblock="onUnblock" />
+      </template>
 
+      <!-- SUGGESTIONS -->
+      <template #suggestions>
         <USelectMenu
           v-model="selectedEventId"
           :items="eventOptions"
           value-key="value"
           :search-input="false"
           placeholder="Select an event"
-          class="w-full mb-4"
+          class="w-full sm:max-w-sm mb-4"
         />
 
         <div v-if="suggestions.length" class="space-y-3">
@@ -241,42 +350,36 @@ async function toggleSuggestion(id: string, deleted: boolean): Promise<void> {
         <UCard v-else variant="subtle" class="text-center text-muted">
           No suggestions for this event.
         </UCard>
-      </section>
-    </div>
+      </template>
 
-    <!-- Bring list management (for the selected event) -->
-    <section class="mt-8">
-      <div class="mb-4">
-        <h2 class="text-xl font-semibold">
-          Bring list
-        </h2>
-        <p class="text-sm text-muted">
+      <!-- BRING LIST -->
+      <template #bring>
+        <p class="text-sm text-muted mb-4">
           Add what the group needs for this event — people claim items on the event page.
         </p>
-      </div>
-
-      <USelectMenu
-        v-model="selectedEventId"
-        :items="eventOptions"
-        value-key="value"
-        :search-input="false"
-        placeholder="Select an event"
-        class="w-full sm:max-w-sm mb-4"
-      />
-
-      <div v-if="selectedEventId" class="max-w-xl">
-        <BringList
-          :items="bringItems"
-          :doughs="rsvpCounts.going"
-          manage
-          @add="onAddBring"
-          @remove="onRemoveBring"
+        <USelectMenu
+          v-model="selectedEventId"
+          :items="eventOptions"
+          value-key="value"
+          :search-input="false"
+          placeholder="Select an event"
+          class="w-full sm:max-w-sm mb-4"
         />
-      </div>
-      <UCard v-else variant="subtle" class="text-center text-muted">
-        Select an event to manage its bring list.
-      </UCard>
-    </section>
+
+        <div v-if="selectedEventId" class="max-w-xl">
+          <BringList
+            :items="bringItems"
+            :doughs="rsvpCounts.going"
+            manage
+            @add="onAddBring"
+            @remove="onRemoveBring"
+          />
+        </div>
+        <UCard v-else variant="subtle" class="text-center text-muted">
+          Select an event to manage its bring list.
+        </UCard>
+      </template>
+    </UTabs>
 
     <!-- Create / edit modal -->
     <EventFormModal v-model:open="modalOpen" :event="editingEvent" @save="onSave" />

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -6,9 +6,9 @@ export interface Database {
   public: {
     Tables: {
       profiles: {
-        Row: { id: string, email: string | null, display_name: string | null, avatar_url: string | null, is_admin: boolean, created_at: string }
-        Insert: { id: string, email?: string | null, display_name?: string | null, avatar_url?: string | null, is_admin?: boolean, created_at?: string }
-        Update: { id?: string, email?: string | null, display_name?: string | null, avatar_url?: string | null, is_admin?: boolean, created_at?: string }
+        Row: { id: string, email: string | null, display_name: string | null, avatar_url: string | null, is_admin: boolean, blocked: boolean, created_at: string }
+        Insert: { id: string, email?: string | null, display_name?: string | null, avatar_url?: string | null, is_admin?: boolean, blocked?: boolean, created_at?: string }
+        Update: { id?: string, email?: string | null, display_name?: string | null, avatar_url?: string | null, is_admin?: boolean, blocked?: boolean, created_at?: string }
         Relationships: []
       }
       events: {
@@ -43,7 +43,9 @@ export interface Database {
       }
     }
     Views: { [_ in never]: never }
-    Functions: { [_ in never]: never }
+    Functions: {
+      admin_set_blocked: { Args: { target_id: string, value: boolean }, Returns: undefined }
+    }
     Enums: { [_ in never]: never }
     CompositeTypes: { [_ in never]: never }
   }

--- a/shared/types/user.ts
+++ b/shared/types/user.ts
@@ -5,5 +5,6 @@ export interface Profile {
   display_name: string | null
   avatar_url: string | null
   is_admin: boolean
+  blocked: boolean
   created_at: string
 }

--- a/supabase/migrations/20260617000000_user_blocking.sql
+++ b/supabase/migrations/20260617000000_user_blocking.sql
@@ -1,0 +1,61 @@
+-- ============================================================================
+-- Admin user blocking (ban). A blocked user can still read, but cannot write
+-- (suggest, vote, RSVP, or touch the bring list). RLS is the boundary — the
+-- admin UI is only a convenience (Invariant 1). is_admin is never touched here
+-- (Invariant 4): blocking only flips `blocked`, via an admin-gated RPC.
+-- ============================================================================
+
+alter table public.profiles add column if not exists blocked boolean not null default false;
+
+-- Current user's blocked flag. SECURITY DEFINER to avoid RLS recursion on
+-- profiles (mirrors public.is_admin()).
+create function public.is_blocked() returns boolean
+  language sql security definer set search_path = '' stable as $$
+  select coalesce((select blocked from public.profiles where id = auth.uid()), false);
+$$;
+
+-- Admin-only, column-safe ban/unban: only ever changes `blocked`, never is_admin.
+create function public.admin_set_blocked(target_id uuid, value boolean)
+  returns void language plpgsql security definer set search_path = '' as $$
+begin
+  if not public.is_admin() then
+    raise exception 'only admins may block users';
+  end if;
+  update public.profiles set blocked = value where id = target_id;
+end;
+$$;
+revoke all on function public.admin_set_blocked(uuid, boolean) from public;
+grant execute on function public.admin_set_blocked(uuid, boolean) to authenticated;
+
+-- ---------- Deny writes from blocked users (recreate each write policy) ----------
+drop policy "suggestions: create own" on public.suggestions;
+create policy "suggestions: create own" on public.suggestions
+  for insert to authenticated
+  with check (user_id = auth.uid() and deleted = false and not public.is_blocked());
+
+drop policy "votes: insert own" on public.votes;
+create policy "votes: insert own" on public.votes
+  for insert to authenticated
+  with check (user_id = auth.uid() and not public.is_blocked());
+
+drop policy "rsvps: insert own" on public.rsvps;
+create policy "rsvps: insert own" on public.rsvps
+  for insert to authenticated
+  with check (user_id = auth.uid() and not public.is_blocked());
+
+drop policy "rsvps: update own" on public.rsvps;
+create policy "rsvps: update own" on public.rsvps
+  for update to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid() and not public.is_blocked());
+
+drop policy "bring: create" on public.bring_items;
+create policy "bring: create" on public.bring_items
+  for insert to authenticated
+  with check (created_by = auth.uid() and (user_id is null or user_id = auth.uid()) and not public.is_blocked());
+
+drop policy "bring: update" on public.bring_items;
+create policy "bring: update" on public.bring_items
+  for update to authenticated
+  using (created_by = auth.uid() or user_id = auth.uid() or user_id is null)
+  with check ((user_id is null or user_id = auth.uid()) and not public.is_blocked());

--- a/test/PeopleList.nuxt.test.ts
+++ b/test/PeopleList.nuxt.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import PeopleList from '../app/components/PeopleList.vue'
+
+const people = [
+  { id: 'u1', email: 'alice@x.com', display_name: 'Alice', avatar_url: null, is_admin: false, blocked: false, created_at: '' },
+  { id: 'u2', email: 'bob@x.com', display_name: 'Bob', avatar_url: null, is_admin: false, blocked: true, created_at: '' },
+  { id: 'u3', email: 'carol@x.com', display_name: 'Carol', avatar_url: null, is_admin: true, blocked: false, created_at: '' }
+]
+
+describe('PeopleList', () => {
+  it('lists every member', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people } })
+    expect(w.text()).toContain('Alice')
+    expect(w.text()).toContain('Bob')
+    expect(w.text()).toContain('Carol')
+  })
+
+  it('emits block when banning a normal member', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people } })
+    const banBtn = w.findAll('button').find(b => b.text().trim() === 'Ban')
+    await banBtn?.trigger('click')
+    expect(w.emitted('block')?.[0]).toEqual([people[0]])
+  })
+
+  it('emits unblock when unbanning a blocked member', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people } })
+    const unbanBtn = w.findAll('button').find(b => b.text().trim() === 'Unban')
+    await unbanBtn?.trigger('click')
+    expect(w.emitted('unblock')?.[0]).toEqual([people[1]])
+  })
+
+  it('offers no ban control for admins', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people } })
+    // Only Alice (normal, unblocked) is bannable; Carol (admin) has no Ban button.
+    expect(w.findAll('button').filter(b => b.text().trim() === 'Ban')).toHaveLength(1)
+  })
+
+  it('filters by the search query', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people } })
+    await w.find('input').setValue('bob')
+    expect(w.text()).toContain('Bob')
+    expect(w.text()).not.toContain('Alice')
+  })
+})

--- a/test/useAdminPeople.nuxt.test.ts
+++ b/test/useAdminPeople.nuxt.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+interface RpcCall { fn: string, args: unknown }
+const calls: { rpc: RpcCall[] } = { rpc: [] }
+let rows: unknown[] = []
+
+const supabase = {
+  from() {
+    return { select: () => ({ order: () => Promise.resolve({ data: rows }) }) }
+  },
+  rpc: (fn: string, args: unknown) => {
+    calls.rpc.push({ fn, args })
+    return Promise.resolve({ error: null })
+  }
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+beforeEach(() => {
+  calls.rpc = []
+  rows = []
+})
+
+describe('useAdminPeople', () => {
+  it('setBlocked bans via the admin RPC, then refreshes the directory', async () => {
+    rows = [{ id: 'u1', email: 'a@x.com', display_name: 'Alice', avatar_url: null, is_admin: false, blocked: true, created_at: '' }]
+    const { people, setBlocked } = useAdminPeople()
+    await setBlocked('u1', true)
+    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_blocked', args: { target_id: 'u1', value: true } })
+    expect(people.value).toHaveLength(1)
+  })
+
+  it('setBlocked unbans with value=false', async () => {
+    const { setBlocked } = useAdminPeople()
+    await setBlocked('u1', false)
+    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_blocked', args: { target_id: 'u1', value: false } })
+  })
+})


### PR DESCRIPTION
## Scope

Turns `/admin` into a central command center and adds **user blocking (ban)** — the first slice of the admin epic. (PR B will add Resend email blasts.)

## What's new

- **Tabbed admin** — Overview · Events · People · Suggestions · Bring list (replaces the flat two-column page; all existing functionality preserved).
- **Overview** — member / event / going / blocked counts, plus per-event participation for the focused event: # suggestions, # votes, # going, and **who hasn't suggested yet**.
- **People** — searchable member directory with **Ban / Unban**. Admins aren't bannable from the UI (demote via SQL first).

## Implementation

- **Blocking is enforced in the DB (Invariant 1).** New `profiles.blocked` + `is_blocked()`; every write policy (suggest / vote / RSVP / bring) now denies blocked users. Ban/unban goes through an **admin-gated, column-safe RPC** `admin_set_blocked` — it only ever flips `blocked`, never `is_admin` (Invariant 4). No broad profile-update policy was added.
- Architecture per our decision: composables stay the client repository layer; ban is server-side business logic (an RPC), not a relaxed policy.

> **Migration required:** apply `supabase/migrations/20260617000000_user_blocking.sql` (after the event-day migration).

## How to Test

- **Automated:** `test/useAdminPeople.nuxt.test.ts` (ban/unban RPC args + refresh), `test/PeopleList.nuxt.test.ts` (render / ban / unban / admin-not-bannable / search).
- **Manual:** as an admin, open /admin → People → Ban a member; confirm (in another session) that member can no longer suggest/vote/RSVP, then Unban.
- typecheck ✅ · tests ✅ (63) · build ✅ · lint ✅ (0 errors)

## Invariants & Risk

Touches authorization: adds RLS write-guards + an admin-only RPC. RLS remains the boundary; `is_admin` is never written from the app. No change to TMDB key, vote integrity, or rendered user HTML.
