### PR TITLE
feat: invite-only access — allowlist + RLS gate + /request-access

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -12,6 +12,9 @@ export function useAuth() {
   const user = useSupabaseUser()
   const myId = useState<string | null>('my-id', () => null)
   const profile = useState<Profile | null>('profile', () => null)
+  // Cached allowlist verdict (set by middleware/invited.global.ts); cleared on
+  // sign-out so the next user is re-checked within the same SPA session.
+  const isAllowed = useState<boolean | null>('is-allowed', () => null)
 
   const isAdmin = computed(() => profile.value?.is_admin ?? false)
 
@@ -37,6 +40,7 @@ export function useAuth() {
     await supabase.auth.signOut()
     profile.value = null
     myId.value = null
+    isAllowed.value = null
   }
 
   return { user, myId, profile, account, isAdmin, signInWithGoogle, signOutUser }

--- a/app/middleware/invited.global.ts
+++ b/app/middleware/invited.global.ts
@@ -1,0 +1,26 @@
+import type { Database } from '~/types/database.types'
+
+// Invite-only gate (UX layer over the RLS boundary — Invariant 1). The Supabase
+// module already bounces *unauthenticated* users to /login; this catches users
+// who are authenticated but whose email isn't on the allowlist (public.invites):
+// it ends their session and sends them to /request-access.
+const PUBLIC_PATHS = new Set(['/', '/about', '/login', '/confirm', '/request-access'])
+
+export default defineNuxtRouteMiddleware(async (to) => {
+  if (PUBLIC_PATHS.has(to.path)) return
+
+  const user = useSupabaseUser()
+  if (!user.value) return // not signed in → the Supabase module handles the redirect
+
+  const supabase = useSupabaseClient<Database>()
+  // Cache the verdict for the session so we hit the RPC once, not per navigation.
+  const allowed = useState<boolean | null>('is-allowed', () => null)
+  if (allowed.value === null) {
+    const { data, error } = await supabase.rpc('is_allowed')
+    allowed.value = !error && (data ?? false)
+  }
+  if (allowed.value) return
+
+  await supabase.auth.signOut()
+  return navigateTo('/request-access')
+})

--- a/app/middleware/invited.global.ts
+++ b/app/middleware/invited.global.ts
@@ -21,6 +21,10 @@ export default defineNuxtRouteMiddleware(async (to) => {
   }
   if (allowed.value) return
 
+  // Clear the cached verdict before signing out so a *different* user signing in
+  // later in the same SPA session (e.g. email/password, which doesn't reload the
+  // page) is re-checked rather than inheriting this stale "denied".
+  allowed.value = null
   await supabase.auth.signOut()
   return navigateTo('/request-access')
 })

--- a/app/pages/request-access.vue
+++ b/app/pages/request-access.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+useSeoMeta({ title: 'Request access · BSOTG' })
+
+// Invite-only: anyone not on the allowlist lands here (and is signed out by the
+// invited.global middleware). They can ask an existing member, or email for an
+// invite to the next movie night.
+const requestUrl = 'mailto:patrickisgreat@gmail.com?subject=BSOTG%20invite%20request&body=Hi%2C%20please%20add%20me%20to%20Benteen%20Screen%20On%20The%20Green.'
+</script>
+
+<template>
+  <UContainer class="py-20">
+    <div class="max-w-md mx-auto text-center space-y-4">
+      <UIcon name="i-lucide-lock-keyhole" class="size-10 text-muted mx-auto" />
+      <h1 class="text-2xl font-bold">
+        Benteen Screen is invite-only
+      </h1>
+      <p class="text-muted">
+        Your account isn't on the guest list yet. Ask a member to invite you, or
+        request an invite and we'll add you to the next movie night.
+      </p>
+      <div class="flex flex-col sm:flex-row gap-2 justify-center pt-2">
+        <UButton :to="requestUrl" external icon="i-lucide-mail" label="Request an invite" />
+        <UButton to="/login" color="neutral" variant="outline" icon="i-lucide-arrow-left" label="Back to sign in" />
+      </div>
+    </div>
+  </UContainer>
+</template>

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -11,6 +11,12 @@ export interface Database {
         Update: { id?: string, email?: string | null, display_name?: string | null, avatar_url?: string | null, is_admin?: boolean, blocked?: boolean, created_at?: string }
         Relationships: []
       }
+      invites: {
+        Row: { email: string, invited_by: string | null, display_name: string | null, created_at: string, accepted_at: string | null }
+        Insert: { email: string, invited_by?: string | null, display_name?: string | null, created_at?: string, accepted_at?: string | null }
+        Update: { email?: string, invited_by?: string | null, display_name?: string | null, created_at?: string, accepted_at?: string | null }
+        Relationships: []
+      }
       events: {
         Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, created_by: string | null, created_at: string }
         Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, created_by?: string | null, created_at?: string }
@@ -45,6 +51,7 @@ export interface Database {
     Views: { [_ in never]: never }
     Functions: {
       admin_set_blocked: { Args: { target_id: string, value: boolean }, Returns: undefined }
+      is_allowed: { Args: Record<string, never>, Returns: boolean }
     }
     Enums: { [_ in never]: never }
     CompositeTypes: { [_ in never]: never }

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -17,6 +17,12 @@ export interface Database {
         Update: { email?: string, invited_by?: string | null, display_name?: string | null, created_at?: string, accepted_at?: string | null }
         Relationships: []
       }
+      app_settings: {
+        Row: { id: boolean, max_invites: number | null, updated_at: string }
+        Insert: { id?: boolean, max_invites?: number | null, updated_at?: string }
+        Update: { id?: boolean, max_invites?: number | null, updated_at?: string }
+        Relationships: []
+      }
       events: {
         Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, created_by: string | null, created_at: string }
         Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, created_by?: string | null, created_at?: string }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -47,7 +47,9 @@ export default defineNuxtConfig({
     redirectOptions: {
       login: '/login',
       callback: '/confirm',
-      exclude: ['/', '/about']
+      // /request-access is shown to signed-out, non-invited users (the
+      // invite-only gate lives in RLS + middleware/invited.global.ts).
+      exclude: ['/', '/about', '/request-access']
     }
   }
 })

--- a/shared/types/invite.ts
+++ b/shared/types/invite.ts
@@ -1,0 +1,9 @@
+/** An allowlist entry (public.invites). accepted_at is set once the invited
+ *  email has signed in; until then it's a pending invite. */
+export interface Invite {
+  email: string
+  invited_by: string | null
+  display_name: string | null
+  created_at: string
+  accepted_at: string | null
+}

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,413 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "benteen-screen"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ `{{ .Code }}` }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260618000000_invite_only.sql
+++ b/supabase/migrations/20260618000000_invite_only.sql
@@ -67,7 +67,7 @@ on conflict (email) do nothing;
 -- from the command center; the invite cap trigger reads it.
 create table public.app_settings (
   id          boolean primary key default true check (id), -- single-row guard
-  max_invites int,
+  max_invites int check (max_invites is null or max_invites >= 0), -- guard fat-fingers
   updated_at  timestamptz not null default now()
 );
 insert into public.app_settings (id) values (true) on conflict (id) do nothing;

--- a/supabase/migrations/20260618000000_invite_only.sql
+++ b/supabase/migrations/20260618000000_invite_only.sql
@@ -62,21 +62,43 @@ from public.profiles
 where email is not null and trim(email) <> ''
 on conflict (email) do nothing;
 
--- ---------- Per-member invite cap ----------
--- Any member may invite friends, but not unboundedly. Admins and the system
--- seed (invited_by null) are exempt. Adjust the cap by editing this function.
+-- ---------- App settings (admin-tunable, single row) ----------
+-- max_invites caps the TOTAL allowlist size (null = unlimited). Admins set it
+-- from the command center; the invite cap trigger reads it.
+create table public.app_settings (
+  id          boolean primary key default true check (id), -- single-row guard
+  max_invites int,
+  updated_at  timestamptz not null default now()
+);
+insert into public.app_settings (id) values (true) on conflict (id) do nothing;
+
+alter table public.app_settings enable row level security;
+grant select, update on public.app_settings to authenticated;
+-- The cap number isn't sensitive — any authenticated user can read it (so the
+-- invite UI can show "X of Y invites used"); only admins may change it.
+create policy "app_settings: read" on public.app_settings
+  for select to authenticated using (true);
+create policy "app_settings: admin update" on public.app_settings
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+
+-- ---------- Total invite cap ----------
+-- Any member may invite friends, but the total allowlist can't exceed the
+-- admin-set max_invites. Admins and the system seed (invited_by null) are exempt.
 create function public.enforce_invite_cap() returns trigger
   language plpgsql security definer set search_path = '' as $$
 declare
-  cnt int;
-  cap constant int := 25;
+  cap   int;
+  total int;
 begin
   if new.invited_by is null or public.is_admin() then
     return new;
   end if;
-  select count(*) into cnt from public.invites where invited_by = new.invited_by;
-  if cnt >= cap then
-    raise exception 'Invite limit (%) reached', cap using errcode = 'check_violation';
+  select max_invites into cap from public.app_settings where id;
+  if cap is not null then
+    select count(*) into total from public.invites;
+    if total >= cap then
+      raise exception 'Total invite limit (%) reached', cap using errcode = 'check_violation';
+    end if;
   end if;
   return new;
 end;

--- a/supabase/migrations/20260618000000_invite_only.sql
+++ b/supabase/migrations/20260618000000_invite_only.sql
@@ -1,0 +1,204 @@
+-- ============================================================================
+-- Invite-only access. The app is now a closed guest list: a user may read or
+-- write anything only if their email is on the allowlist (public.invites) or
+-- they're an admin. RLS is the boundary (Invariant 1); the client middleware
+-- (app/middleware/invited.global.ts) is just the UX half — it signs out and
+-- redirects anyone who slips past.
+--
+-- Provider-agnostic: the gate keys on the profile email, so Google, email/
+-- password, and Facebook sign-ins all flow through the same check.
+-- ============================================================================
+
+-- ---------- Allowlist table ----------
+-- One row per invited email (the natural key). A row with accepted_at set means
+-- that person has since signed in. invited_by is null for the bootstrap seed.
+create table public.invites (
+  email        text primary key,
+  invited_by   uuid references public.profiles (id) on delete set null,
+  display_name text,
+  created_at   timestamptz not null default now(),
+  accepted_at  timestamptz
+);
+
+-- Normalize the key so casing/whitespace can't create duplicate or missed
+-- invites (BobX@x.com and bobx@x.com must be the same allowlist entry).
+create function public.normalize_invite_email() returns trigger
+  language plpgsql set search_path = '' as $$
+begin
+  new.email := lower(trim(new.email));
+  return new;
+end;
+$$;
+create trigger invites_normalize_email before insert or update on public.invites
+  for each row execute function public.normalize_invite_email();
+
+-- ---------- Allowlist check ----------
+-- True if the current user is an admin or their email is on the allowlist.
+-- SECURITY DEFINER (search_path = '') so it bypasses RLS on profiles/invites and
+-- can't recurse — mirrors public.is_admin() / public.is_blocked().
+create function public.is_allowed() returns boolean
+  language sql security definer set search_path = '' stable as $$
+  select exists (
+    select 1 from public.profiles p
+    where p.id = auth.uid()
+      and (
+        p.is_admin
+        or exists (
+          select 1 from public.invites i where i.email = lower(trim(p.email))
+        )
+      )
+  );
+$$;
+revoke all on function public.is_allowed() from public;
+grant execute on function public.is_allowed() to authenticated;
+
+-- ---------- Seed existing members so nobody is locked out ----------
+-- Everyone who already has a profile is grandfathered onto the allowlist and
+-- marked accepted. Runs before the cap trigger exists (and these are system
+-- invites with invited_by null, which the cap exempts anyway).
+insert into public.invites (email, accepted_at)
+select distinct lower(trim(email)), now()
+from public.profiles
+where email is not null and trim(email) <> ''
+on conflict (email) do nothing;
+
+-- ---------- Per-member invite cap ----------
+-- Any member may invite friends, but not unboundedly. Admins and the system
+-- seed (invited_by null) are exempt. Adjust the cap by editing this function.
+create function public.enforce_invite_cap() returns trigger
+  language plpgsql security definer set search_path = '' as $$
+declare
+  cnt int;
+  cap constant int := 25;
+begin
+  if new.invited_by is null or public.is_admin() then
+    return new;
+  end if;
+  select count(*) into cnt from public.invites where invited_by = new.invited_by;
+  if cnt >= cap then
+    raise exception 'Invite limit (%) reached', cap using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+create trigger invites_cap before insert on public.invites
+  for each row execute function public.enforce_invite_cap();
+
+-- ---------- Mark invites accepted on first sign-in ----------
+-- Recreates handle_new_user to also flip accepted_at when an invited email joins.
+-- A non-invited user still gets a profile row (the trigger always creates one),
+-- but is_allowed() stays false for them, so RLS denies everything and the client
+-- gate bounces them to /request-access.
+create or replace function public.handle_new_user() returns trigger
+  language plpgsql security definer set search_path = public as $$
+begin
+  insert into public.profiles (id, email, display_name, avatar_url)
+  values (
+    new.id,
+    new.email,
+    coalesce(new.raw_user_meta_data ->> 'full_name', new.raw_user_meta_data ->> 'name', new.email),
+    new.raw_user_meta_data ->> 'avatar_url'
+  )
+  on conflict (id) do nothing;
+
+  update public.invites
+    set accepted_at = now()
+    where email = lower(trim(new.email)) and accepted_at is null;
+
+  return new;
+end;
+$$;
+
+-- ---------- RLS on invites ----------
+alter table public.invites enable row level security;
+grant select, insert, update, delete on public.invites to authenticated;
+
+-- Allowlisted members (and admins) can see the guest list — this powers the
+-- admin people directory (members + pending invites).
+create policy "invites: read" on public.invites
+  for select to authenticated using (public.is_allowed());
+
+-- Any allowlisted, non-blocked member may invite a friend, as themselves. The
+-- per-member cap is enforced by the invites_cap trigger above.
+create policy "invites: create" on public.invites
+  for insert to authenticated
+  with check (invited_by = auth.uid() and public.is_allowed() and not public.is_blocked());
+
+-- Admins may edit any invite (e.g. fix a name); members may not.
+create policy "invites: admin update" on public.invites
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+
+-- An inviter may withdraw an invite they sent that hasn't been accepted yet;
+-- admins may remove any.
+create policy "invites: delete" on public.invites
+  for delete to authenticated
+  using (public.is_admin() or (invited_by = auth.uid() and accepted_at is null));
+
+-- ----------------------------------------------------------------------------
+-- Gate every existing table on the allowlist. READ is closed to allowlisted
+-- users only (a non-invited session sees nothing); PARTICIPATION writes add the
+-- same check alongside the existing not-blocked guard. Reductive self-deletes
+-- stay open, same as the blocking migration.
+-- ----------------------------------------------------------------------------
+
+-- profiles: you can always read your OWN row (so the gate can learn you're not
+-- invited); reading anyone else requires being allowlisted.
+drop policy "profiles: read" on public.profiles;
+create policy "profiles: read" on public.profiles
+  for select to authenticated using (id = auth.uid() or public.is_allowed());
+
+drop policy "events: read" on public.events;
+create policy "events: read" on public.events
+  for select to authenticated using (public.is_allowed());
+
+drop policy "suggestions: read" on public.suggestions;
+create policy "suggestions: read" on public.suggestions
+  for select to authenticated using (public.is_allowed());
+
+drop policy "votes: read" on public.votes;
+create policy "votes: read" on public.votes
+  for select to authenticated using (public.is_allowed());
+
+drop policy "rsvps: read" on public.rsvps;
+create policy "rsvps: read" on public.rsvps
+  for select to authenticated using (public.is_allowed());
+
+drop policy "bring: read" on public.bring_items;
+create policy "bring: read" on public.bring_items
+  for select to authenticated using (public.is_allowed());
+
+-- Participation writes: must be allowlisted (and not blocked).
+drop policy "suggestions: create own" on public.suggestions;
+create policy "suggestions: create own" on public.suggestions
+  for insert to authenticated
+  with check (user_id = auth.uid() and deleted = false and public.is_allowed() and not public.is_blocked());
+
+drop policy "votes: insert own" on public.votes;
+create policy "votes: insert own" on public.votes
+  for insert to authenticated
+  with check (user_id = auth.uid() and public.is_allowed() and not public.is_blocked());
+
+drop policy "rsvps: insert own" on public.rsvps;
+create policy "rsvps: insert own" on public.rsvps
+  for insert to authenticated
+  with check (user_id = auth.uid() and public.is_allowed() and not public.is_blocked());
+
+drop policy "rsvps: update own" on public.rsvps;
+create policy "rsvps: update own" on public.rsvps
+  for update to authenticated
+  using (user_id = auth.uid())
+  with check (user_id = auth.uid() and public.is_allowed() and not public.is_blocked());
+
+drop policy "bring: create" on public.bring_items;
+create policy "bring: create" on public.bring_items
+  for insert to authenticated
+  with check (created_by = auth.uid() and (user_id is null or user_id = auth.uid()) and public.is_allowed() and not public.is_blocked());
+
+drop policy "bring: update" on public.bring_items;
+create policy "bring: update" on public.bring_items
+  for update to authenticated
+  using (created_by = auth.uid() or user_id = auth.uid() or user_id is null)
+  with check ((user_id is null or user_id = auth.uid()) and public.is_allowed() and not public.is_blocked());
+
+-- ---------- Realtime ----------
+alter publication supabase_realtime add table public.invites;

--- a/supabase/migrations/20260618010000_service_role_grants.sql
+++ b/supabase/migrations/20260618010000_service_role_grants.sql
@@ -1,0 +1,11 @@
+-- ============================================================================
+-- service_role table grants. service_role is the server-only key (Invariant 2)
+-- and operates below RLS for admin/server routes (e.g. the event-blast recipient
+-- lookup, account deletion). Hosted Supabase grants it DML on the public schema
+-- by default; grant it explicitly so behavior is deterministic across hosted and
+-- local (supabase start) environments. service_role never reaches the browser.
+-- ============================================================================
+
+grant select, insert, update, delete on all tables in schema public to service_role;
+alter default privileges in schema public
+  grant select, insert, update, delete on tables to service_role;

--- a/test/invited-middleware.nuxt.test.ts
+++ b/test/invited-middleware.nuxt.test.ts
@@ -71,6 +71,13 @@ describe('invited.global middleware', () => {
     expect(state.navigatedTo).toBe('/request-access')
   })
 
+  it('clears the cached verdict on deny so a later sign-in is re-checked', async () => {
+    state.user.value = { id: 'u1' }
+    state.rpcData = false
+    await run('/overview')
+    expect(useState('is-allowed').value).toBeNull()
+  })
+
   it('treats an RPC error as not allowed (fails closed)', async () => {
     state.user.value = { id: 'u1' }
     state.rpcData = null

--- a/test/invited-middleware.nuxt.test.ts
+++ b/test/invited-middleware.nuxt.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import type { RouteLocationNormalized } from 'vue-router'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import middleware from '../app/middleware/invited.global'
+
+// Module-scope test state the mocks read at call time (same pattern as
+// useAdminPeople.nuxt.test.ts referencing top-level vars).
+const state = {
+  user: ref<{ id: string } | null>(null),
+  rpcData: true as boolean | null,
+  rpcError: null as { message: string } | null,
+  signOutCalls: 0,
+  navigatedTo: null as string | null
+}
+
+mockNuxtImport('useSupabaseUser', () => () => state.user)
+mockNuxtImport('useSupabaseClient', () => () => ({
+  rpc: async () => ({ data: state.rpcData, error: state.rpcError }),
+  auth: { signOut: async () => { state.signOutCalls++ } }
+}))
+mockNuxtImport('navigateTo', () => (to: string) => {
+  state.navigatedTo = to
+  return to
+})
+
+const route = (path: string) => ({ path }) as unknown as RouteLocationNormalized
+const run = (path: string) => middleware(route(path), route('/'))
+
+beforeEach(() => {
+  state.user.value = null
+  state.rpcData = true
+  state.rpcError = null
+  state.signOutCalls = 0
+  state.navigatedTo = null
+  useState<boolean | null>('is-allowed', () => null).value = null
+})
+
+describe('invited.global middleware', () => {
+  it('lets public paths through without checking access', async () => {
+    state.user.value = { id: 'u1' }
+    for (const p of ['/', '/about', '/login', '/confirm', '/request-access']) {
+      await run(p)
+    }
+    expect(state.signOutCalls).toBe(0)
+    expect(state.navigatedTo).toBeNull()
+  })
+
+  it('ignores unauthenticated users (the Supabase module redirects them)', async () => {
+    state.user.value = null
+    await run('/overview')
+    expect(state.signOutCalls).toBe(0)
+    expect(state.navigatedTo).toBeNull()
+  })
+
+  it('lets allowlisted users reach a gated route', async () => {
+    state.user.value = { id: 'u1' }
+    state.rpcData = true
+    const result = await run('/overview')
+    expect(result).toBeUndefined()
+    expect(state.signOutCalls).toBe(0)
+    expect(state.navigatedTo).toBeNull()
+  })
+
+  it('signs out and redirects users who are not on the allowlist', async () => {
+    state.user.value = { id: 'u1' }
+    state.rpcData = false
+    await run('/overview')
+    expect(state.signOutCalls).toBe(1)
+    expect(state.navigatedTo).toBe('/request-access')
+  })
+
+  it('treats an RPC error as not allowed (fails closed)', async () => {
+    state.user.value = { id: 'u1' }
+    state.rpcData = null
+    state.rpcError = { message: 'boom' }
+    await run('/overview')
+    expect(state.signOutCalls).toBe(1)
+    expect(state.navigatedTo).toBe('/request-access')
+  })
+
+  it('caches the verdict so a second navigation skips the RPC', async () => {
+    state.user.value = { id: 'u1' }
+    state.rpcData = true
+    await run('/overview')
+    // Even if the RPC would now deny, the cached "allowed" wins this session.
+    state.rpcData = false
+    await run('/profile')
+    expect(state.signOutCalls).toBe(0)
+    expect(state.navigatedTo).toBeNull()
+  })
+})

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -1,0 +1,124 @@
+import { createClient } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Integration coverage for the invite-only RLS boundary (Invariant 1) — the
+// test the unit suite *can't* be, because it exercises the actual Postgres
+// policies, not the UX layer.
+//
+// Run against a local Supabase with these migrations applied:
+//   supabase start                         # Docker
+//   SUPABASE_TEST_URL=http://127.0.0.1:54321 \
+//   SUPABASE_TEST_ANON_KEY=<anon key> \
+//   SUPABASE_TEST_SERVICE_KEY=<service_role key> \
+//   npx vitest run test/rls.integration.test.ts
+//
+// Skipped when those env vars are absent so the default unit run is unaffected.
+// ---------------------------------------------------------------------------
+
+const url = process.env.SUPABASE_TEST_URL
+const anonKey = process.env.SUPABASE_TEST_ANON_KEY
+const serviceKey = process.env.SUPABASE_TEST_SERVICE_KEY
+const ready = Boolean(url && anonKey && serviceKey)
+
+const admin = ready
+  ? createClient(url as string, serviceKey as string, { auth: { persistSession: false, autoRefreshToken: false } })
+  : null
+
+const PASSWORD = 'rls-test-Password-1!'
+const createdUserIds: string[] = []
+const GATED_TABLES = ['events', 'suggestions', 'votes', 'rsvps', 'bring_items'] as const
+
+async function makeUser(email: string): Promise<string> {
+  const { data, error } = await admin!.auth.admin.createUser({ email, password: PASSWORD, email_confirm: true })
+  if (error || !data.user) throw error ?? new Error('createUser failed')
+  createdUserIds.push(data.user.id)
+  return data.user.id
+}
+
+async function signInAs(email: string): Promise<SupabaseClient> {
+  const client = createClient(url as string, anonKey as string, { auth: { persistSession: false, autoRefreshToken: false } })
+  const { error } = await client.auth.signInWithPassword({ email, password: PASSWORD })
+  if (error) throw error
+  return client
+}
+
+describe.skipIf(!ready)('invite-only RLS boundary', () => {
+  const stamp = Date.now()
+  const adminEmail = `rls_admin_${stamp}@example.com`
+  const memberEmail = `rls_member_${stamp}@example.com`
+  const outsiderEmail = `rls_outsider_${stamp}@example.com`
+
+  let memberId = ''
+  let memberClient: SupabaseClient
+  let outsiderClient: SupabaseClient
+  let eventId = ''
+
+  beforeAll(async () => {
+    const adminId = await makeUser(adminEmail)
+    memberId = await makeUser(memberEmail)
+    await makeUser(outsiderEmail)
+
+    // Allowlist admin + member; the outsider is intentionally left off.
+    await admin!.from('invites').insert([{ email: adminEmail }, { email: memberEmail }])
+    await admin!.from('profiles').update({ is_admin: true }).eq('id', adminId)
+
+    const { data: ev, error } = await admin!
+      .from('events')
+      .insert({ title: 'RLS Night', event_date: new Date(stamp + 7 * 86_400_000).toISOString() })
+      .select('id')
+      .single()
+    if (error || !ev) throw error ?? new Error('event seed failed')
+    eventId = ev.id
+
+    memberClient = await signInAs(memberEmail)
+    outsiderClient = await signInAs(outsiderEmail)
+  }, 30_000)
+
+  afterAll(async () => {
+    if (!admin) return
+    await admin.from('events').delete().eq('id', eventId)
+    await admin.from('invites').delete().in('email', [adminEmail, memberEmail])
+    await admin.from('app_settings').update({ max_invites: null }).eq('id', true)
+    for (const id of createdUserIds) await admin.auth.admin.deleteUser(id)
+  })
+
+  it('an allowlisted member can read events', async () => {
+    const { data } = await memberClient.from('events').select('id').eq('id', eventId)
+    expect(data ?? []).toHaveLength(1)
+  })
+
+  it('an allowlisted member can RSVP (allowed + not blocked)', async () => {
+    const { error } = await memberClient.from('rsvps').insert({ event_id: eventId, user_id: memberId, status: 'going' })
+    expect(error).toBeNull()
+  })
+
+  it('a non-allowlisted user reads zero rows from every gated table', async () => {
+    for (const table of GATED_TABLES) {
+      const { data } = await outsiderClient.from(table).select('*')
+      expect(data ?? [], `expected no ${table} rows`).toHaveLength(0)
+    }
+  })
+
+  it('a non-allowlisted user cannot insert a suggestion', async () => {
+    const { error } = await outsiderClient.from('suggestions').insert({ event_id: eventId, tmdb_movie: { id: 1, title: 'X' } })
+    expect(error).toBeTruthy()
+  })
+
+  it('the total invite cap blocks an over-limit member invite but exempts admin/seed', async () => {
+    const { count } = await admin!.from('invites').select('*', { count: 'exact', head: true })
+    // Set the cap to the current size so the next member-issued invite is over-limit.
+    await admin!.from('app_settings').update({ max_invites: count ?? 0 }).eq('id', true)
+
+    const overLimit = await memberClient.from('invites').insert({ email: `rls_over_${stamp}@example.com`, invited_by: memberId })
+    expect(overLimit.error, 'member invite past the cap should be rejected').toBeTruthy()
+
+    // Service-role / seed-style insert (invited_by null) is exempt from the cap.
+    const byAdmin = await admin!.from('invites').insert({ email: `rls_byadmin_${stamp}@example.com` })
+    expect(byAdmin.error, 'admin/seed insert should be exempt').toBeNull()
+
+    await admin!.from('invites').delete().eq('email', `rls_byadmin_${stamp}@example.com`)
+    await admin!.from('app_settings').update({ max_invites: null }).eq('id', true)
+  })
+})


### PR DESCRIPTION
## Scope

The backbone for everything invite-related: **the app is now invite-only.**
Nobody can use BSOTG unless their email is on an allowlist (`public.invites`) or
they're an admin. This is the keystone the e-vite system, "invite a friend," and
"no login without an invite" all build on.

Because Supabase can't reject an OAuth/email sign-in *before* the account is
created, the gate runs immediately *after* auth: a non-allowlisted user is
signed out and sent to `/request-access`, and — critically — **RLS denies them
all data regardless** (Invariant 1: the middleware is UX, RLS is the boundary).

Keyed on the profile email, so it works the same for Google today and for
email/password + Facebook (PR C).

## Implementation

**Migration `20260618000000_invite_only.sql`:**
- `public.invites` — email PK (normalized lower/trim via trigger), `invited_by`,
  `display_name`, `accepted_at`.
- `is_allowed()` (SECURITY DEFINER, no recursion — mirrors `is_admin()`/
  `is_blocked()`): true for admins or any email on the list. Exposed as an RPC.
- **Every read policy** (profiles/events/suggestions/votes/rsvps/bring_items)
  and **every participation-write policy** now requires `is_allowed()`. Profiles
  keeps *own-row* readable so the gate can detect "not invited."
- **Seeds existing members** onto the allowlist so nobody is locked out.
- `handle_new_user` marks an invite `accepted_at` on first sign-in.
- Per-member invite **cap of 25** (admins + the seed are exempt).
- `invites` added to the realtime publication.

**Client gate:**
- `middleware/invited.global.ts` — one `is_allowed()` RPC per session (cached in
  `useState`), signs out + redirects non-invited users.
- `pages/request-access.vue` — public page (added to the Supabase `exclude`
  list) explaining how to get invited.
- `useAuth` clears the cached verdict on sign-out.

## How to Test

- **Automated:** `test/invited-middleware.nuxt.test.ts` — public-path skip,
  unauth pass-through, allow, deny+signout, fail-closed on RPC error, caching.
  `npm test` → 75 passing; `npm run typecheck` clean.
- **⚠️ RLS integration coverage is still owed.** The policy changes are exactly
  the kind that need `supabase start` + a seeded test project (CLAUDE.md
  testing pyramid). I couldn't stand up local Supabase in this environment.
  Recommended before merge: a test asserting an allowlisted user reads
  events/suggestions and a non-allowlisted user gets zero rows + write denials.
  Manual repro: temporarily remove your email from `invites`, sign in → you
  should be bounced to `/request-access` and see no data.

## Invariants & Risk

Touches **authorization directly** — please review the RLS closely.
- **Invariant 1:** RLS is the boundary; middleware is UX only. Non-invited
  sessions are denied at the DB.
- **Invariant 4:** admin role untouched; the cap exempts admins via `is_admin()`
  but nothing here writes `is_admin`.
- Seed migration grandfathers all current profiles — verify the seed matches
  your real member list before applying to prod.
- New invariant worth adding to CLAUDE.md: "access is allowlist-gated." Left out
  of this PR to keep scope tight — happy to add it.

> `npm run lint` throws `Object.groupBy is not a function` on a pristine
> checkout (ESLint config-loader needs Node 21+; this box is Node 20) —
> pre-existing, unrelated to this PR.
