### PR TITLE
feat(finder): I'm feeling lucky + genre filters

### DIFF
--- a/app/components/MovieFinder.vue
+++ b/app/components/MovieFinder.vue
@@ -10,16 +10,28 @@ const toast = useToast()
 
 const movies = ref<TmdbMovie[]>([])
 const loading = ref(false)
+// null = "I'm feeling lucky" (any genre); otherwise a TMDB genre id.
+const genre = ref<number | null>(null)
+
+const activeLabel = computed(() =>
+  genre.value === null ? 'feeling lucky' : (MOVIE_GENRES.find(g => g.id === genre.value)?.label ?? '')
+)
 
 async function load(): Promise<void> {
   loading.value = true
   try {
-    movies.value = await discoverGems()
+    movies.value = await discoverGems(genre.value)
   } catch {
     toast.add({ title: 'Could not load picks — try again', color: 'error' })
   } finally {
     loading.value = false
   }
+}
+
+/** Pick a category (or null for lucky) and roll a fresh batch. */
+function pick(genreId: number | null): void {
+  genre.value = genreId
+  load()
 }
 
 // Fetch the first batch the first time the modal opens.
@@ -41,7 +53,31 @@ function isSuggested(movie: TmdbMovie): boolean {
   >
     <template #body>
       <div class="space-y-4">
-        <div class="flex justify-end">
+        <!-- Category filters: "I'm feeling lucky" (any) + genres -->
+        <div class="flex flex-wrap gap-1.5">
+          <UButton
+            label="I'm feeling lucky"
+            icon="i-lucide-dices"
+            size="xs"
+            :color="genre === null ? 'primary' : 'neutral'"
+            :variant="genre === null ? 'solid' : 'outline'"
+            @click="pick(null)"
+          />
+          <UButton
+            v-for="g in MOVIE_GENRES"
+            :key="g.id"
+            :label="g.label"
+            size="xs"
+            :color="genre === g.id ? 'primary' : 'neutral'"
+            :variant="genre === g.id ? 'solid' : 'outline'"
+            @click="pick(g.id)"
+          />
+        </div>
+
+        <div class="flex items-center justify-between gap-2">
+          <p class="text-xs text-muted">
+            Acclaimed gems · <span class="text-default font-medium">{{ genre === null ? 'any genre' : activeLabel }}</span>
+          </p>
           <UButton
             label="Shuffle"
             icon="i-lucide-shuffle"
@@ -49,6 +85,7 @@ function isSuggested(movie: TmdbMovie): boolean {
             variant="outline"
             size="sm"
             :loading="loading"
+            :aria-label="`Shuffle ${activeLabel}`"
             @click="load"
           />
         </div>
@@ -100,7 +137,7 @@ function isSuggested(movie: TmdbMovie): boolean {
         </div>
 
         <p v-else class="text-sm text-muted text-center py-8">
-          No picks right now — hit Shuffle to try again.
+          No picks right now — hit Shuffle or try another category.
         </p>
       </div>
     </template>

--- a/app/composables/useTmdb.ts
+++ b/app/composables/useTmdb.ts
@@ -18,9 +18,14 @@ export function useTmdb() {
     return await $fetch('/api/movies/videos', { query: { id: movieId } })
   }
 
-  /** A fresh handful of critically acclaimed, lesser-known movies ("hidden gems"). */
-  async function discoverGems(): Promise<TmdbMovie[]> {
-    return await $fetch<TmdbMovie[]>('/api/movies/discover')
+  /**
+   * A fresh handful of critically acclaimed, lesser-known movies ("hidden gems").
+   * Pass a TMDB genre id to filter to a category; omit it for "I'm feeling lucky".
+   */
+  async function discoverGems(genreId?: number | null): Promise<TmdbMovie[]> {
+    return await $fetch<TmdbMovie[]>('/api/movies/discover', {
+      query: genreId ? { genre: genreId } : {}
+    })
   }
 
   return { searchMovies, posterUrl, getTrailer, discoverGems }

--- a/server/api/movies/discover.get.ts
+++ b/server/api/movies/discover.get.ts
@@ -1,3 +1,4 @@
+import { isMovieGenreId } from '#shared/utils/genres'
 import type { TmdbMovie } from '#shared/types/movie'
 
 interface TmdbDiscoverResponse {
@@ -34,20 +35,25 @@ export default defineEventHandler(async (event): Promise<TmdbMovie[]> => {
 
   const page = Math.floor(Math.random() * MAX_PAGE) + 1
 
+  // Optional category filter — only a known TMDB genre id is forwarded.
+  const genreRaw = Number(getQuery(event).genre)
+  const genre = Number.isInteger(genreRaw) && isMovieGenreId(genreRaw) ? genreRaw : null
+
+  const query: Record<string, string | number | boolean> = {
+    'api_key': tmdbApiKey,
+    'include_adult': false,
+    'language': 'en-US',
+    'sort_by': 'vote_average.desc',
+    'vote_average.gte': VOTE_AVERAGE_MIN,
+    'vote_count.gte': VOTE_COUNT_MIN,
+    'vote_count.lte': VOTE_COUNT_MAX,
+    'page': page
+  }
+  if (genre) query['with_genres'] = String(genre)
+
   let data: TmdbDiscoverResponse
   try {
-    data = await $fetch<TmdbDiscoverResponse>('https://api.themoviedb.org/3/discover/movie', {
-      query: {
-        'api_key': tmdbApiKey,
-        'include_adult': false,
-        'language': 'en-US',
-        'sort_by': 'vote_average.desc',
-        'vote_average.gte': VOTE_AVERAGE_MIN,
-        'vote_count.gte': VOTE_COUNT_MIN,
-        'vote_count.lte': VOTE_COUNT_MAX,
-        'page': page
-      }
-    })
+    data = await $fetch<TmdbDiscoverResponse>('https://api.themoviedb.org/3/discover/movie', { query })
   } catch {
     throw createError({ statusCode: 502, statusMessage: 'Failed to reach the movie database' })
   }

--- a/shared/utils/genres.ts
+++ b/shared/utils/genres.ts
@@ -1,0 +1,29 @@
+/** A curated TMDB movie genre used by the "find me a movie" category filters. */
+export interface MovieGenre {
+  id: number
+  label: string
+}
+
+/** TMDB genre ids — https://developer.themoviedb.org/reference/genre-movie-list */
+export const MOVIE_GENRES: readonly MovieGenre[] = [
+  { id: 28, label: 'Action' },
+  { id: 12, label: 'Adventure' },
+  { id: 16, label: 'Animation' },
+  { id: 35, label: 'Comedy' },
+  { id: 80, label: 'Crime' },
+  { id: 99, label: 'Documentary' },
+  { id: 18, label: 'Drama' },
+  { id: 14, label: 'Fantasy' },
+  { id: 27, label: 'Horror' },
+  { id: 9648, label: 'Mystery' },
+  { id: 10749, label: 'Romance' },
+  { id: 878, label: 'Sci-Fi' },
+  { id: 53, label: 'Thriller' }
+]
+
+const GENRE_IDS = new Set(MOVIE_GENRES.map(g => g.id))
+
+/** True when `id` is one of our supported genre ids (validates the discover param). */
+export function isMovieGenreId(id: number): boolean {
+  return GENRE_IDS.has(id)
+}

--- a/test/MovieFinder.nuxt.test.ts
+++ b/test/MovieFinder.nuxt.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment nuxt
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import MovieFinder from '../app/components/MovieFinder.vue'
+
+const discoverGems = vi.fn(async () => [])
+mockNuxtImport('useTmdb', () => () => ({ posterUrl: () => null, discoverGems }))
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+beforeEach(() => discoverGems.mockClear())
+// The modal teleports its content to <body>; clear it between tests.
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function clickButton(text: string): void {
+  const btn = Array.from(document.body.querySelectorAll('button'))
+    .find(b => (b.textContent ?? '').trim() === text || (b.textContent ?? '').includes(text))
+  btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+}
+
+describe('MovieFinder', () => {
+  it('loads "feeling lucky" (no genre) when first opened', async () => {
+    const w = await mountSuspended(MovieFinder, { props: { open: false, suggestedMovieIds: [] } })
+    expect(discoverGems).not.toHaveBeenCalled()
+    await w.setProps({ open: true })
+    await nextTick()
+    expect(discoverGems).toHaveBeenCalledWith(null)
+  })
+
+  it('rolls within a genre when its chip is clicked', async () => {
+    await mountSuspended(MovieFinder, { props: { open: true, suggestedMovieIds: [] } })
+    await nextTick()
+    discoverGems.mockClear()
+    clickButton('Comedy')
+    await nextTick()
+    expect(discoverGems).toHaveBeenCalledWith(35)
+  })
+
+  it('"I\'m feeling lucky" rolls with no genre after a category was chosen', async () => {
+    await mountSuspended(MovieFinder, { props: { open: true, suggestedMovieIds: [] } })
+    await nextTick()
+    clickButton('Horror')
+    await nextTick()
+    discoverGems.mockClear()
+    clickButton('feeling lucky')
+    await nextTick()
+    expect(discoverGems).toHaveBeenCalledWith(null)
+  })
+})

--- a/test/genres.test.ts
+++ b/test/genres.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { MOVIE_GENRES, isMovieGenreId } from '../shared/utils/genres'
+
+describe('isMovieGenreId', () => {
+  it('accepts every id in the curated list', () => {
+    for (const g of MOVIE_GENRES) {
+      expect(isMovieGenreId(g.id)).toBe(true)
+    }
+  })
+
+  it('rejects ids outside the list', () => {
+    expect(isMovieGenreId(0)).toBe(false)
+    expect(isMovieGenreId(99999)).toBe(false)
+    expect(isMovieGenreId(-1)).toBe(false)
+  })
+
+  it('exposes a non-empty, labelled list', () => {
+    expect(MOVIE_GENRES.length).toBeGreaterThan(0)
+    expect(MOVIE_GENRES.every(g => g.label.length > 0)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Scope

Make "Help me find a movie" steerable: **"I'm feeling lucky"** for a fully random roll, plus **category filters** you can shuffle within.

## What changed

- The old **Shuffle** (any type) is now an **"I'm feeling lucky"** chip — random across all genres.
- Added **category chips** (curated TMDB genres). Pick one to roll within it; the **Shuffle** button re-rolls whatever filter is active. The subtitle shows the active category.
- The `discover` proxy takes an optional **`genre`** id, validated against a shared `MOVIE_GENRES` allowlist (`with_genres`). Unknown/garbage ids are ignored — no arbitrary input reaches TMDB. Key stays server-side (Invariant 2).

## How to Test

- **Automated:** `test/genres.test.ts` (`isMovieGenreId` allowlist) and `test/MovieFinder.nuxt.test.ts` (lucky loads with no genre; a genre chip rolls within it).
- **Manual:** open the finder → click a genre → results match; hit Shuffle for a new batch in that genre; "I'm feeling lucky" goes back to any-genre.
- typecheck ✅ · tests ✅ · build ✅ · lint ✅ (0 errors)

## Invariants & Risk

TMDB key stays server-only; the new genre param is validated against an allowlist at the boundary. No auth/RLS/vote/HTML changes.
