### PR TITLE
feat: people directory + admin invite-limit + event-blast UI (stacked on #52)

### DIFF
--- a/app/components/EventAnnounceComposer.vue
+++ b/app/components/EventAnnounceComposer.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { z } from 'zod'
+import type { FormSubmitEvent } from '@nuxt/ui'
+
+// Admin event blast composer → POST /api/events/announce (admin-gated server-side).
+const props = defineProps<{ eventId: string | undefined }>()
+const toast = useToast()
+const sending = ref(false)
+
+const scopeOptions = [
+  { label: 'Everyone invited', value: 'invited' as const },
+  { label: 'Members (joined)', value: 'members' as const },
+  { label: 'Going to this event', value: 'going' as const }
+]
+type Scope = (typeof scopeOptions)[number]['value']
+
+const schema = z.object({
+  subject: z.string().trim().max(200).optional(),
+  message: z.string().trim().min(1, 'Write a message'),
+  scope: z.enum(['invited', 'members', 'going'])
+})
+const state = reactive<{ subject: string, message: string, scope: Scope }>({
+  subject: '',
+  message: '',
+  scope: 'members'
+})
+
+function messageOf(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'statusMessage' in error) {
+    const m = (error as { statusMessage?: unknown }).statusMessage
+    if (typeof m === 'string') return m
+  }
+  return error instanceof Error ? error.message : undefined
+}
+
+async function onSubmit(event: FormSubmitEvent<{ subject?: string, message: string, scope: Scope }>): Promise<void> {
+  if (!props.eventId) {
+    toast.add({ title: 'Pick an event first', color: 'warning' })
+    return
+  }
+  sending.value = true
+  try {
+    const res = await $fetch<{ ok: boolean, count: number }>('/api/events/announce', {
+      method: 'POST',
+      body: { eventId: props.eventId, subject: event.data.subject || undefined, message: event.data.message, scope: event.data.scope }
+    })
+    toast.add({
+      title: res.count ? `Sent to ${res.count} ${res.count === 1 ? 'person' : 'people'}` : 'No recipients matched',
+      icon: 'i-lucide-send',
+      color: res.count ? 'success' : 'warning'
+    })
+    state.subject = ''
+    state.message = ''
+  } catch (error) {
+    toast.add({ title: 'Could not send the blast', description: messageOf(error), color: 'error' })
+  } finally {
+    sending.value = false
+  }
+}
+</script>
+
+<template>
+  <UForm :schema="schema" :state="state" class="space-y-3" @submit="onSubmit">
+    <UFormField label="Audience" name="scope">
+      <USelectMenu
+        v-model="state.scope"
+        :items="scopeOptions"
+        value-key="value"
+        :search-input="false"
+        class="w-full sm:max-w-xs"
+      />
+    </UFormField>
+    <UFormField label="Subject" name="subject" hint="Optional">
+      <UInput v-model="state.subject" placeholder="Movie night reminder" class="w-full" />
+    </UFormField>
+    <UFormField label="Message" name="message" required>
+      <UTextarea v-model="state.message" :rows="5" placeholder="Doors at 7, first film at 7:30…" class="w-full" />
+    </UFormField>
+    <div class="flex justify-end">
+      <UButton type="submit" label="Send blast" icon="i-lucide-megaphone" :loading="sending" :disabled="!eventId" />
+    </div>
+  </UForm>
+</template>

--- a/app/components/InviteLimitSetting.vue
+++ b/app/components/InviteLimitSetting.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+// Admin control for the total invite cap (app_settings.max_invites). RLS enforces
+// admin-only writes; this lives behind the admin page.
+const { maxInvites, setMaxInvites } = useAppSettings()
+const toast = useToast()
+const draft = ref<number | null>(null)
+const saving = ref(false)
+
+watch(maxInvites, value => { draft.value = value }, { immediate: true })
+
+async function save(): Promise<void> {
+  saving.value = true
+  try {
+    const n = Number(draft.value)
+    const value = Number.isFinite(n) && n > 0 ? Math.floor(n) : null
+    await setMaxInvites(value)
+    draft.value = value
+    toast.add({ title: 'Invite limit saved', icon: 'i-lucide-check', color: 'success' })
+  } catch {
+    toast.add({ title: 'Could not save the limit', color: 'error' })
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <UCard variant="subtle">
+    <div class="flex flex-wrap items-end gap-3">
+      <UFormField label="Total invite limit" hint="Blank = unlimited" class="flex-1 min-w-40">
+        <UInput v-model="draft" type="number" min="0" placeholder="Unlimited" class="w-full" />
+      </UFormField>
+      <UButton label="Save" icon="i-lucide-save" :loading="saving" @click="save" />
+    </div>
+    <p class="text-xs text-muted mt-2">
+      Caps the total number of people on the guest list. Admins are exempt.
+    </p>
+  </UCard>
+</template>

--- a/app/components/PeopleList.vue
+++ b/app/components/PeopleList.vue
@@ -1,71 +1,128 @@
 <script setup lang="ts">
 import type { Profile } from '#shared/types/user'
+import type { Invite } from '#shared/types/invite'
 
-const props = defineProps<{ people: Profile[] }>()
-const emit = defineEmits<{ block: [person: Profile], unblock: [person: Profile] }>()
+const props = withDefaults(
+  defineProps<{ people: Profile[], pending?: Invite[] }>(),
+  { pending: () => [] }
+)
+const emit = defineEmits<{
+  block: [person: Profile]
+  unblock: [person: Profile]
+  revoke: [invite: Invite]
+}>()
+
+type Row =
+  | { kind: 'member', key: string, name: string, email: string, profile: Profile }
+  | { kind: 'pending', key: string, name: string, email: string, invite: Invite }
 
 const query = ref('')
-const filtered = computed(() => {
-  const q = query.value.trim().toLowerCase()
-  if (!q) return props.people
-  return props.people.filter(p =>
-    (p.display_name ?? '').toLowerCase().includes(q) || (p.email ?? '').toLowerCase().includes(q)
-  )
+
+// Pending invites whose email already belongs to a member are redundant — drop them.
+const memberEmails = computed(
+  () => new Set(props.people.map(p => (p.email ?? '').toLowerCase()).filter(Boolean))
+)
+
+const rows = computed<Row[]>(() => {
+  const members: Row[] = props.people.map(p => ({
+    kind: 'member',
+    key: p.id,
+    name: p.display_name ?? 'Unnamed',
+    email: p.email ?? '',
+    profile: p
+  }))
+  const invites: Row[] = props.pending
+    .filter(i => !memberEmails.value.has(i.email.toLowerCase()))
+    .map(i => ({
+      kind: 'pending',
+      key: `invite:${i.email}`,
+      name: i.display_name ?? i.email,
+      email: i.email,
+      invite: i
+    }))
+  return [...members, ...invites]
 })
 
-function initials(p: Profile): string {
-  return (p.display_name ?? p.email ?? '?').slice(0, 2).toUpperCase()
+const filtered = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q) return rows.value
+  return rows.value.filter(r => r.name.toLowerCase().includes(q) || r.email.toLowerCase().includes(q))
+})
+
+function initials(name: string, email: string): string {
+  return (name || email || '?').slice(0, 2).toUpperCase()
 }
 </script>
 
 <template>
   <div class="space-y-3">
-    <UInput v-model="query" icon="i-lucide-search" placeholder="Search members…" class="w-full sm:max-w-xs" />
+    <UInput
+      v-model="query"
+      icon="i-lucide-search"
+      placeholder="Search members…"
+      aria-label="Search members"
+      class="w-full sm:max-w-xs"
+    />
 
     <ul v-if="filtered.length" class="divide-y divide-default rounded-lg ring ring-default overflow-hidden">
       <li
-        v-for="person in filtered"
-        :key="person.id"
+        v-for="row in filtered"
+        :key="row.key"
         class="flex items-center gap-3 p-3"
-        :class="person.blocked ? 'opacity-70' : ''"
+        :class="row.kind === 'member' && row.profile.blocked ? 'opacity-70' : ''"
       >
         <UAvatar
-          :src="person.avatar_url ?? undefined"
-          :alt="person.display_name ?? ''"
-          :text="initials(person)"
+          :src="row.kind === 'member' ? (row.profile.avatar_url ?? undefined) : undefined"
+          :alt="row.name"
+          :text="initials(row.name, row.email)"
           size="sm"
           class="shrink-0"
         />
         <div class="min-w-0 flex-1">
           <p class="font-medium truncate flex items-center gap-1.5">
-            {{ person.display_name ?? 'Unnamed' }}
-            <UBadge v-if="person.is_admin" label="Admin" color="primary" variant="subtle" size="xs" />
-            <UBadge v-if="person.blocked" label="Blocked" color="error" variant="subtle" size="xs" />
+            {{ row.name }}
+            <UBadge v-if="row.kind === 'member' && row.profile.is_admin" label="Admin" color="primary" variant="subtle" size="xs" />
+            <UBadge v-if="row.kind === 'member' && row.profile.blocked" label="Blocked" color="error" variant="subtle" size="xs" />
+            <UBadge v-if="row.kind === 'pending'" label="Pending" color="warning" variant="subtle" size="xs" />
           </p>
           <p class="text-xs text-muted truncate">
-            {{ person.email ?? '—' }}
+            {{ row.email || '—' }}
           </p>
         </div>
-        <!-- Admins can't be banned from the UI (demote via SQL first). -->
+
+        <!-- Member actions: ban/unban (admins can't be banned from the UI). -->
+        <template v-if="row.kind === 'member'">
+          <UButton
+            v-if="row.profile.blocked"
+            label="Unban"
+            icon="i-lucide-user-check"
+            color="neutral"
+            variant="outline"
+            size="xs"
+            class="shrink-0"
+            @click="emit('unblock', row.profile)"
+          />
+          <UButton
+            v-else-if="!row.profile.is_admin"
+            label="Ban"
+            icon="i-lucide-user-x"
+            color="error"
+            variant="outline"
+            size="xs"
+            class="shrink-0"
+            @click="emit('block', row.profile)"
+          />
+        </template>
+        <!-- Pending invite: revoke it. -->
         <UButton
-          v-if="person.blocked"
-          label="Unban"
-          icon="i-lucide-user-check"
+          v-else
+          label="Revoke"
+          icon="i-lucide-x"
           color="neutral"
           variant="outline"
           size="xs"
           class="shrink-0"
-          @click="emit('unblock', person)"
-        />
-        <UButton
-          v-else-if="!person.is_admin"
-          label="Ban"
-          icon="i-lucide-user-x"
-          color="error"
-          variant="outline"
-          size="xs"
-          class="shrink-0"
-          @click="emit('block', person)"
+          @click="emit('revoke', row.invite)"
         />
       </li>
     </ul>

--- a/app/composables/useAdminPeople.ts
+++ b/app/composables/useAdminPeople.ts
@@ -1,29 +1,58 @@
 import type { Database } from '~/types/database.types'
 import type { Profile } from '#shared/types/user'
+import type { Invite } from '#shared/types/invite'
 
-/** Admin people directory: every profile + ban/unban (via the admin-gated RPC). */
+/**
+ * Admin people directory: joined members (profiles) plus pending invites (people
+ * on the allowlist who haven't signed in yet), so the directory is the whole
+ * guest list — searchable, not just whoever happens to have logged in. Members
+ * can be banned/unbanned (admin RPC); pending invites can be revoked.
+ */
 export function useAdminPeople() {
   const supabase = useSupabaseClient<Database>()
   const people = ref<Profile[]>([])
+  const pendingInvites = ref<Invite[]>([])
   const pending = ref(true)
+  const loadError = ref<string | null>(null)
 
   async function refresh(): Promise<void> {
-    const { data } = await supabase
-      .from('profiles')
-      .select('id, email, display_name, avatar_url, is_admin, blocked, created_at')
-      .order('display_name')
-    people.value = data ?? []
+    pending.value = true
+    loadError.value = null
+    const [members, invites] = await Promise.all([
+      supabase
+        .from('profiles')
+        .select('id, email, display_name, avatar_url, is_admin, blocked, created_at')
+        .order('display_name'),
+      supabase
+        .from('invites')
+        .select('email, invited_by, display_name, created_at, accepted_at')
+        .is('accepted_at', null)
+        .order('created_at', { ascending: false })
+    ])
+    // Surface failures instead of silently showing an empty directory.
+    if (members.error || invites.error) {
+      loadError.value = (members.error ?? invites.error)?.message ?? 'Failed to load people'
+    }
+    people.value = members.data ?? []
+    pendingInvites.value = invites.data ?? []
     pending.value = false
   }
 
   onMounted(refresh)
 
-  /** Ban or unban a user. Authorization is enforced in the RPC (admin-only). */
+  /** Ban or unban a member. Authorization is enforced in the RPC (admin-only). */
   async function setBlocked(id: string, value: boolean): Promise<void> {
     const { error } = await supabase.rpc('admin_set_blocked', { target_id: id, value })
     if (error) throw error
     await refresh()
   }
 
-  return { people, pending, setBlocked }
+  /** Withdraw a pending invite. RLS allows admins to delete any invite. */
+  async function revokeInvite(email: string): Promise<void> {
+    const { error } = await supabase.from('invites').delete().eq('email', email)
+    if (error) throw error
+    await refresh()
+  }
+
+  return { people, pendingInvites, pending, loadError, setBlocked, revokeInvite }
 }

--- a/app/composables/useAppSettings.ts
+++ b/app/composables/useAppSettings.ts
@@ -1,0 +1,29 @@
+import type { Database } from '~/types/database.types'
+
+/** Admin-tunable app settings (single row). Reading is open; writing is gated to
+ *  admins by RLS — this composable is only used behind the admin page. */
+export function useAppSettings() {
+  const supabase = useSupabaseClient<Database>()
+  const maxInvites = ref<number | null>(null)
+  const pending = ref(true)
+
+  async function refresh(): Promise<void> {
+    const { data } = await supabase.from('app_settings').select('max_invites').eq('id', true).maybeSingle()
+    maxInvites.value = data?.max_invites ?? null
+    pending.value = false
+  }
+
+  onMounted(refresh)
+
+  /** Set the total invite cap (null = unlimited). RLS enforces admin-only. */
+  async function setMaxInvites(value: number | null): Promise<void> {
+    const { error } = await supabase
+      .from('app_settings')
+      .update({ max_invites: value, updated_at: new Date().toISOString() })
+      .eq('id', true)
+    if (error) throw error
+    maxInvites.value = value
+  }
+
+  return { maxInvites, pending, setMaxInvites }
+}

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -2,6 +2,7 @@
 import type { MovieEvent } from '#shared/types/event'
 import type { BringItem } from '#shared/types/bring'
 import type { Profile } from '#shared/types/user'
+import type { Invite } from '#shared/types/invite'
 
 definePageMeta({ middleware: 'admin' })
 useSeoMeta({ title: 'Admin · BSOTG' })
@@ -9,9 +10,10 @@ useSeoMeta({ title: 'Admin · BSOTG' })
 const toast = useToast()
 const { events } = useEvents()
 const { createEvent, updateEvent, deleteEvent } = useEventAdmin()
-const { people, setBlocked } = useAdminPeople()
+const { people, pendingInvites, loadError, setBlocked, revokeInvite } = useAdminPeople()
 
 const modalOpen = ref(false)
+const inviteOpen = ref(false)
 const editingEvent = ref<MovieEvent | null>(null)
 const eventPendingDelete = ref<MovieEvent | null>(null)
 
@@ -38,7 +40,8 @@ const tabs = [
   { label: 'Events', icon: 'i-lucide-calendar', slot: 'events' },
   { label: 'People', icon: 'i-lucide-users', slot: 'people' },
   { label: 'Suggestions', icon: 'i-lucide-clapperboard', slot: 'suggestions' },
-  { label: 'Bring list', icon: 'i-lucide-utensils', slot: 'bring' }
+  { label: 'Bring list', icon: 'i-lucide-utensils', slot: 'bring' },
+  { label: 'Comms', icon: 'i-lucide-megaphone', slot: 'comms' }
 ]
 
 // --- Overview stats (for the focused event) ---
@@ -144,6 +147,14 @@ async function onUnblock(person: Profile): Promise<void> {
     toast.add({ title: `${person.display_name ?? 'User'} unbanned`, icon: 'i-lucide-check', color: 'success' })
   } catch {
     toast.add({ title: 'Could not unban user', color: 'error' })
+  }
+}
+async function onRevoke(invite: Invite): Promise<void> {
+  try {
+    await revokeInvite(invite.email)
+    toast.add({ title: `Invite to ${invite.email} revoked`, color: 'neutral' })
+  } catch {
+    toast.add({ title: 'Could not revoke invite', color: 'error' })
   }
 }
 </script>
@@ -279,7 +290,34 @@ async function onUnblock(person: Profile): Promise<void> {
 
       <!-- PEOPLE -->
       <template #people>
-        <PeopleList :people="people" @block="onBlock" @unblock="onUnblock" />
+        <div class="space-y-5">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <p class="text-sm text-muted">
+              {{ people.length }} member{{ people.length === 1 ? '' : 's' }}
+              <template v-if="pendingInvites.length">· {{ pendingInvites.length }} pending</template>
+            </p>
+            <UButton label="Invite someone" icon="i-lucide-user-plus" size="sm" @click="inviteOpen = true" />
+          </div>
+
+          <InviteLimitSetting />
+
+          <UAlert
+            v-if="loadError"
+            color="error"
+            variant="subtle"
+            icon="i-lucide-circle-alert"
+            title="Couldn't load the directory"
+            :description="loadError"
+          />
+
+          <PeopleList
+            :people="people"
+            :pending="pendingInvites"
+            @block="onBlock"
+            @unblock="onUnblock"
+            @revoke="onRevoke"
+          />
+        </div>
       </template>
 
       <!-- SUGGESTIONS -->
@@ -379,10 +417,32 @@ async function onUnblock(person: Profile): Promise<void> {
           Select an event to manage its bring list.
         </UCard>
       </template>
+
+      <!-- COMMS -->
+      <template #comms>
+        <p class="text-sm text-muted mb-4">
+          Email an announcement or reminder about an event. Recipients are BCC'd.
+        </p>
+        <USelectMenu
+          v-model="selectedEventId"
+          :items="eventOptions"
+          value-key="value"
+          :search-input="false"
+          placeholder="Select an event"
+          class="w-full sm:max-w-sm mb-4"
+        />
+        <EventAnnounceComposer v-if="selectedEventId" :event-id="selectedEventId" class="max-w-xl" />
+        <UCard v-else variant="subtle" class="text-center text-muted">
+          Select an event to send a blast.
+        </UCard>
+      </template>
     </UTabs>
 
     <!-- Create / edit modal -->
     <EventFormModal v-model:open="modalOpen" :event="editingEvent" @save="onSave" />
+
+    <!-- Admin invite a friend -->
+    <InviteFriendModal v-model:open="inviteOpen" />
 
     <!-- Delete confirmation -->
     <UModal

--- a/test/EventAnnounceComposer.nuxt.test.ts
+++ b/test/EventAnnounceComposer.nuxt.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment nuxt
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import EventAnnounceComposer from '../app/components/EventAnnounceComposer.vue'
+
+const calls: Array<{ url: string, body: unknown }> = []
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+beforeEach(() => {
+  calls.length = 0
+  vi.stubGlobal('$fetch', (url: string, opts: { body: unknown }) => {
+    calls.push({ url, body: opts.body })
+    return Promise.resolve({ ok: true, count: 3 })
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('EventAnnounceComposer', () => {
+  it('posts the announcement for the selected event', async () => {
+    const w = await mountSuspended(EventAnnounceComposer, { props: { eventId: 'e1' } })
+    await w.find('textarea').setValue('Doors at 7')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(calls[0]?.url).toBe('/api/events/announce')
+    expect(calls[0]?.body).toMatchObject({ eventId: 'e1', message: 'Doors at 7', scope: 'members' })
+  })
+
+  it('does not post an empty message', async () => {
+    const w = await mountSuspended(EventAnnounceComposer, { props: { eventId: 'e1' } })
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/test/InviteLimitSetting.nuxt.test.ts
+++ b/test/InviteLimitSetting.nuxt.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import InviteLimitSetting from '../app/components/InviteLimitSetting.vue'
+
+let saved: number | null | undefined
+mockNuxtImport('useAppSettings', () => () => ({
+  maxInvites: ref<number | null>(10),
+  setMaxInvites: async (value: number | null) => { saved = value }
+}))
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+beforeEach(() => { saved = undefined })
+
+async function clickSave(w: { findAll: (s: string) => Array<{ text: () => string, trigger: (e: string) => Promise<void> }> }): Promise<void> {
+  const btn = w.findAll('button').find(b => b.text().includes('Save'))
+  await btn?.trigger('click')
+  await flushPromises()
+}
+
+describe('InviteLimitSetting', () => {
+  it('saves a positive number as the cap', async () => {
+    const w = await mountSuspended(InviteLimitSetting)
+    await w.find('input').setValue('50')
+    await clickSave(w)
+    expect(saved).toBe(50)
+  })
+
+  it('treats a blank value as unlimited (null)', async () => {
+    const w = await mountSuspended(InviteLimitSetting)
+    await w.find('input').setValue('')
+    await clickSave(w)
+    expect(saved).toBeNull()
+  })
+})

--- a/test/PeopleList.nuxt.test.ts
+++ b/test/PeopleList.nuxt.test.ts
@@ -9,6 +9,10 @@ const people = [
   { id: 'u3', email: 'carol@x.com', display_name: 'Carol', avatar_url: null, is_admin: true, blocked: false, created_at: '' }
 ]
 
+const pending = [
+  { email: 'pat@x.com', invited_by: null, display_name: 'Pat', created_at: '', accepted_at: null }
+]
+
 describe('PeopleList', () => {
   it('lists every member', async () => {
     const w = await mountSuspended(PeopleList, { props: { people } })
@@ -42,5 +46,32 @@ describe('PeopleList', () => {
     await w.find('input').setValue('bob')
     expect(w.text()).toContain('Bob')
     expect(w.text()).not.toContain('Alice')
+  })
+
+  it('lists pending invites with a Revoke action', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people, pending } })
+    expect(w.text()).toContain('Pat')
+    expect(w.text()).toContain('Pending')
+    expect(w.findAll('button').some(b => b.text().trim() === 'Revoke')).toBe(true)
+  })
+
+  it('emits revoke with the pending invite', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people, pending } })
+    const revoke = w.findAll('button').find(b => b.text().trim() === 'Revoke')
+    await revoke?.trigger('click')
+    expect(w.emitted('revoke')?.[0]).toEqual([pending[0]])
+  })
+
+  it('searches across pending invites too', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people, pending } })
+    await w.find('input').setValue('pat')
+    expect(w.text()).toContain('Pat')
+    expect(w.text()).not.toContain('Alice')
+  })
+
+  it('hides a pending invite that already belongs to a member', async () => {
+    const dupe = [{ email: 'alice@x.com', invited_by: null, display_name: 'Alice Dupe', created_at: '', accepted_at: null }]
+    const w = await mountSuspended(PeopleList, { props: { people, pending: dupe } })
+    expect(w.text()).not.toContain('Alice Dupe')
   })
 })

--- a/test/useAdminPeople.nuxt.test.ts
+++ b/test/useAdminPeople.nuxt.test.ts
@@ -3,38 +3,68 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
 interface RpcCall { fn: string, args: unknown }
-const calls: { rpc: RpcCall[] } = { rpc: [] }
-let rows: unknown[] = []
+const calls: { rpc: RpcCall[], del: Array<{ col: string, val: unknown }> } = { rpc: [], del: [] }
+let profiles: unknown[] = []
+let invites: unknown[] = []
+let profilesError: { message: string } | null = null
+let invitesError: { message: string } | null = null
+
+function from(table: string) {
+  const data = table === 'profiles' ? profiles : invites
+  const error = table === 'profiles' ? profilesError : invitesError
+  const result = Promise.resolve({ data, error })
+  const chain: Record<string, unknown> = {
+    select: () => chain,
+    order: () => result,
+    is: () => chain,
+    delete: () => chain,
+    eq: (col: string, val: unknown) => { calls.del.push({ col, val }); return Promise.resolve({ error: null }) }
+  }
+  return chain
+}
 
 const supabase = {
-  from() {
-    return { select: () => ({ order: () => Promise.resolve({ data: rows }) }) }
-  },
-  rpc: (fn: string, args: unknown) => {
-    calls.rpc.push({ fn, args })
-    return Promise.resolve({ error: null })
-  }
+  from,
+  rpc: (fn: string, args: unknown) => { calls.rpc.push({ fn, args }); return Promise.resolve({ error: null }) }
 }
 
 mockNuxtImport('useSupabaseClient', () => () => supabase)
 
 beforeEach(() => {
   calls.rpc = []
-  rows = []
+  calls.del = []
+  profiles = []
+  invites = []
+  profilesError = null
+  invitesError = null
 })
 
 describe('useAdminPeople', () => {
-  it('setBlocked bans via the admin RPC, then refreshes the directory', async () => {
-    rows = [{ id: 'u1', email: 'a@x.com', display_name: 'Alice', avatar_url: null, is_admin: false, blocked: true, created_at: '' }]
-    const { people, setBlocked } = useAdminPeople()
-    await setBlocked('u1', true)
-    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_blocked', args: { target_id: 'u1', value: true } })
+  it('loads members and pending invites together', async () => {
+    profiles = [{ id: 'u1', email: 'a@x.com', display_name: 'Alice', avatar_url: null, is_admin: false, blocked: false, created_at: '' }]
+    invites = [{ email: 'pending@x.com', invited_by: 'u1', display_name: 'Pat', created_at: '', accepted_at: null }]
+    const { people, pendingInvites, setBlocked } = useAdminPeople()
+    await setBlocked('u1', true) // triggers refresh()
     expect(people.value).toHaveLength(1)
+    expect(pendingInvites.value).toHaveLength(1)
   })
 
-  it('setBlocked unbans with value=false', async () => {
+  it('surfaces a load error instead of a silent empty list', async () => {
+    invitesError = { message: 'permission denied' }
+    const { loadError, setBlocked } = useAdminPeople()
+    await setBlocked('u1', true)
+    expect(loadError.value).toBe('permission denied')
+  })
+
+  it('setBlocked bans via the admin RPC', async () => {
     const { setBlocked } = useAdminPeople()
-    await setBlocked('u1', false)
-    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_blocked', args: { target_id: 'u1', value: false } })
+    await setBlocked('u1', true)
+    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_blocked', args: { target_id: 'u1', value: true } })
+  })
+
+  it('revokeInvite deletes the invite by email', async () => {
+    const { revokeInvite } = useAdminPeople()
+    await revokeInvite('pending@x.com')
+    expect(calls.del).toContainEqual({ col: 'email', val: 'pending@x.com' })
   })
 })

--- a/test/useAppSettings.nuxt.test.ts
+++ b/test/useAppSettings.nuxt.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+const updates: unknown[] = []
+const supabase = {
+  from() {
+    return {
+      select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { max_invites: 10 } }) }) }),
+      update: (payload: unknown) => { updates.push(payload); return { eq: () => Promise.resolve({ error: null }) } }
+    }
+  }
+}
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+beforeEach(() => { updates.length = 0 })
+
+describe('useAppSettings', () => {
+  it('setMaxInvites updates the singleton and reflects the new value', async () => {
+    const { setMaxInvites, maxInvites } = useAppSettings()
+    await setMaxInvites(50)
+    expect(updates[0]).toMatchObject({ max_invites: 50 })
+    expect(maxInvites.value).toBe(50)
+  })
+
+  it('setMaxInvites can clear the cap (null = unlimited)', async () => {
+    const { setMaxInvites, maxInvites } = useAppSettings()
+    await setMaxInvites(null)
+    expect(updates[0]).toMatchObject({ max_invites: null })
+    expect(maxInvites.value).toBeNull()
+  })
+})


### PR DESCRIPTION
## Scope

The admin command center round-out: fixes the "search does nothing" directory
and adds the admin controls for the e-vite system.

- **People search now has people to find.** The directory only listed profiles
  of people who'd already signed in — so searching felt broken. It now shows
  **members + pending invites** (allowlist entries not yet accepted) in one
  searchable list, and surfaces load errors instead of failing to an empty list.
- **Admin sets the total invite limit** (your ask). A control in the People tab
  writes `app_settings.max_invites` (null = unlimited); RLS keeps writes
  admin-only and the cap trigger from #50 enforces it.
- **Event blasts** get a UI. A new **Comms** tab composes subject/message/
  audience and posts to the `/api/events/announce` route from #52.
- **Invite someone** button in the People tab (reuses `InviteFriendModal`).

> **Stacked on #52** (`feat/evite`), which is stacked on #50. Review/merge order:
> #50 → #52 → this. Base is set to `feat/evite`.

## Implementation

- `useAdminPeople`: parallel-loads profiles + pending invites, exposes
  `loadError`, adds `revokeInvite(email)` (admin delete per RLS).
- `PeopleList`: one searchable list of members (ban/unban) + pending invites
  (Pending badge, Revoke), de-duping a pending invite that's already a member.
  Existing `:people` prop unchanged (back-compat).
- `useAppSettings` + `InviteLimitSetting` for the cap; `EventAnnounceComposer`
  for blasts; both wired into `admin.vue` (People tab + new Comms tab).

## How to Test

- **Automated:** updated `useAdminPeople` (loads members + pending, error
  surfaced, revoke) and `PeopleList` (pending badge/revoke, search across
  invites, member de-dupe); new `useAppSettings`, `InviteLimitSetting`,
  `EventAnnounceComposer`. `npm test` → 99 passing; typecheck clean.
- **Manual:** Admin → People → search finds invited-but-not-joined people; set
  a limit and save; revoke a pending invite. Admin → Comms → pick an event,
  write a message, send (needs Resend configured, per #52).

## Invariants & Risk

- **Invariant 1:** invite-limit writes and invite reads are RLS-gated
  (`app_settings` admin-only update; `invites` read = allowlisted). Revoke uses
  the admin delete policy. The blast route is admin-checked server-side (#52).
- No client write of `is_admin`/`blocked` beyond the existing admin RPC
  (Invariant 4 intact).
