### PR TITLE
feat: e-vite system — invite a friend, social share, event blasts (stacked on #50)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,13 @@ NUXT_SUPABASE_SECRET_KEY=your-service-role-key
 # Maps to runtimeConfig.tmdbApiKey. Get one at https://www.themoviedb.org/settings/api
 # ----------------------------------------------------------------------------
 NUXT_TMDB_API_KEY=your-tmdb-api-key
+
+# ----------------------------------------------------------------------------
+# Resend — SERVER-ONLY (Invariant 2). Powers invite e-vites + admin event blasts
+# (server/api/invites/send, server/api/events/announce). Get a key at resend.com.
+# ----------------------------------------------------------------------------
+NUXT_RESEND_API_KEY=your-resend-api-key
+# Optional — override the From header (must be a verified Resend sender/domain).
+NUXT_RESEND_FROM=Benteen Screen On The Green <movienight@benteenscreenonthegreen.com>
+# Optional — absolute site URL used in email links (else derived from the request).
+NUXT_SITE_URL=https://benteenscreenonthegreen.com

--- a/app/components/EventAnnounceComposer.vue
+++ b/app/components/EventAnnounceComposer.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { z } from 'zod'
+import type { FormSubmitEvent } from '@nuxt/ui'
+
+// Admin event blast composer → POST /api/events/announce (admin-gated server-side).
+const props = defineProps<{ eventId: string | undefined }>()
+const toast = useToast()
+const sending = ref(false)
+
+const scopeOptions = [
+  { label: 'Everyone invited', value: 'invited' as const },
+  { label: 'Members (joined)', value: 'members' as const },
+  { label: 'Going to this event', value: 'going' as const }
+]
+type Scope = (typeof scopeOptions)[number]['value']
+
+const schema = z.object({
+  subject: z.string().trim().max(200).optional(),
+  message: z.string().trim().min(1, 'Write a message'),
+  scope: z.enum(['invited', 'members', 'going'])
+})
+const state = reactive<{ subject: string, message: string, scope: Scope }>({
+  subject: '',
+  message: '',
+  scope: 'members'
+})
+
+function messageOf(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'statusMessage' in error) {
+    const m = (error as { statusMessage?: unknown }).statusMessage
+    if (typeof m === 'string') return m
+  }
+  return error instanceof Error ? error.message : undefined
+}
+
+async function onSubmit(event: FormSubmitEvent<{ subject?: string, message: string, scope: Scope }>): Promise<void> {
+  if (!props.eventId) {
+    toast.add({ title: 'Pick an event first', color: 'warning' })
+    return
+  }
+  sending.value = true
+  try {
+    const res = await $fetch<{ ok: boolean, count: number }>('/api/events/announce', {
+      method: 'POST',
+      body: { eventId: props.eventId, subject: event.data.subject || undefined, message: event.data.message, scope: event.data.scope }
+    })
+    toast.add({
+      title: res.count ? `Sent to ${res.count} ${res.count === 1 ? 'person' : 'people'}` : 'No recipients matched',
+      icon: 'i-lucide-send',
+      color: res.count ? 'success' : 'warning'
+    })
+    state.subject = ''
+    state.message = ''
+  } catch (error) {
+    toast.add({ title: 'Could not send the blast', description: messageOf(error), color: 'error' })
+  } finally {
+    sending.value = false
+  }
+}
+</script>
+
+<template>
+  <UForm :schema="schema" :state="state" class="space-y-3" @submit="onSubmit">
+    <UFormField label="Audience" name="scope">
+      <USelectMenu
+        v-model="state.scope"
+        :items="scopeOptions"
+        value-key="value"
+        :search-input="false"
+        class="w-full sm:max-w-xs"
+      />
+    </UFormField>
+    <UFormField label="Subject" name="subject" hint="Optional">
+      <UInput v-model="state.subject" placeholder="Movie night reminder" class="w-full" />
+    </UFormField>
+    <UFormField label="Message" name="message" required>
+      <UTextarea v-model="state.message" :rows="5" placeholder="Doors at 7, first film at 7:30…" class="w-full" />
+    </UFormField>
+    <div class="flex justify-end">
+      <UButton type="submit" label="Send blast" icon="i-lucide-megaphone" :loading="sending" :disabled="!eventId" />
+    </div>
+  </UForm>
+</template>

--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -98,6 +98,14 @@ function downloadIcs(): void {
           />
         </div>
 
+        <!-- Share to invite others (access stays allowlist-gated) -->
+        <div v-if="isUpcoming(event.event_date)">
+          <h3 class="text-sm font-semibold text-muted mb-2">
+            Spread the word
+          </h3>
+          <ShareEvent :event="event" />
+        </div>
+
         <!-- Description -->
         <div
           v-if="event.description"

--- a/app/components/InviteFriendModal.vue
+++ b/app/components/InviteFriendModal.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { z } from 'zod'
+import type { FormSubmitEvent } from '@nuxt/ui'
+
+const open = defineModel<boolean>('open', { default: false })
+const { sendInvite } = useInvites()
+const toast = useToast()
+const submitting = ref(false)
+
+const schema = z.object({
+  email: z.string().email('Enter a valid email'),
+  name: z.string().trim().max(120).optional()
+})
+const state = reactive({ email: '', name: '' })
+
+function messageOf(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'statusMessage' in error) {
+    const m = (error as { statusMessage?: unknown }).statusMessage
+    if (typeof m === 'string') return m
+  }
+  return error instanceof Error ? error.message : undefined
+}
+
+async function onSubmit(event: FormSubmitEvent<{ email: string, name?: string }>): Promise<void> {
+  submitting.value = true
+  try {
+    const res = await sendInvite(event.data.email, event.data.name || undefined)
+    toast.add({
+      title: 'Invite sent',
+      description: res.emailed
+        ? `We emailed an invite to ${event.data.email}.`
+        : `${event.data.email} was added to the guest list.`,
+      icon: 'i-lucide-mail-check',
+      color: 'success'
+    })
+    state.email = ''
+    state.name = ''
+    open.value = false
+  } catch (error) {
+    toast.add({
+      title: 'Could not send invite',
+      description: messageOf(error),
+      icon: 'i-lucide-circle-alert',
+      color: 'error'
+    })
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <UModal
+    v-model:open="open"
+    title="Invite a friend"
+    description="Add them to the guest list and we'll email them an invite."
+  >
+    <template #body>
+      <UForm :schema="schema" :state="state" class="space-y-4" @submit="onSubmit">
+        <UFormField label="Their email" name="email" required>
+          <UInput v-model="state.email" type="email" placeholder="friend@example.com" class="w-full" />
+        </UFormField>
+        <UFormField label="Their name" name="name" hint="Optional">
+          <UInput v-model="state.name" placeholder="Jordan" class="w-full" />
+        </UFormField>
+        <div class="flex justify-end gap-2 pt-1">
+          <UButton label="Cancel" color="neutral" variant="ghost" @click="open = false" />
+          <UButton type="submit" label="Send invite" icon="i-lucide-send" :loading="submitting" />
+        </div>
+      </UForm>
+    </template>
+  </UModal>
+</template>

--- a/app/components/InviteLimitSetting.vue
+++ b/app/components/InviteLimitSetting.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+// Admin control for the total invite cap (app_settings.max_invites). RLS enforces
+// admin-only writes; this lives behind the admin page.
+const { maxInvites, setMaxInvites } = useAppSettings()
+const toast = useToast()
+const draft = ref<number | null>(null)
+const saving = ref(false)
+
+watch(maxInvites, value => { draft.value = value }, { immediate: true })
+
+async function save(): Promise<void> {
+  saving.value = true
+  try {
+    const n = Number(draft.value)
+    const value = Number.isFinite(n) && n > 0 ? Math.floor(n) : null
+    await setMaxInvites(value)
+    draft.value = value
+    toast.add({ title: 'Invite limit saved', icon: 'i-lucide-check', color: 'success' })
+  } catch {
+    toast.add({ title: 'Could not save the limit', color: 'error' })
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <UCard variant="subtle">
+    <div class="flex flex-wrap items-end gap-3">
+      <UFormField label="Total invite limit" hint="Blank = unlimited" class="flex-1 min-w-40">
+        <UInput v-model="draft" type="number" min="0" placeholder="Unlimited" class="w-full" />
+      </UFormField>
+      <UButton label="Save" icon="i-lucide-save" :loading="saving" @click="save" />
+    </div>
+    <p class="text-xs text-muted mt-2">
+      Caps the total number of people on the guest list. Admins are exempt.
+    </p>
+  </UCard>
+</template>

--- a/app/components/PeopleList.vue
+++ b/app/components/PeopleList.vue
@@ -1,71 +1,128 @@
 <script setup lang="ts">
 import type { Profile } from '#shared/types/user'
+import type { Invite } from '#shared/types/invite'
 
-const props = defineProps<{ people: Profile[] }>()
-const emit = defineEmits<{ block: [person: Profile], unblock: [person: Profile] }>()
+const props = withDefaults(
+  defineProps<{ people: Profile[], pending?: Invite[] }>(),
+  { pending: () => [] }
+)
+const emit = defineEmits<{
+  block: [person: Profile]
+  unblock: [person: Profile]
+  revoke: [invite: Invite]
+}>()
+
+type Row =
+  | { kind: 'member', key: string, name: string, email: string, profile: Profile }
+  | { kind: 'pending', key: string, name: string, email: string, invite: Invite }
 
 const query = ref('')
-const filtered = computed(() => {
-  const q = query.value.trim().toLowerCase()
-  if (!q) return props.people
-  return props.people.filter(p =>
-    (p.display_name ?? '').toLowerCase().includes(q) || (p.email ?? '').toLowerCase().includes(q)
-  )
+
+// Pending invites whose email already belongs to a member are redundant — drop them.
+const memberEmails = computed(
+  () => new Set(props.people.map(p => (p.email ?? '').toLowerCase()).filter(Boolean))
+)
+
+const rows = computed<Row[]>(() => {
+  const members: Row[] = props.people.map(p => ({
+    kind: 'member',
+    key: p.id,
+    name: p.display_name ?? 'Unnamed',
+    email: p.email ?? '',
+    profile: p
+  }))
+  const invites: Row[] = props.pending
+    .filter(i => !memberEmails.value.has(i.email.toLowerCase()))
+    .map(i => ({
+      kind: 'pending',
+      key: `invite:${i.email}`,
+      name: i.display_name ?? i.email,
+      email: i.email,
+      invite: i
+    }))
+  return [...members, ...invites]
 })
 
-function initials(p: Profile): string {
-  return (p.display_name ?? p.email ?? '?').slice(0, 2).toUpperCase()
+const filtered = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q) return rows.value
+  return rows.value.filter(r => r.name.toLowerCase().includes(q) || r.email.toLowerCase().includes(q))
+})
+
+function initials(name: string, email: string): string {
+  return (name || email || '?').slice(0, 2).toUpperCase()
 }
 </script>
 
 <template>
   <div class="space-y-3">
-    <UInput v-model="query" icon="i-lucide-search" placeholder="Search members…" class="w-full sm:max-w-xs" />
+    <UInput
+      v-model="query"
+      icon="i-lucide-search"
+      placeholder="Search members…"
+      aria-label="Search members"
+      class="w-full sm:max-w-xs"
+    />
 
     <ul v-if="filtered.length" class="divide-y divide-default rounded-lg ring ring-default overflow-hidden">
       <li
-        v-for="person in filtered"
-        :key="person.id"
+        v-for="row in filtered"
+        :key="row.key"
         class="flex items-center gap-3 p-3"
-        :class="person.blocked ? 'opacity-70' : ''"
+        :class="row.kind === 'member' && row.profile.blocked ? 'opacity-70' : ''"
       >
         <UAvatar
-          :src="person.avatar_url ?? undefined"
-          :alt="person.display_name ?? ''"
-          :text="initials(person)"
+          :src="row.kind === 'member' ? (row.profile.avatar_url ?? undefined) : undefined"
+          :alt="row.name"
+          :text="initials(row.name, row.email)"
           size="sm"
           class="shrink-0"
         />
         <div class="min-w-0 flex-1">
           <p class="font-medium truncate flex items-center gap-1.5">
-            {{ person.display_name ?? 'Unnamed' }}
-            <UBadge v-if="person.is_admin" label="Admin" color="primary" variant="subtle" size="xs" />
-            <UBadge v-if="person.blocked" label="Blocked" color="error" variant="subtle" size="xs" />
+            {{ row.name }}
+            <UBadge v-if="row.kind === 'member' && row.profile.is_admin" label="Admin" color="primary" variant="subtle" size="xs" />
+            <UBadge v-if="row.kind === 'member' && row.profile.blocked" label="Blocked" color="error" variant="subtle" size="xs" />
+            <UBadge v-if="row.kind === 'pending'" label="Pending" color="warning" variant="subtle" size="xs" />
           </p>
           <p class="text-xs text-muted truncate">
-            {{ person.email ?? '—' }}
+            {{ row.email || '—' }}
           </p>
         </div>
-        <!-- Admins can't be banned from the UI (demote via SQL first). -->
+
+        <!-- Member actions: ban/unban (admins can't be banned from the UI). -->
+        <template v-if="row.kind === 'member'">
+          <UButton
+            v-if="row.profile.blocked"
+            label="Unban"
+            icon="i-lucide-user-check"
+            color="neutral"
+            variant="outline"
+            size="xs"
+            class="shrink-0"
+            @click="emit('unblock', row.profile)"
+          />
+          <UButton
+            v-else-if="!row.profile.is_admin"
+            label="Ban"
+            icon="i-lucide-user-x"
+            color="error"
+            variant="outline"
+            size="xs"
+            class="shrink-0"
+            @click="emit('block', row.profile)"
+          />
+        </template>
+        <!-- Pending invite: revoke it. -->
         <UButton
-          v-if="person.blocked"
-          label="Unban"
-          icon="i-lucide-user-check"
+          v-else
+          label="Revoke"
+          icon="i-lucide-x"
           color="neutral"
           variant="outline"
           size="xs"
           class="shrink-0"
-          @click="emit('unblock', person)"
-        />
-        <UButton
-          v-else-if="!person.is_admin"
-          label="Ban"
-          icon="i-lucide-user-x"
-          color="error"
-          variant="outline"
-          size="xs"
-          class="shrink-0"
-          @click="emit('block', person)"
+          @click="emit('revoke', row.invite)"
         />
       </li>
     </ul>

--- a/app/components/ShareEvent.vue
+++ b/app/components/ShareEvent.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import type { MovieEvent } from '#shared/types/event'
+
+// Share an event to social media to drum up invitees. Access is still
+// allowlist-gated — sharing spreads the word; "Invite a friend" grants access.
+const props = defineProps<{ event: MovieEvent }>()
+const toast = useToast()
+
+const shareUrl = computed(() => (import.meta.client ? window.location.origin : ''))
+const shareText = computed(() =>
+  `Join us for ${props.event.title}${props.event.event_date ? ` on ${formatDate(props.event.event_date)}` : ''} at Benteen Screen On The Green! 🎬`
+)
+
+const canNativeShare = computed(() =>
+  import.meta.client && typeof navigator !== 'undefined' && typeof navigator.share === 'function'
+)
+
+const networks = computed(() => {
+  const u = encodeURIComponent(shareUrl.value)
+  const t = encodeURIComponent(shareText.value)
+  return [
+    { label: 'Facebook', icon: 'i-simple-icons-facebook', href: `https://www.facebook.com/sharer/sharer.php?u=${u}&quote=${t}` },
+    { label: 'X', icon: 'i-simple-icons-x', href: `https://twitter.com/intent/tweet?text=${t}&url=${u}` },
+    { label: 'WhatsApp', icon: 'i-simple-icons-whatsapp', href: `https://wa.me/?text=${t}%20${u}` },
+    { label: 'Email', icon: 'i-lucide-mail', href: `mailto:?subject=${encodeURIComponent(props.event.title)}&body=${t}%20${u}` }
+  ]
+})
+
+async function nativeShare(): Promise<void> {
+  try {
+    await navigator.share({ title: props.event.title, text: shareText.value, url: shareUrl.value })
+  } catch {
+    // Cancelled or unsupported — fall back to the per-network buttons.
+  }
+}
+
+async function copyLink(): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(`${shareText.value} ${shareUrl.value}`)
+    toast.add({ title: 'Link copied', icon: 'i-lucide-check', color: 'success' })
+  } catch {
+    toast.add({ title: 'Could not copy the link', color: 'error' })
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center gap-2">
+    <UButton
+      v-if="canNativeShare"
+      label="Share"
+      icon="i-lucide-share-2"
+      size="sm"
+      color="neutral"
+      variant="outline"
+      @click="nativeShare"
+    />
+    <UButton
+      v-for="network in networks"
+      :key="network.label"
+      :icon="network.icon"
+      :to="network.href"
+      target="_blank"
+      rel="noopener"
+      size="sm"
+      color="neutral"
+      variant="outline"
+      :aria-label="`Share on ${network.label}`"
+    />
+    <UButton label="Copy link" icon="i-lucide-link" size="sm" color="neutral" variant="ghost" @click="copyLink" />
+  </div>
+</template>

--- a/app/composables/useAdminPeople.ts
+++ b/app/composables/useAdminPeople.ts
@@ -1,29 +1,58 @@
 import type { Database } from '~/types/database.types'
 import type { Profile } from '#shared/types/user'
+import type { Invite } from '#shared/types/invite'
 
-/** Admin people directory: every profile + ban/unban (via the admin-gated RPC). */
+/**
+ * Admin people directory: joined members (profiles) plus pending invites (people
+ * on the allowlist who haven't signed in yet), so the directory is the whole
+ * guest list — searchable, not just whoever happens to have logged in. Members
+ * can be banned/unbanned (admin RPC); pending invites can be revoked.
+ */
 export function useAdminPeople() {
   const supabase = useSupabaseClient<Database>()
   const people = ref<Profile[]>([])
+  const pendingInvites = ref<Invite[]>([])
   const pending = ref(true)
+  const loadError = ref<string | null>(null)
 
   async function refresh(): Promise<void> {
-    const { data } = await supabase
-      .from('profiles')
-      .select('id, email, display_name, avatar_url, is_admin, blocked, created_at')
-      .order('display_name')
-    people.value = data ?? []
+    pending.value = true
+    loadError.value = null
+    const [members, invites] = await Promise.all([
+      supabase
+        .from('profiles')
+        .select('id, email, display_name, avatar_url, is_admin, blocked, created_at')
+        .order('display_name'),
+      supabase
+        .from('invites')
+        .select('email, invited_by, display_name, created_at, accepted_at')
+        .is('accepted_at', null)
+        .order('created_at', { ascending: false })
+    ])
+    // Surface failures instead of silently showing an empty directory.
+    if (members.error || invites.error) {
+      loadError.value = (members.error ?? invites.error)?.message ?? 'Failed to load people'
+    }
+    people.value = members.data ?? []
+    pendingInvites.value = invites.data ?? []
     pending.value = false
   }
 
   onMounted(refresh)
 
-  /** Ban or unban a user. Authorization is enforced in the RPC (admin-only). */
+  /** Ban or unban a member. Authorization is enforced in the RPC (admin-only). */
   async function setBlocked(id: string, value: boolean): Promise<void> {
     const { error } = await supabase.rpc('admin_set_blocked', { target_id: id, value })
     if (error) throw error
     await refresh()
   }
 
-  return { people, pending, setBlocked }
+  /** Withdraw a pending invite. RLS allows admins to delete any invite. */
+  async function revokeInvite(email: string): Promise<void> {
+    const { error } = await supabase.from('invites').delete().eq('email', email)
+    if (error) throw error
+    await refresh()
+  }
+
+  return { people, pendingInvites, pending, loadError, setBlocked, revokeInvite }
 }

--- a/app/composables/useAppSettings.ts
+++ b/app/composables/useAppSettings.ts
@@ -1,0 +1,29 @@
+import type { Database } from '~/types/database.types'
+
+/** Admin-tunable app settings (single row). Reading is open; writing is gated to
+ *  admins by RLS — this composable is only used behind the admin page. */
+export function useAppSettings() {
+  const supabase = useSupabaseClient<Database>()
+  const maxInvites = ref<number | null>(null)
+  const pending = ref(true)
+
+  async function refresh(): Promise<void> {
+    const { data } = await supabase.from('app_settings').select('max_invites').eq('id', true).maybeSingle()
+    maxInvites.value = data?.max_invites ?? null
+    pending.value = false
+  }
+
+  onMounted(refresh)
+
+  /** Set the total invite cap (null = unlimited). RLS enforces admin-only. */
+  async function setMaxInvites(value: number | null): Promise<void> {
+    const { error } = await supabase
+      .from('app_settings')
+      .update({ max_invites: value, updated_at: new Date().toISOString() })
+      .eq('id', true)
+    if (error) throw error
+    maxInvites.value = value
+  }
+
+  return { maxInvites, pending, setMaxInvites }
+}

--- a/app/composables/useInvites.ts
+++ b/app/composables/useInvites.ts
@@ -1,0 +1,12 @@
+/** Member-facing invite actions. The server route adds the email to the
+ *  allowlist (RLS + cap enforced there) and sends the e-vite via Resend. */
+export function useInvites() {
+  async function sendInvite(email: string, name?: string): Promise<{ ok: boolean, emailed: boolean }> {
+    return await $fetch('/api/invites/send', {
+      method: 'POST',
+      body: { email, name }
+    })
+  }
+
+  return { sendInvite }
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -2,6 +2,7 @@
 import type { DropdownMenuItem, NavigationMenuItem } from '@nuxt/ui'
 
 const { account, isAdmin, signOutUser } = useAuth()
+const inviteOpen = ref(false)
 
 const links = computed<NavigationMenuItem[]>(() => {
   const items: NavigationMenuItem[] = [
@@ -17,6 +18,7 @@ const userMenu = computed<DropdownMenuItem[][]>(() => [
   [{ label: account.value?.displayName ?? 'Signed in', type: 'label' as const, avatar: { src: account.value?.avatarUrl ?? undefined } }],
   [
     { label: 'Profile', icon: 'i-lucide-user', to: '/profile' },
+    { label: 'Invite a friend', icon: 'i-lucide-user-plus', onSelect: () => { inviteOpen.value = true } },
     ...(isAdmin.value ? [{ label: 'Admin', icon: 'i-lucide-shield', to: '/admin' }] : [])
   ],
   [{ label: 'Sign out', icon: 'i-lucide-log-out', color: 'error' as const, onSelect: () => handleSignOut() }]
@@ -76,5 +78,7 @@ async function handleSignOut(): Promise<void> {
     <UMain>
       <slot />
     </UMain>
+
+    <InviteFriendModal v-model:open="inviteOpen" />
   </div>
 </template>

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -2,6 +2,7 @@
 import type { MovieEvent } from '#shared/types/event'
 import type { BringItem } from '#shared/types/bring'
 import type { Profile } from '#shared/types/user'
+import type { Invite } from '#shared/types/invite'
 
 definePageMeta({ middleware: 'admin' })
 useSeoMeta({ title: 'Admin · BSOTG' })
@@ -9,9 +10,10 @@ useSeoMeta({ title: 'Admin · BSOTG' })
 const toast = useToast()
 const { events } = useEvents()
 const { createEvent, updateEvent, deleteEvent } = useEventAdmin()
-const { people, setBlocked } = useAdminPeople()
+const { people, pendingInvites, loadError, setBlocked, revokeInvite } = useAdminPeople()
 
 const modalOpen = ref(false)
+const inviteOpen = ref(false)
 const editingEvent = ref<MovieEvent | null>(null)
 const eventPendingDelete = ref<MovieEvent | null>(null)
 
@@ -38,7 +40,8 @@ const tabs = [
   { label: 'Events', icon: 'i-lucide-calendar', slot: 'events' },
   { label: 'People', icon: 'i-lucide-users', slot: 'people' },
   { label: 'Suggestions', icon: 'i-lucide-clapperboard', slot: 'suggestions' },
-  { label: 'Bring list', icon: 'i-lucide-utensils', slot: 'bring' }
+  { label: 'Bring list', icon: 'i-lucide-utensils', slot: 'bring' },
+  { label: 'Comms', icon: 'i-lucide-megaphone', slot: 'comms' }
 ]
 
 // --- Overview stats (for the focused event) ---
@@ -144,6 +147,14 @@ async function onUnblock(person: Profile): Promise<void> {
     toast.add({ title: `${person.display_name ?? 'User'} unbanned`, icon: 'i-lucide-check', color: 'success' })
   } catch {
     toast.add({ title: 'Could not unban user', color: 'error' })
+  }
+}
+async function onRevoke(invite: Invite): Promise<void> {
+  try {
+    await revokeInvite(invite.email)
+    toast.add({ title: `Invite to ${invite.email} revoked`, color: 'neutral' })
+  } catch {
+    toast.add({ title: 'Could not revoke invite', color: 'error' })
   }
 }
 </script>
@@ -279,7 +290,34 @@ async function onUnblock(person: Profile): Promise<void> {
 
       <!-- PEOPLE -->
       <template #people>
-        <PeopleList :people="people" @block="onBlock" @unblock="onUnblock" />
+        <div class="space-y-5">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <p class="text-sm text-muted">
+              {{ people.length }} member{{ people.length === 1 ? '' : 's' }}
+              <template v-if="pendingInvites.length">· {{ pendingInvites.length }} pending</template>
+            </p>
+            <UButton label="Invite someone" icon="i-lucide-user-plus" size="sm" @click="inviteOpen = true" />
+          </div>
+
+          <InviteLimitSetting />
+
+          <UAlert
+            v-if="loadError"
+            color="error"
+            variant="subtle"
+            icon="i-lucide-circle-alert"
+            title="Couldn't load the directory"
+            :description="loadError"
+          />
+
+          <PeopleList
+            :people="people"
+            :pending="pendingInvites"
+            @block="onBlock"
+            @unblock="onUnblock"
+            @revoke="onRevoke"
+          />
+        </div>
       </template>
 
       <!-- SUGGESTIONS -->
@@ -379,10 +417,32 @@ async function onUnblock(person: Profile): Promise<void> {
           Select an event to manage its bring list.
         </UCard>
       </template>
+
+      <!-- COMMS -->
+      <template #comms>
+        <p class="text-sm text-muted mb-4">
+          Email an announcement or reminder about an event. Recipients are BCC'd.
+        </p>
+        <USelectMenu
+          v-model="selectedEventId"
+          :items="eventOptions"
+          value-key="value"
+          :search-input="false"
+          placeholder="Select an event"
+          class="w-full sm:max-w-sm mb-4"
+        />
+        <EventAnnounceComposer v-if="selectedEventId" :event-id="selectedEventId" class="max-w-xl" />
+        <UCard v-else variant="subtle" class="text-center text-muted">
+          Select an event to send a blast.
+        </UCard>
+      </template>
     </UTabs>
 
     <!-- Create / edit modal -->
     <EventFormModal v-model:open="modalOpen" :event="editingEvent" @save="onSave" />
+
+    <!-- Admin invite a friend -->
+    <InviteFriendModal v-model:open="inviteOpen" />
 
     <!-- Delete confirmation -->
     <UModal

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,9 +23,14 @@ export default defineNuxtConfig({
   css: ['~/assets/css/main.css'],
 
   runtimeConfig: {
-    // Server-only — never shipped to the browser. Nitro overrides this from
-    // NUXT_TMDB_API_KEY at runtime.
-    tmdbApiKey: ''
+    // Server-only — never shipped to the browser. Nitro overrides these from
+    // the matching NUXT_* env vars at runtime (Product Invariant 2).
+    tmdbApiKey: '',
+    resendApiKey: '',
+    // Verified Resend sender for e-vites / event blasts. Override per env.
+    resendFrom: 'Benteen Screen On The Green <movienight@benteenscreenonthegreen.com>',
+    // Absolute site URL used in email links; falls back to the request origin.
+    siteUrl: ''
   },
 
   compatibilityDate: '2025-01-15',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@tiptap/vue-3": "^3.26.1",
         "dompurify": "^3.4.10",
         "nuxt": "^4.4.8",
+        "resend": "^6.12.4",
         "tailwindcss": "^4.3.1",
         "zod": "^4.0.0"
       },
@@ -5125,6 +5126,12 @@
       "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -10129,6 +10136,12 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -13973,6 +13986,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -14886,6 +14905,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resend": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
+      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/reserved-identifiers": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
@@ -15599,6 +15639,16 @@
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tiptap/vue-3": "^3.26.1",
     "dompurify": "^3.4.10",
     "nuxt": "^4.4.8",
+    "resend": "^6.12.4",
     "tailwindcss": "^4.3.1",
     "zod": "^4.0.0"
   },

--- a/server/api/events/announce.post.ts
+++ b/server/api/events/announce.post.ts
@@ -1,0 +1,80 @@
+import { serverSupabaseServiceRole, serverSupabaseUser } from '#supabase/server'
+import { z } from 'zod'
+import type { Database } from '~/types/database.types'
+
+const bodySchema = z.object({
+  eventId: z.string().uuid(),
+  subject: z.string().trim().max(200).optional(),
+  message: z.string().trim().min(1).max(5000),
+  scope: z.enum(['members', 'going', 'invited'])
+})
+
+/**
+ * Admin event blast: emails members about an event. Admin-gated server-side
+ * (service role checks is_admin) rather than trusting the client. Recipients are
+ * BCC'd so addresses aren't leaked. Resend key is server-only (Invariant 2).
+ *
+ *  - invited: everyone on the allowlist (incl. not-yet-joined)
+ *  - members: people who've actually signed in (accepted invites)
+ *  - going:   people who RSVP'd "going" to this event
+ */
+export default defineEventHandler(async (event) => {
+  const user = await serverSupabaseUser(event)
+  if (!user) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const admin = serverSupabaseServiceRole<Database>(event)
+  const { data: me } = await admin.from('profiles').select('is_admin').eq('id', user.id).single()
+  if (!me?.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) throw createError({ statusCode: 400, statusMessage: 'Invalid announcement' })
+  const { eventId, subject, message, scope } = parsed.data
+
+  const { data: ev } = await admin.from('events').select('title, event_date').eq('id', eventId).single()
+  if (!ev) throw createError({ statusCode: 404, statusMessage: 'Event not found' })
+
+  let emails: string[] = []
+  if (scope === 'invited') {
+    const { data } = await admin.from('invites').select('email')
+    emails = uniqueEmails((data ?? []).map(row => row.email))
+  } else if (scope === 'members') {
+    const { data } = await admin.from('invites').select('email').not('accepted_at', 'is', null)
+    emails = uniqueEmails((data ?? []).map(row => row.email))
+  } else {
+    const { data: going } = await admin
+      .from('rsvps').select('user_id').eq('event_id', eventId).eq('status', 'going')
+    const ids = (going ?? []).map(row => row.user_id)
+    if (ids.length) {
+      const { data: profs } = await admin.from('profiles').select('email').in('id', ids)
+      emails = uniqueEmails((profs ?? []).map(profile => profile.email))
+    }
+  }
+
+  if (!emails.length) return { ok: true, count: 0 }
+
+  const config = useRuntimeConfig(event)
+  if (!config.resendApiKey) throw createError({ statusCode: 500, statusMessage: 'Email is not configured' })
+
+  const mail = buildAnnounceEmail({
+    eventTitle: ev.title,
+    eventDate: ev.event_date ? formatEmailDate(ev.event_date) : null,
+    message,
+    subject,
+    link: `${config.siteUrl || getRequestURL(event).origin}/overview`
+  })
+
+  try {
+    await sendEmail(config.resendApiKey, config.resendFrom, {
+      to: config.resendFrom, // a `to` is required; real recipients are BCC'd
+      bcc: emails,
+      subject: mail.subject,
+      html: mail.html,
+      text: mail.text,
+      replyTo: user.email ?? undefined
+    })
+  } catch (error) {
+    throw createError({ statusCode: 502, statusMessage: error instanceof Error ? error.message : 'Send failed' })
+  }
+
+  return { ok: true, count: emails.length }
+})

--- a/server/api/invites/send.post.ts
+++ b/server/api/invites/send.post.ts
@@ -1,0 +1,77 @@
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server'
+import { z } from 'zod'
+import type { Database } from '~/types/database.types'
+
+const bodySchema = z.object({
+  email: z.string().email().transform(s => s.trim().toLowerCase()),
+  name: z.string().trim().max(120).optional()
+})
+
+/**
+ * Invite a friend: any allowlisted member adds an email to the allowlist and we
+ * send them an e-vite. The insert runs under the member's own session so RLS
+ * (must be allowlisted + not blocked) and the total-invite cap trigger apply —
+ * the route never bypasses the authorization boundary (Invariant 1). The Resend
+ * key stays server-only (Invariant 2).
+ */
+export default defineEventHandler(async (event) => {
+  const user = await serverSupabaseUser(event)
+  if (!user) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) {
+    throw createError({ statusCode: 400, statusMessage: 'A valid email is required' })
+  }
+  const { email, name } = parsed.data
+
+  const client = await serverSupabaseClient<Database>(event)
+  const { error: insertError } = await client.from('invites').insert({
+    email,
+    display_name: name ?? null,
+    invited_by: user.id
+  })
+  // 23505 = already on the allowlist; that's fine, we still (re)send the e-vite.
+  if (insertError && insertError.code !== '23505') {
+    // RLS denial / cap reached / blocked all surface here.
+    throw createError({ statusCode: 403, statusMessage: insertError.message || 'Could not add invite' })
+  }
+
+  // Enrich the e-vite with the next upcoming event, if any (read is RLS-gated).
+  const { data: nextEvent } = await client
+    .from('events')
+    .select('title, event_date')
+    .gte('event_date', new Date().toISOString())
+    .order('event_date', { ascending: true })
+    .limit(1)
+    .maybeSingle()
+
+  const config = useRuntimeConfig(event)
+  if (!config.resendApiKey) {
+    // Allowlisting succeeded; email just isn't configured in this environment.
+    return { ok: true, emailed: false }
+  }
+
+  const meta = user.user_metadata as Record<string, string | undefined> | undefined
+  const inviterName = meta?.full_name ?? meta?.name ?? user.email ?? null
+  const mail = buildInviteEmail({
+    inviterName,
+    link: `${config.siteUrl || getRequestURL(event).origin}/login`,
+    eventTitle: nextEvent?.title ?? null,
+    eventDate: nextEvent?.event_date ? formatEmailDate(nextEvent.event_date) : null
+  })
+
+  try {
+    await sendEmail(config.resendApiKey, config.resendFrom, {
+      to: email,
+      subject: mail.subject,
+      html: mail.html,
+      text: mail.text,
+      replyTo: user.email ?? undefined
+    })
+  } catch {
+    // The person is allowlisted either way — report partial success.
+    throw createError({ statusCode: 502, statusMessage: 'Invited, but the email could not be sent' })
+  }
+
+  return { ok: true, emailed: true }
+})

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -1,0 +1,112 @@
+import { Resend } from 'resend'
+
+/** Escape user-supplied text before it goes into email HTML (no injection). */
+export function escapeHtml(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export interface BuiltEmail {
+  subject: string
+  html: string
+  text: string
+}
+
+/** Human-readable date for email bodies (server-side; no app auto-imports here). */
+export function formatEmailDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })
+}
+
+/** Normalize, lowercase, and de-duplicate a recipient list. */
+export function uniqueEmails(values: Array<string | null | undefined>): string[] {
+  const seen = new Set<string>()
+  for (const value of values) {
+    const email = value?.trim().toLowerCase()
+    if (email) seen.add(email)
+  }
+  return [...seen]
+}
+
+function shell(bodyHtml: string): string {
+  return `<div style="font-family:ui-sans-serif,system-ui,sans-serif;max-width:560px;margin:0 auto;color:#1f2937;line-height:1.5">${bodyHtml}</div>`
+}
+
+function ctaButton(label: string, link: string): string {
+  return `<a href="${escapeHtml(link)}" style="display:inline-block;background:#16a34a;color:#fff;text-decoration:none;padding:10px 18px;border-radius:8px;font-weight:600">${escapeHtml(label)}</a>`
+}
+
+/** "Come join us" invite to a new person (adds nothing — the route does the allowlisting). */
+export function buildInviteEmail(opts: {
+  inviterName: string | null
+  link: string
+  eventTitle?: string | null
+  eventDate?: string | null
+}): BuiltEmail {
+  const inviter = opts.inviterName ? escapeHtml(opts.inviterName) : 'A member'
+  const eventLine = opts.eventTitle
+    ? `<p>First up: <strong>${escapeHtml(opts.eventTitle)}</strong>${opts.eventDate ? ` on ${escapeHtml(opts.eventDate)}` : ''}.</p>`
+    : ''
+  const subject = `${inviter} invited you to Benteen Screen On The Green`
+  const html = shell(
+    `<h1 style="font-size:20px;margin:0 0 12px">You're invited to movie night 🎬</h1>`
+    + `<p>${inviter} added you to <strong>Benteen Screen On The Green</strong> — a group movie-night voting app. It Really Whips the Movie's Ass.</p>`
+    + eventLine
+    + `<p style="margin:20px 0">${ctaButton('Sign in to join', opts.link)}</p>`
+    + `<p style="font-size:13px;color:#6b7280">Sign in with the email this was sent to. If you weren't expecting this, you can ignore it.</p>`
+  )
+  const text = `${inviter} invited you to Benteen Screen On The Green — a group movie-night voting app.`
+    + (opts.eventTitle ? `\n\nFirst up: ${opts.eventTitle}${opts.eventDate ? ` on ${opts.eventDate}` : ''}.` : '')
+    + `\n\nSign in to join: ${opts.link}`
+  return { subject, html, text }
+}
+
+/** Admin announcement / reminder blast about a specific event. */
+export function buildAnnounceEmail(opts: {
+  eventTitle: string
+  eventDate: string | null
+  message: string
+  link: string
+  subject?: string
+}): BuiltEmail {
+  const subject = opts.subject?.trim() || `${opts.eventTitle} — Benteen Screen On The Green`
+  // The admin message is plain text; escape it and preserve line breaks.
+  const messageHtml = escapeHtml(opts.message).replace(/\n/g, '<br>')
+  const html = shell(
+    `<h1 style="font-size:20px;margin:0 0 4px">${escapeHtml(opts.eventTitle)}</h1>`
+    + (opts.eventDate ? `<p style="color:#6b7280;margin:0 0 16px">${escapeHtml(opts.eventDate)}</p>` : '')
+    + `<p>${messageHtml}</p>`
+    + `<p style="margin:20px 0">${ctaButton('View on Benteen Screen', opts.link)}</p>`
+  )
+  const text = `${opts.eventTitle}${opts.eventDate ? ` — ${opts.eventDate}` : ''}\n\n${opts.message}\n\n${opts.link}`
+  return { subject, html, text }
+}
+
+export interface SendParams {
+  to: string | string[]
+  bcc?: string[]
+  subject: string
+  html: string
+  text: string
+  replyTo?: string
+}
+
+/** Thin Resend wrapper — throws on failure so callers map it to an HTTP error. */
+export async function sendEmail(apiKey: string, from: string, params: SendParams): Promise<void> {
+  const resend = new Resend(apiKey)
+  const { error } = await resend.emails.send({
+    from,
+    to: params.to,
+    bcc: params.bcc,
+    subject: params.subject,
+    html: params.html,
+    text: params.text,
+    replyTo: params.replyTo
+  })
+  if (error) throw new Error(error.message || 'Failed to send email')
+}

--- a/test/EventAnnounceComposer.nuxt.test.ts
+++ b/test/EventAnnounceComposer.nuxt.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment nuxt
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import EventAnnounceComposer from '../app/components/EventAnnounceComposer.vue'
+
+const calls: Array<{ url: string, body: unknown }> = []
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+beforeEach(() => {
+  calls.length = 0
+  vi.stubGlobal('$fetch', (url: string, opts: { body: unknown }) => {
+    calls.push({ url, body: opts.body })
+    return Promise.resolve({ ok: true, count: 3 })
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('EventAnnounceComposer', () => {
+  it('posts the announcement for the selected event', async () => {
+    const w = await mountSuspended(EventAnnounceComposer, { props: { eventId: 'e1' } })
+    await w.find('textarea').setValue('Doors at 7')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(calls[0]?.url).toBe('/api/events/announce')
+    expect(calls[0]?.body).toMatchObject({ eventId: 'e1', message: 'Doors at 7', scope: 'members' })
+  })
+
+  it('does not post an empty message', async () => {
+    const w = await mountSuspended(EventAnnounceComposer, { props: { eventId: 'e1' } })
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/test/InviteFriendModal.nuxt.test.ts
+++ b/test/InviteFriendModal.nuxt.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import InviteFriendModal from '../app/components/InviteFriendModal.vue'
+
+const calls: Array<{ email: string, name?: string }> = []
+mockNuxtImport('useInvites', () => () => ({
+  sendInvite: async (email: string, name?: string) => {
+    calls.push({ email, name })
+    return { ok: true, emailed: true }
+  }
+}))
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+// UModal teleports its body to <body>; query the document, not the wrapper.
+function emailInput(): HTMLInputElement | null {
+  return document.querySelector('input[type="email"]')
+}
+function form(): HTMLFormElement | null {
+  return document.querySelector('form')
+}
+
+beforeEach(() => {
+  calls.length = 0
+  document.body.innerHTML = ''
+})
+
+describe('InviteFriendModal', () => {
+  it('sends the invite on submit', async () => {
+    await mountSuspended(InviteFriendModal, { props: { open: true } })
+    await flushPromises()
+    const input = emailInput()
+    expect(input).not.toBeNull()
+    input!.value = 'friend@x.com'
+    input!.dispatchEvent(new Event('input'))
+    await flushPromises()
+    form()!.dispatchEvent(new Event('submit'))
+    await flushPromises()
+    expect(calls[0]?.email).toBe('friend@x.com')
+  })
+
+  it('does not send for an invalid email', async () => {
+    await mountSuspended(InviteFriendModal, { props: { open: true } })
+    await flushPromises()
+    const input = emailInput()
+    input!.value = 'nope'
+    input!.dispatchEvent(new Event('input'))
+    await flushPromises()
+    form()!.dispatchEvent(new Event('submit'))
+    await flushPromises()
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/test/InviteLimitSetting.nuxt.test.ts
+++ b/test/InviteLimitSetting.nuxt.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import InviteLimitSetting from '../app/components/InviteLimitSetting.vue'
+
+let saved: number | null | undefined
+mockNuxtImport('useAppSettings', () => () => ({
+  maxInvites: ref<number | null>(10),
+  setMaxInvites: async (value: number | null) => { saved = value }
+}))
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+beforeEach(() => { saved = undefined })
+
+async function clickSave(w: { findAll: (s: string) => Array<{ text: () => string, trigger: (e: string) => Promise<void> }> }): Promise<void> {
+  const btn = w.findAll('button').find(b => b.text().includes('Save'))
+  await btn?.trigger('click')
+  await flushPromises()
+}
+
+describe('InviteLimitSetting', () => {
+  it('saves a positive number as the cap', async () => {
+    const w = await mountSuspended(InviteLimitSetting)
+    await w.find('input').setValue('50')
+    await clickSave(w)
+    expect(saved).toBe(50)
+  })
+
+  it('treats a blank value as unlimited (null)', async () => {
+    const w = await mountSuspended(InviteLimitSetting)
+    await w.find('input').setValue('')
+    await clickSave(w)
+    expect(saved).toBeNull()
+  })
+})

--- a/test/PeopleList.nuxt.test.ts
+++ b/test/PeopleList.nuxt.test.ts
@@ -9,6 +9,10 @@ const people = [
   { id: 'u3', email: 'carol@x.com', display_name: 'Carol', avatar_url: null, is_admin: true, blocked: false, created_at: '' }
 ]
 
+const pending = [
+  { email: 'pat@x.com', invited_by: null, display_name: 'Pat', created_at: '', accepted_at: null }
+]
+
 describe('PeopleList', () => {
   it('lists every member', async () => {
     const w = await mountSuspended(PeopleList, { props: { people } })
@@ -42,5 +46,32 @@ describe('PeopleList', () => {
     await w.find('input').setValue('bob')
     expect(w.text()).toContain('Bob')
     expect(w.text()).not.toContain('Alice')
+  })
+
+  it('lists pending invites with a Revoke action', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people, pending } })
+    expect(w.text()).toContain('Pat')
+    expect(w.text()).toContain('Pending')
+    expect(w.findAll('button').some(b => b.text().trim() === 'Revoke')).toBe(true)
+  })
+
+  it('emits revoke with the pending invite', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people, pending } })
+    const revoke = w.findAll('button').find(b => b.text().trim() === 'Revoke')
+    await revoke?.trigger('click')
+    expect(w.emitted('revoke')?.[0]).toEqual([pending[0]])
+  })
+
+  it('searches across pending invites too', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people, pending } })
+    await w.find('input').setValue('pat')
+    expect(w.text()).toContain('Pat')
+    expect(w.text()).not.toContain('Alice')
+  })
+
+  it('hides a pending invite that already belongs to a member', async () => {
+    const dupe = [{ email: 'alice@x.com', invited_by: null, display_name: 'Alice Dupe', created_at: '', accepted_at: null }]
+    const w = await mountSuspended(PeopleList, { props: { people, pending: dupe } })
+    expect(w.text()).not.toContain('Alice Dupe')
   })
 })

--- a/test/ShareEvent.nuxt.test.ts
+++ b/test/ShareEvent.nuxt.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import ShareEvent from '../app/components/ShareEvent.vue'
+
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+const event = {
+  id: 'e1',
+  title: 'Jaws',
+  description: '',
+  event_date: '2999-07-15T19:00:00Z',
+  start_time: null,
+  location: null,
+  location_url: null,
+  poster_url: null,
+  created_at: ''
+}
+
+describe('ShareEvent', () => {
+  it('renders social share targets for the event', async () => {
+    const w = await mountSuspended(ShareEvent, { props: { event } })
+    const html = w.html()
+    expect(html).toContain('facebook.com/sharer')
+    expect(html).toContain('twitter.com/intent')
+    expect(html).toContain('wa.me')
+    expect(html).toContain('mailto:')
+  })
+
+  it('offers a copy-link action', async () => {
+    const w = await mountSuspended(ShareEvent, { props: { event } })
+    expect(w.text()).toContain('Copy link')
+  })
+})

--- a/test/email.test.ts
+++ b/test/email.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAnnounceEmail,
+  buildInviteEmail,
+  escapeHtml,
+  formatEmailDate,
+  uniqueEmails
+} from '../server/utils/email'
+
+describe('email utils', () => {
+  it('escapeHtml neutralizes angle brackets and quotes', () => {
+    expect(escapeHtml(`<script>"x"&'`)).toBe('&lt;script&gt;&quot;x&quot;&amp;&#39;')
+  })
+
+  it('buildInviteEmail names the inviter and links to sign in', () => {
+    const m = buildInviteEmail({ inviterName: 'Sam', link: 'https://x/login', eventTitle: 'Jaws', eventDate: 'Friday' })
+    expect(m.subject).toContain('Sam')
+    expect(m.html).toContain('https://x/login')
+    expect(m.html).toContain('Jaws')
+    expect(m.text).toContain('https://x/login')
+  })
+
+  it('buildInviteEmail falls back to "A member" without an inviter name', () => {
+    const m = buildInviteEmail({ inviterName: null, link: 'https://x/login' })
+    expect(m.subject).toContain('A member')
+  })
+
+  it('buildAnnounceEmail escapes the admin message (no HTML injection)', () => {
+    const m = buildAnnounceEmail({ eventTitle: 'Movie', eventDate: null, message: '<img src=x onerror=alert(1)>', link: 'https://x/overview' })
+    expect(m.html).not.toContain('<img')
+    expect(m.html).toContain('&lt;img')
+  })
+
+  it('buildAnnounceEmail honors a custom subject', () => {
+    const m = buildAnnounceEmail({ eventTitle: 'Movie', eventDate: null, message: 'hi', link: 'l', subject: 'Reminder!' })
+    expect(m.subject).toBe('Reminder!')
+  })
+
+  it('uniqueEmails lowercases, trims, and de-duplicates', () => {
+    expect(uniqueEmails([' A@x.com ', 'a@x.com', null, 'b@x.com', undefined, ''])).toEqual(['a@x.com', 'b@x.com'])
+  })
+
+  it('formatEmailDate renders a readable date and tolerates junk', () => {
+    expect(formatEmailDate('2026-07-15T19:00:00Z')).toContain('2026')
+    expect(formatEmailDate('not-a-date')).toBe('')
+  })
+})

--- a/test/useAdminPeople.nuxt.test.ts
+++ b/test/useAdminPeople.nuxt.test.ts
@@ -3,38 +3,68 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
 interface RpcCall { fn: string, args: unknown }
-const calls: { rpc: RpcCall[] } = { rpc: [] }
-let rows: unknown[] = []
+const calls: { rpc: RpcCall[], del: Array<{ col: string, val: unknown }> } = { rpc: [], del: [] }
+let profiles: unknown[] = []
+let invites: unknown[] = []
+let profilesError: { message: string } | null = null
+let invitesError: { message: string } | null = null
+
+function from(table: string) {
+  const data = table === 'profiles' ? profiles : invites
+  const error = table === 'profiles' ? profilesError : invitesError
+  const result = Promise.resolve({ data, error })
+  const chain: Record<string, unknown> = {
+    select: () => chain,
+    order: () => result,
+    is: () => chain,
+    delete: () => chain,
+    eq: (col: string, val: unknown) => { calls.del.push({ col, val }); return Promise.resolve({ error: null }) }
+  }
+  return chain
+}
 
 const supabase = {
-  from() {
-    return { select: () => ({ order: () => Promise.resolve({ data: rows }) }) }
-  },
-  rpc: (fn: string, args: unknown) => {
-    calls.rpc.push({ fn, args })
-    return Promise.resolve({ error: null })
-  }
+  from,
+  rpc: (fn: string, args: unknown) => { calls.rpc.push({ fn, args }); return Promise.resolve({ error: null }) }
 }
 
 mockNuxtImport('useSupabaseClient', () => () => supabase)
 
 beforeEach(() => {
   calls.rpc = []
-  rows = []
+  calls.del = []
+  profiles = []
+  invites = []
+  profilesError = null
+  invitesError = null
 })
 
 describe('useAdminPeople', () => {
-  it('setBlocked bans via the admin RPC, then refreshes the directory', async () => {
-    rows = [{ id: 'u1', email: 'a@x.com', display_name: 'Alice', avatar_url: null, is_admin: false, blocked: true, created_at: '' }]
-    const { people, setBlocked } = useAdminPeople()
-    await setBlocked('u1', true)
-    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_blocked', args: { target_id: 'u1', value: true } })
+  it('loads members and pending invites together', async () => {
+    profiles = [{ id: 'u1', email: 'a@x.com', display_name: 'Alice', avatar_url: null, is_admin: false, blocked: false, created_at: '' }]
+    invites = [{ email: 'pending@x.com', invited_by: 'u1', display_name: 'Pat', created_at: '', accepted_at: null }]
+    const { people, pendingInvites, setBlocked } = useAdminPeople()
+    await setBlocked('u1', true) // triggers refresh()
     expect(people.value).toHaveLength(1)
+    expect(pendingInvites.value).toHaveLength(1)
   })
 
-  it('setBlocked unbans with value=false', async () => {
+  it('surfaces a load error instead of a silent empty list', async () => {
+    invitesError = { message: 'permission denied' }
+    const { loadError, setBlocked } = useAdminPeople()
+    await setBlocked('u1', true)
+    expect(loadError.value).toBe('permission denied')
+  })
+
+  it('setBlocked bans via the admin RPC', async () => {
     const { setBlocked } = useAdminPeople()
-    await setBlocked('u1', false)
-    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_blocked', args: { target_id: 'u1', value: false } })
+    await setBlocked('u1', true)
+    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_blocked', args: { target_id: 'u1', value: true } })
+  })
+
+  it('revokeInvite deletes the invite by email', async () => {
+    const { revokeInvite } = useAdminPeople()
+    await revokeInvite('pending@x.com')
+    expect(calls.del).toContainEqual({ col: 'email', val: 'pending@x.com' })
   })
 })

--- a/test/useAppSettings.nuxt.test.ts
+++ b/test/useAppSettings.nuxt.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+const updates: unknown[] = []
+const supabase = {
+  from() {
+    return {
+      select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { max_invites: 10 } }) }) }),
+      update: (payload: unknown) => { updates.push(payload); return { eq: () => Promise.resolve({ error: null }) } }
+    }
+  }
+}
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+beforeEach(() => { updates.length = 0 })
+
+describe('useAppSettings', () => {
+  it('setMaxInvites updates the singleton and reflects the new value', async () => {
+    const { setMaxInvites, maxInvites } = useAppSettings()
+    await setMaxInvites(50)
+    expect(updates[0]).toMatchObject({ max_invites: 50 })
+    expect(maxInvites.value).toBe(50)
+  })
+
+  it('setMaxInvites can clear the cap (null = unlimited)', async () => {
+    const { setMaxInvites, maxInvites } = useAppSettings()
+    await setMaxInvites(null)
+    expect(updates[0]).toMatchObject({ max_invites: null })
+    expect(maxInvites.value).toBeNull()
+  })
+})

--- a/test/useInvites.nuxt.test.ts
+++ b/test/useInvites.nuxt.test.ts
@@ -1,0 +1,26 @@
+// @vitest-environment nuxt
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface FetchCall { url: string, opts: { method?: string, body?: unknown } }
+const calls: FetchCall[] = []
+
+beforeEach(() => {
+  calls.length = 0
+  vi.stubGlobal('$fetch', (url: string, opts: { method?: string, body?: unknown }) => {
+    calls.push({ url, opts })
+    return Promise.resolve({ ok: true, emailed: true })
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('useInvites', () => {
+  it('POSTs the email and name to the invite endpoint', async () => {
+    const { sendInvite } = useInvites()
+    const res = await sendInvite('a@b.com', 'Al')
+    expect(calls[0]).toMatchObject({
+      url: '/api/invites/send',
+      opts: { method: 'POST', body: { email: 'a@b.com', name: 'Al' } }
+    })
+    expect(res.emailed).toBe(true)
+  })
+})


### PR DESCRIPTION
## Scope

The **e-vite system** (your "we need to work on the e-vite system" ask) plus
member-driven invites and social sharing. Built on the allowlist from #50.

- **Invite a friend (any member).** A new "Invite a friend" item in the user
  menu opens a modal; enter an email (+ optional name) → the friend is added to
  the allowlist and gets a Resend e-vite. Enforced server-side under the
  member's own session, so RLS + the total-invite cap apply (Invariant 1).
- **Share an event to social media.** `EventInfoModal` gains a share row —
  native Web Share plus Facebook / X / WhatsApp / email / copy-link — to drum up
  invitees. (Access stays allowlist-gated; sharing spreads the word, "Invite a
  friend" grants entry.)
- **Admin event blasts (backend).** `POST /api/events/announce` sends an
  announcement/reminder to `members` / `going` / `invited`, BCC'd for privacy,
  admin-gated server-side. *The admin composer UI + the invite-limit setter land
  in the people-directory PR (next), where the admin command center lives.*

> **Stacked on #50** (`feat/invite-only`). Base set accordingly so the diff is
> just the e-vite work.

## Implementation

- `resend` dep; server-only `runtimeConfig.resendApiKey` / `resendFrom`
  (defaults to `movienight@benteenscreenonthegreen.com`) / `siteUrl`; `.env.example`.
- `server/utils/email.ts` — escaped HTML/text builders for invite + announce,
  `formatEmailDate`, `uniqueEmails`, and a thin Resend `sendEmail` wrapper.
- `server/api/invites/send.post.ts` — zod-validated; inserts under the member's
  session (RLS/cap), idempotent on duplicate, enriches the e-vite with the next
  event, then sends. Returns `{ ok, emailed }` (allowlisting still succeeds if
  email isn't configured).
- `server/api/events/announce.post.ts` — service-role `is_admin` check, resolves
  recipients by scope, BCC send.
- Client: `useInvites`, `InviteFriendModal`, `ShareEvent`; wired into the layout
  nav + event modal.

## ⚙️ Required config (out-of-band)

- `NUXT_RESEND_API_KEY` set in the deploy env.
- **`benteenscreenonthegreen.com` verified in Resend** (you chose this sender);
  the from-address is overridable via `NUXT_RESEND_FROM`.

## How to Test

- **Automated:** `email.test.ts` (escaping/injection-safety, templates, dedup,
  date), `useInvites`, `InviteFriendModal` (submit + invalid-email guard),
  `ShareEvent` (share targets). `npm test` → 87 passing; typecheck clean.
- **⚠️ Owed:** server-route integration tests (the handlers need an h3/Supabase
  harness the repo doesn't have yet). Pure logic in the routes is covered via the
  extracted `server/utils/email.ts` helpers; the I/O glue is not.
- **Manual:** with Resend configured — user menu → Invite a friend → enter an
  email → it arrives; open an event → Share → pick a network.

## Invariants & Risk

- **Invariant 1:** invite insert runs under the member's RLS session; announce is
  admin-checked server-side. No policy bypass.
- **Invariant 2:** Resend key is server-only (runtimeConfig, used in `server/**`).
- **Invariant 5:** the admin announcement message is escaped before going into
  email HTML (`buildAnnounceEmail` test asserts no `<img>` injection).
- `EventInfoModal` is also touched by the pending pizza-dough cleanup on #49 —
  changes are in different parts of the file (no expected textual conflict).
