### PR TITLE
feat: email/password + Facebook sign-in (stacked on #50)

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -29,11 +29,42 @@ export function useAuth() {
     }
   })
 
-  async function signInWithGoogle(): Promise<void> {
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: { redirectTo: `${window.location.origin}/confirm` }
+  const callbackUrl = (): string => `${window.location.origin}/confirm`
+
+  // OAuth providers redirect away to the provider then back to /confirm; the
+  // page unloads, so there's nothing to await beyond kicking it off.
+  async function oauth(provider: 'google' | 'facebook'): Promise<void> {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: { redirectTo: callbackUrl() }
     })
+    if (error) throw error
+  }
+  const signInWithGoogle = (): Promise<void> => oauth('google')
+  const signInWithFacebook = (): Promise<void> => oauth('facebook')
+
+  // Email/password. Sign-in sets the session immediately (no redirect); sign-up
+  // sends a confirmation email whose link returns to /confirm. Both still pass
+  // through the invite-only gate after auth (middleware/invited.global.ts).
+  async function signInWithEmail(email: string, password: string): Promise<void> {
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) throw error
+  }
+
+  async function signUpWithEmail(email: string, password: string): Promise<void> {
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { emailRedirectTo: callbackUrl() }
+    })
+    if (error) throw error
+  }
+
+  async function sendPasswordReset(email: string): Promise<void> {
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: callbackUrl()
+    })
+    if (error) throw error
   }
 
   async function signOutUser(): Promise<void> {
@@ -43,5 +74,17 @@ export function useAuth() {
     isAllowed.value = null
   }
 
-  return { user, myId, profile, account, isAdmin, signInWithGoogle, signOutUser }
+  return {
+    user,
+    myId,
+    profile,
+    account,
+    isAdmin,
+    signInWithGoogle,
+    signInWithFacebook,
+    signInWithEmail,
+    signUpWithEmail,
+    sendPasswordReset,
+    signOutUser
+  }
 }

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,62 +1,171 @@
 <script setup lang="ts">
+import { z } from 'zod'
+import type { FormSubmitEvent } from '@nuxt/ui'
+
 definePageMeta({ layout: false })
 
-const { user, signInWithGoogle } = useAuth()
+const {
+  user,
+  signInWithGoogle,
+  signInWithFacebook,
+  signInWithEmail,
+  signUpWithEmail,
+  sendPasswordReset
+} = useAuth()
 const toast = useToast()
-const loading = ref(false)
 
-// Already signed in? Skip the login screen.
+const oauthLoading = ref<'google' | 'facebook' | null>(null)
+const submitting = ref(false)
+const mode = ref<'signin' | 'signup'>('signin')
+
+// Already signed in? Skip the login screen (the invite gate runs downstream).
 watchEffect(() => {
-  if (user.value) {
-    navigateTo('/overview')
-  }
+  if (user.value) navigateTo('/overview')
 })
 
-async function handleSignIn(): Promise<void> {
-  loading.value = true
+const schema = computed(() =>
+  z.object({
+    email: z.string().email('Enter a valid email'),
+    password: mode.value === 'signup'
+      ? z.string().min(8, 'At least 8 characters')
+      : z.string().min(1, 'Enter your password')
+  })
+)
+const state = reactive({ email: '', password: '' })
+
+function notifyError(error: unknown, fallback: string): void {
+  toast.add({
+    title: fallback,
+    description: error instanceof Error ? error.message : undefined,
+    color: 'error',
+    icon: 'i-lucide-circle-alert'
+  })
+}
+
+async function startOAuth(provider: 'google' | 'facebook'): Promise<void> {
+  oauthLoading.value = provider
   try {
-    // Redirects to Google, then back to /confirm — this page unloads.
-    await signInWithGoogle()
+    await (provider === 'google' ? signInWithGoogle() : signInWithFacebook())
+    // Redirects away on success — this page unloads.
   } catch (error) {
-    loading.value = false
-    toast.add({
-      title: 'Sign in failed',
-      description: error instanceof Error ? error.message : 'Please try again.',
-      color: 'error',
-      icon: 'i-lucide-circle-alert'
-    })
+    oauthLoading.value = null
+    notifyError(error, 'Sign in failed')
+  }
+}
+
+async function onSubmit(event: FormSubmitEvent<{ email: string, password: string }>): Promise<void> {
+  submitting.value = true
+  const { email, password } = event.data
+  try {
+    if (mode.value === 'signup') {
+      await signUpWithEmail(email, password)
+      toast.add({
+        title: 'Check your email',
+        description: 'Confirm your address to finish signing up.',
+        color: 'success',
+        icon: 'i-lucide-mail-check'
+      })
+    } else {
+      await signInWithEmail(email, password)
+      // On success the user populates and watchEffect routes to /overview.
+    }
+  } catch (error) {
+    notifyError(error, mode.value === 'signup' ? 'Could not sign up' : 'Could not sign in')
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function onForgotPassword(): Promise<void> {
+  const email = state.email.trim()
+  if (!z.string().email().safeParse(email).success) {
+    toast.add({ title: 'Enter your email first', description: 'Then tap “Forgot password”.', color: 'warning' })
+    return
+  }
+  try {
+    await sendPasswordReset(email)
+    toast.add({ title: 'Reset link sent', description: `Check ${email} for a password reset link.`, color: 'success' })
+  } catch (error) {
+    notifyError(error, 'Could not send reset link')
   }
 }
 </script>
 
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-500/10 via-default to-primary-500/5 px-4">
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-500/10 via-default to-primary-500/5 px-4 py-10">
     <UCard class="w-full max-w-md">
-      <div class="flex flex-col items-center text-center gap-4 py-4">
+      <div class="flex flex-col items-center text-center gap-4 py-2">
         <img src="/img/logo.png" alt="Benteen Screen On The Green" class="h-16 w-auto">
         <div>
           <h1 class="text-2xl font-bold">
-            Welcome back
+            {{ mode === 'signup' ? 'Create your account' : 'Welcome back' }}
           </h1>
           <p class="mt-1 text-muted">
-            Sign in to vote for the next movie night.
+            {{ mode === 'signup' ? 'Sign up to join the next movie night.' : 'Sign in to vote for the next movie night.' }}
           </p>
         </div>
 
-        <UButton
-          label="Continue with Google"
-          icon="i-simple-icons-google"
-          size="lg"
-          block
-          color="neutral"
-          variant="outline"
-          :loading="loading"
-          class="mt-2"
-          @click="handleSignIn"
-        />
+        <div class="w-full space-y-2">
+          <UButton
+            label="Continue with Google"
+            icon="i-simple-icons-google"
+            size="lg"
+            block
+            color="neutral"
+            variant="outline"
+            :loading="oauthLoading === 'google'"
+            :disabled="oauthLoading !== null"
+            @click="startOAuth('google')"
+          />
+          <UButton
+            label="Continue with Facebook"
+            icon="i-simple-icons-facebook"
+            size="lg"
+            block
+            color="neutral"
+            variant="outline"
+            :loading="oauthLoading === 'facebook'"
+            :disabled="oauthLoading !== null"
+            @click="startOAuth('facebook')"
+          />
+        </div>
 
-        <p class="text-xs text-dimmed mt-2">
-          By signing in you agree to the Terms of Service and Privacy Policy.
+        <USeparator label="or" class="w-full" />
+
+        <UForm :schema="schema" :state="state" class="w-full space-y-3 text-left" @submit="onSubmit">
+          <UFormField label="Email" name="email">
+            <UInput v-model="state.email" type="email" autocomplete="email" placeholder="you@example.com" class="w-full" />
+          </UFormField>
+          <UFormField label="Password" name="password">
+            <UInput
+              v-model="state.password"
+              type="password"
+              :autocomplete="mode === 'signup' ? 'new-password' : 'current-password'"
+              placeholder="••••••••"
+              class="w-full"
+            />
+          </UFormField>
+
+          <UButton
+            type="submit"
+            :label="mode === 'signup' ? 'Sign up' : 'Sign in'"
+            size="lg"
+            block
+            :loading="submitting"
+          />
+        </UForm>
+
+        <div class="w-full flex items-center justify-between text-sm">
+          <button type="button" class="text-primary hover:underline" @click="mode = mode === 'signup' ? 'signin' : 'signup'">
+            {{ mode === 'signup' ? 'Have an account? Sign in' : 'New here? Create an account' }}
+          </button>
+          <button v-if="mode === 'signin'" type="button" class="text-muted hover:underline" @click="onForgotPassword">
+            Forgot password?
+          </button>
+        </div>
+
+        <p class="text-xs text-dimmed">
+          Benteen Screen is invite-only. By signing in you agree to the Terms of Service and Privacy Policy.
         </p>
       </div>
     </UCard>

--- a/test/login.nuxt.test.ts
+++ b/test/login.nuxt.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import LoginPage from '../app/pages/login.vue'
+
+const calls: string[] = []
+const auth = {
+  user: ref<unknown>(null),
+  signInWithGoogle: async () => { calls.push('google') },
+  signInWithFacebook: async () => { calls.push('facebook') },
+  signInWithEmail: async (email: string) => { calls.push(`email:${email}`) },
+  signUpWithEmail: async (email: string) => { calls.push(`signup:${email}`) },
+  sendPasswordReset: async () => { calls.push('reset') }
+}
+
+mockNuxtImport('useAuth', () => () => auth)
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+beforeEach(() => {
+  calls.length = 0
+  auth.user.value = null
+})
+
+describe('login page', () => {
+  it('offers both Google and Facebook sign-in', async () => {
+    const w = await mountSuspended(LoginPage)
+    const labels = w.findAll('button').map(b => b.text())
+    expect(labels.some(t => t.includes('Google'))).toBe(true)
+    expect(labels.some(t => t.includes('Facebook'))).toBe(true)
+  })
+
+  it('starts Facebook OAuth when its button is clicked', async () => {
+    const w = await mountSuspended(LoginPage)
+    const fb = w.findAll('button').find(b => b.text().includes('Facebook'))
+    await fb?.trigger('click')
+    expect(calls).toContain('facebook')
+  })
+
+  it('toggles between sign-in and sign-up', async () => {
+    const w = await mountSuspended(LoginPage)
+    expect(w.text()).toContain('Welcome back')
+    const toggle = w.findAll('button').find(b => b.text().includes('Create an account'))
+    await toggle?.trigger('click')
+    expect(w.text()).toContain('Create your account')
+  })
+
+  it('signs in with email + password on submit', async () => {
+    const w = await mountSuspended(LoginPage)
+    await w.find('input[type="email"]').setValue('a@b.com')
+    await w.find('input[type="password"]').setValue('secret12')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(calls).toContain('email:a@b.com')
+  })
+
+  it('signs up when submitting in sign-up mode', async () => {
+    const w = await mountSuspended(LoginPage)
+    const toggle = w.findAll('button').find(b => b.text().includes('Create an account'))
+    await toggle?.trigger('click')
+    await w.find('input[type="email"]').setValue('new@b.com')
+    await w.find('input[type="password"]').setValue('secret12')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(calls).toContain('signup:new@b.com')
+  })
+})

--- a/test/useAuth.nuxt.test.ts
+++ b/test/useAuth.nuxt.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+interface Call { fn: string, args: unknown[] }
+const calls: Call[] = []
+let nextError: Error | null = null
+
+const auth = {
+  signInWithOAuth: (args: unknown) => { calls.push({ fn: 'signInWithOAuth', args: [args] }); return Promise.resolve({ error: nextError }) },
+  signInWithPassword: (args: unknown) => { calls.push({ fn: 'signInWithPassword', args: [args] }); return Promise.resolve({ error: nextError }) },
+  signUp: (args: unknown) => { calls.push({ fn: 'signUp', args: [args] }); return Promise.resolve({ error: nextError }) },
+  resetPasswordForEmail: (email: string, opts: unknown) => { calls.push({ fn: 'resetPasswordForEmail', args: [email, opts] }); return Promise.resolve({ error: nextError }) },
+  signOut: () => { calls.push({ fn: 'signOut', args: [] }); return Promise.resolve({ error: null }) }
+}
+
+mockNuxtImport('useSupabaseClient', () => () => ({ auth }))
+mockNuxtImport('useSupabaseUser', () => () => ref(null))
+
+beforeEach(() => {
+  calls.length = 0
+  nextError = null
+})
+
+describe('useAuth providers', () => {
+  it('signInWithGoogle uses the google provider and the /confirm callback', async () => {
+    await useAuth().signInWithGoogle()
+    const c = calls[0]
+    expect(c.fn).toBe('signInWithOAuth')
+    const arg = c.args[0] as { provider: string, options: { redirectTo: string } }
+    expect(arg.provider).toBe('google')
+    expect(arg.options.redirectTo).toContain('/confirm')
+  })
+
+  it('signInWithFacebook uses the facebook provider', async () => {
+    await useAuth().signInWithFacebook()
+    expect((calls[0].args[0] as { provider: string }).provider).toBe('facebook')
+  })
+
+  it('signInWithEmail calls signInWithPassword with the credentials', async () => {
+    await useAuth().signInWithEmail('a@b.com', 'pw')
+    expect(calls[0]).toMatchObject({ fn: 'signInWithPassword', args: [{ email: 'a@b.com', password: 'pw' }] })
+  })
+
+  it('signUpWithEmail calls signUp with an email confirmation redirect', async () => {
+    await useAuth().signUpWithEmail('a@b.com', 'pw12345678')
+    const arg = calls[0].args[0] as { email: string, options: { emailRedirectTo: string } }
+    expect(calls[0].fn).toBe('signUp')
+    expect(arg.email).toBe('a@b.com')
+    expect(arg.options.emailRedirectTo).toContain('/confirm')
+  })
+
+  it('sendPasswordReset calls resetPasswordForEmail', async () => {
+    await useAuth().sendPasswordReset('a@b.com')
+    expect(calls[0].fn).toBe('resetPasswordForEmail')
+    expect(calls[0].args[0]).toBe('a@b.com')
+  })
+
+  it('surfaces supabase auth errors by throwing', async () => {
+    nextError = new Error('Invalid login credentials')
+    await expect(useAuth().signInWithEmail('a@b.com', 'pw')).rejects.toThrow('Invalid login credentials')
+  })
+})


### PR DESCRIPTION
## Scope

Adds the two sign-in methods you asked for beyond Google:
- **Email + password** — a sign-in / sign-up toggle with a forgot-password reset
  link.
- **Facebook** — a "Continue with Facebook" OAuth button alongside Google.

All of them still flow through the **invite-only gate** (#50) after auth, so a
new account whose email isn't on the allowlist is signed out and sent to
`/request-access` — the gate keys on email, so it's provider-agnostic.

> **Stacked on #50** (`feat/invite-only`) — review/merge that first. Base is set
> to `feat/invite-only` so this diff is just the auth changes.

## Implementation

- `useAuth`: `signInWithFacebook`, `signInWithEmail`, `signUpWithEmail`,
  `sendPasswordReset`; the two OAuth providers share one `oauth()` helper. All
  return-`{error}` calls now throw so the UI can surface them.
- `login.vue`: rebuilt with both OAuth buttons, a zod-validated email/password
  `UForm` (password min 8 on sign-up), mode toggle, and forgot-password.
  Sign-up shows a "check your email to confirm" toast; sign-in routes onward.

## ⚙️ Required Supabase dashboard config (out-of-band)

This is the app side; these must be enabled in the Supabase project for it to
work end-to-end:
1. **Auth → Providers → Email**: enable (decide whether to require email
   confirmation).
2. **Auth → Providers → Facebook**: enable + paste the Facebook app ID/secret
   (and add the Supabase callback URL to the FB app).
3. **Auth → SMTP**: a custom sender (e.g. your Resend SMTP creds) so
   confirmation + reset emails actually send and look right.

## How to Test

- **Automated:** `test/useAuth.nuxt.test.ts` (each provider/method calls the
  right Supabase auth fn with the `/confirm` redirect, and errors throw) and
  `test/login.nuxt.test.ts` (Google + Facebook buttons present, mode toggle,
  email sign-in + sign-up submit). `npm test` → 86 passing; typecheck clean.
- **Manual:** with the providers enabled — sign up with email → confirm → land
  on `/overview` (if invited) or `/request-access` (if not). Try Facebook.

## Invariants & Risk

No RLS/authorization change here — the gate from #50 does the enforcement. No
secrets in client code (OAuth + Supabase anon key only). Note: an uninvited
person can still *create* an auth account (same as Google today); RLS denies
them all data and the gate bounces them — they just can't use anything.
