### PR TITLE
feat: poster-backed event header + admin-only event switcher on overview

### DIFF
--- a/app/components/EventHero.vue
+++ b/app/components/EventHero.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import type { MovieEvent } from '#shared/types/event'
+
+// Header for the active event: its poster fills the background, the title rides
+// on top. `backdrop` is resolved by the parent (event poster, falling back to the
+// current leader's movie poster) so this stays purely presentational.
+const props = defineProps<{ event: MovieEvent, backdrop: string | null }>()
+defineEmits<{ open: [] }>()
+
+const upcoming = computed(() => isUpcoming(props.event.event_date))
+</script>
+
+<template>
+  <button
+    type="button"
+    class="group relative block w-full overflow-hidden rounded-xl text-left ring ring-default min-h-44 sm:min-h-56 transition group-hover:ring-primary/30"
+    :aria-label="`${event.title} — view event details`"
+    @click="$emit('open')"
+  >
+    <!-- Poster background (falls back to a neutral surface when none is set) -->
+    <div
+      v-if="backdrop"
+      class="absolute inset-0 bg-cover bg-center transition-transform duration-500 group-hover:scale-105"
+      :style="{ backgroundImage: `url(${backdrop})` }"
+    />
+    <div v-else class="absolute inset-0 bg-elevated" />
+
+    <!-- Legibility gradient so the title is readable over any poster -->
+    <div class="absolute inset-0 bg-gradient-to-t from-black/85 via-black/45 to-black/10" />
+
+    <!-- Title block, anchored to the bottom -->
+    <div class="absolute inset-x-0 bottom-0 p-5 sm:p-6">
+      <div class="flex flex-wrap items-center gap-2 mb-2">
+        <UBadge
+          :color="upcoming ? 'primary' : 'neutral'"
+          :variant="upcoming ? 'solid' : 'subtle'"
+          :label="upcoming ? 'Upcoming' : 'Past'"
+          icon="i-lucide-calendar"
+          size="sm"
+        />
+        <span class="text-sm text-white/80">{{ formatDate(event.event_date) }}</span>
+      </div>
+      <h1 class="text-2xl sm:text-3xl font-bold text-white drop-shadow-md text-balance">
+        {{ event.title }}
+      </h1>
+      <p class="mt-1.5 inline-flex items-center gap-1 text-xs text-white/70">
+        <UIcon name="i-lucide-info" /> Tap for details
+      </p>
+    </div>
+  </button>
+</template>

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -8,6 +8,8 @@ useSeoMeta({ title: 'Overview · BSOTG' })
 const toast = useToast()
 const { posterUrl } = useTmdb()
 const { events } = useEvents()
+// Admins can flip between events; everyone else just sees the active one.
+const { isAdmin } = useAuth()
 
 const eventIndex = ref(0)
 const initialized = ref(false)
@@ -110,8 +112,8 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
 <template>
   <UContainer class="py-6 sm:py-8">
     <template v-if="events.length && currentEvent">
-      <!-- Event selector -->
-      <div class="flex items-center gap-2 mb-6">
+      <!-- Event selector (admin-only: members just see the active event) -->
+      <div v-if="isAdmin" class="flex items-center gap-2 mb-6">
         <UButton
           icon="i-lucide-chevron-left"
           color="neutral"
@@ -137,48 +139,21 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
         />
       </div>
 
+      <!-- Poster-backed header for the active event -->
+      <EventHero :event="currentEvent" :backdrop="cardBackdrop" class="mb-6" @open="eventInfoOpen = true" />
+
       <div class="grid lg:grid-cols-3 gap-6">
         <!-- LEFT: control panel -->
         <aside class="lg:col-span-1 space-y-4 lg:sticky lg:top-20 lg:self-start">
-          <!-- Event header card → details modal -->
-          <button type="button" class="w-full text-left group" @click="eventInfoOpen = true">
-            <UCard variant="subtle" class="overflow-hidden group-hover:ring-2 group-hover:ring-primary/30 transition" :ui="{ body: 'relative' }">
-              <div
-                v-if="cardBackdrop"
-                class="absolute inset-0 opacity-20 bg-cover bg-center"
-                :style="{ backgroundImage: `url(${cardBackdrop})` }"
-              />
-              <div class="relative">
-                <div class="flex flex-wrap items-center gap-2 mb-1">
-                  <UBadge
-                    :color="isUpcoming(currentEvent.event_date) ? 'primary' : 'neutral'"
-                    :variant="isUpcoming(currentEvent.event_date) ? 'solid' : 'subtle'"
-                    :label="isUpcoming(currentEvent.event_date) ? 'Upcoming' : 'Past'"
-                    icon="i-lucide-calendar"
-                    size="sm"
-                  />
-                  <span class="text-sm text-muted">{{ formatDate(currentEvent.event_date) }}</span>
-                </div>
-                <h1 class="text-xl font-bold">
-                  {{ currentEvent.title }}
-                </h1>
-                <p class="text-xs text-dimmed mt-1 inline-flex items-center gap-1">
-                  <UIcon name="i-lucide-info" /> Tap for details
-                </p>
-              </div>
-            </UCard>
-          </button>
-
           <!-- RSVP (upcoming only) -->
           <UCard v-if="isUpcoming(currentEvent.event_date)" variant="subtle">
             <h2 class="text-sm font-semibold text-muted mb-2">
               Are you coming?
             </h2>
             <RsvpControl :my-status="myStatus" :counts="counts" @set="onRsvp" />
-            <p v-if="counts.going" class="text-xs text-muted mt-3 flex items-center gap-1.5 justify-center">
-              🍕 {{ counts.going }} pizza dough{{ counts.going === 1 ? '' : 's' }} needed —
-              <button type="button" class="text-primary underline" @click="eventInfoOpen = true">
-                bring list
+            <p class="text-xs text-muted mt-3 text-center">
+              <button type="button" class="text-primary underline inline-flex items-center gap-1" @click="eventInfoOpen = true">
+                <UIcon name="i-lucide-list" /> See the bring list
               </button>
             </p>
           </UCard>

--- a/test/EventHero.nuxt.test.ts
+++ b/test/EventHero.nuxt.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import EventHero from '../app/components/EventHero.vue'
+
+const baseEvent = {
+  id: 'e1',
+  title: 'Dazed and Confused',
+  description: '',
+  event_date: '2999-07-15T19:00:00Z',
+  start_time: null,
+  location: null,
+  location_url: null,
+  poster_url: null,
+  created_at: ''
+}
+
+describe('EventHero', () => {
+  it('shows the active event title', async () => {
+    const w = await mountSuspended(EventHero, { props: { event: baseEvent, backdrop: null } })
+    expect(w.text()).toContain('Dazed and Confused')
+  })
+
+  it('paints the poster as the background when a backdrop is provided', async () => {
+    const w = await mountSuspended(EventHero, { props: { event: baseEvent, backdrop: 'https://img/poster.jpg' } })
+    const bg = w.find('div').attributes('style') ?? ''
+    expect(bg).toContain('background-image')
+    expect(bg).toContain('https://img/poster.jpg')
+  })
+
+  it('labels an upcoming event as Upcoming', async () => {
+    const w = await mountSuspended(EventHero, { props: { event: baseEvent, backdrop: null } })
+    expect(w.text()).toContain('Upcoming')
+  })
+
+  it('labels a past event as Past', async () => {
+    const past = { ...baseEvent, event_date: '2000-01-01T00:00:00Z' }
+    const w = await mountSuspended(EventHero, { props: { event: past, backdrop: null } })
+    expect(w.text()).toContain('Past')
+  })
+
+  it('emits open when clicked', async () => {
+    const w = await mountSuspended(EventHero, { props: { event: baseEvent, backdrop: null } })
+    await w.find('button').trigger('click')
+    expect(w.emitted('open')).toHaveLength(1)
+  })
+})

--- a/test/overview.nuxt.test.ts
+++ b/test/overview.nuxt.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import OverviewPage from '../app/pages/overview.vue'
+
+const event = {
+  id: 'e1',
+  title: 'Movie Night',
+  description: '',
+  event_date: '2999-07-15T19:00:00Z',
+  start_time: null,
+  location: null,
+  location_url: null,
+  poster_url: null,
+  created_at: ''
+}
+
+// Shared admin flag — flipped per test before mounting (mockNuxtImport allows
+// referencing module-scope values, same pattern as useAdminPeople.nuxt.test.ts).
+const isAdmin = ref(false)
+
+mockNuxtImport('useAuth', () => () => ({ isAdmin }))
+mockNuxtImport('useEvents', () => () => ({ events: ref([event]) }))
+mockNuxtImport('useTmdb', () => () => ({ posterUrl: () => null }))
+mockNuxtImport('useSuggestions', () => () => ({
+  suggestions: ref([]),
+  alreadySuggested: () => false,
+  suggest: async () => {},
+  vote: async () => {},
+  unvote: async () => {},
+  removeSuggestion: async () => {}
+}))
+mockNuxtImport('useRsvp', () => () => ({
+  myStatus: ref(null),
+  counts: ref({ going: 0, maybe: 0, no: 0 }),
+  setStatus: async () => {}
+}))
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+// Heavy children pull in their own composables/network — stub them; this page
+// test only cares about the header + the admin-gated selector.
+const stubs = {
+  RsvpControl: true,
+  SuggestSection: true,
+  MovieFinder: true,
+  SuggestionCard: true,
+  EventInfoModal: true,
+  TrailerModal: true
+}
+
+beforeEach(() => {
+  isAdmin.value = false
+})
+
+describe('overview page', () => {
+  it('renders the active event in the poster header', async () => {
+    const w = await mountSuspended(OverviewPage, { global: { stubs } })
+    expect(w.text()).toContain('Movie Night')
+  })
+
+  it('hides the event/date selector for non-admins', async () => {
+    isAdmin.value = false
+    const w = await mountSuspended(OverviewPage, { global: { stubs } })
+    expect(w.find('[aria-label="Previous event"]').exists()).toBe(false)
+  })
+
+  it('shows the event/date selector for admins', async () => {
+    isAdmin.value = true
+    const w = await mountSuspended(OverviewPage, { global: { stubs } })
+    expect(w.find('[aria-label="Previous event"]').exists()).toBe(true)
+  })
+
+  it('no longer mentions pizza dough in the RSVP card', async () => {
+    const w = await mountSuspended(OverviewPage, { global: { stubs } })
+    expect(w.text().toLowerCase()).not.toContain('pizza dough')
+    expect(w.text()).toContain('See the bring list')
+  })
+})


### PR DESCRIPTION
## Scope

Reworks the **overview** page header and trims the RSVP card, per Patrick's asks:

- **Poster-backed header.** The active event now leads with a full-width hero
  (`EventHero.vue`) that paints the event's poster as the background with the
  title overlaid on a legibility gradient. Falls back to the current vote
  leader's movie poster, then a neutral surface when neither exists.
- **Members don't get the date picker.** The event/date switcher (prev/next +
  `USelectMenu`) is gated behind `isAdmin`. Members land on the active (next
  upcoming) event and don't need to change that view; admins keep the switcher.
- **No more "pizza dough" headcount.** Dropped the
  "🍕 N pizza doughs needed" line from the RSVP card — we make those by hand for
  everyone. Replaced with a plain "See the bring list" link.

## Implementation

- New presentational `EventHero.vue` (props `event` + `backdrop`, emits `open`)
  so the header stays dumb and unit-testable; the parent resolves the backdrop.
- `overview.vue` adds `const { isAdmin } = useAuth()`, wraps the switcher in
  `v-if="isAdmin"`, drops the old subtle-backdrop card from the left rail in
  favor of the hero, and simplifies the bring-list line.

## Screenshots

> Not captured — `/overview` needs a live Supabase session (Google OAuth) to
> render real event/poster data, which isn't reachable from my environment.
> Happy to grab before/after on desktop + mobile if you want them, or it's a
> quick local `npm run dev` to eyeball.

## How to Test

- **Automated:** `test/EventHero.nuxt.test.ts` (title render, poster background,
  upcoming/past badge, `open` emit) and `test/overview.nuxt.test.ts`
  (switcher hidden for non-admins / shown for admins, active event in the
  header, pizza-dough line gone). `npm test` → 78 passing.
- **Manual:** sign in as a non-admin → no date picker, big poster header for the
  next event. Sign in as an admin → switcher is back and flips the header.

## Invariants & Risk

No authorization, RLS, TMDB-key, vote-integrity, admin-role, or rendered-HTML
surfaces touched. `isAdmin` here is **UX only** (Invariant 1 unchanged) — it
just hides a navigation control; RLS is untouched. Pure presentational change.

> Note: `npm run lint` currently throws `Object.groupBy is not a function` on a
> pristine checkout — that's an ESLint config-loader requiring Node 21+ (this
> box is on Node 20). Pre-existing and unrelated to this PR; `npm run typecheck`
> is clean.
