### PR TITLE
fix: invite gate fails open on is_allowed RPC error (prod lockout hotfix)

### DIFF
--- a/app/middleware/invited.global.ts
+++ b/app/middleware/invited.global.ts
@@ -17,13 +17,21 @@ export default defineNuxtRouteMiddleware(async (to) => {
   const allowed = useState<boolean | null>('is-allowed', () => null)
   if (allowed.value === null) {
     const { data, error } = await supabase.rpc('is_allowed')
-    allowed.value = !error && (data ?? false)
+    if (error) {
+      // Couldn't determine allow-status (e.g. the is_allowed function/migration
+      // isn't present yet, or a transient RPC failure). This gate is UX only —
+      // RLS is the real boundary (Invariant 1) — so we must NOT lock everyone out
+      // on an infra hiccup. Let the user through; RLS still governs their data.
+      console.warn('[invited] is_allowed check failed; allowing through (RLS still enforces access):', error.message)
+      return
+    }
+    allowed.value = data ?? false
   }
   if (allowed.value) return
 
-  // Clear the cached verdict before signing out so a *different* user signing in
-  // later in the same SPA session (e.g. email/password, which doesn't reload the
-  // page) is re-checked rather than inheriting this stale "denied".
+  // Explicit deny. Clear the cached verdict before signing out so a *different*
+  // user signing in later in the same SPA session (e.g. email/password, which
+  // doesn't reload the page) is re-checked rather than inheriting this stale deny.
   allowed.value = null
   await supabase.auth.signOut()
   return navigateTo('/request-access')

--- a/test/invited-middleware.nuxt.test.ts
+++ b/test/invited-middleware.nuxt.test.ts
@@ -78,13 +78,16 @@ describe('invited.global middleware', () => {
     expect(useState('is-allowed').value).toBeNull()
   })
 
-  it('treats an RPC error as not allowed (fails closed)', async () => {
+  it('fails OPEN on an RPC error (UX gate must not lock everyone out; RLS still enforces)', async () => {
     state.user.value = { id: 'u1' }
     state.rpcData = null
-    state.rpcError = { message: 'boom' }
+    state.rpcError = { message: 'function is_allowed does not exist' }
     await run('/overview')
-    expect(state.signOutCalls).toBe(1)
-    expect(state.navigatedTo).toBe('/request-access')
+    // No sign-out, no redirect — the user proceeds; RLS governs their data.
+    expect(state.signOutCalls).toBe(0)
+    expect(state.navigatedTo).toBeNull()
+    // And the verdict isn't cached, so a later (recovered) navigation re-checks.
+    expect(useState('is-allowed').value).toBeNull()
   })
 
   it('caches the verdict so a second navigation skips the RPC', async () => {


### PR DESCRIPTION
## Scope — production hotfix

Existing users (including an **admin**) are stuck in a redirect loop to
`/request-access` and can't get into the app.

**Root cause:** the invite gate (`invited.global.ts`) failed **closed** when the
`is_allowed()` RPC errored — and it errors when the **#50 migration hasn't been
applied to the database the deployed app talks to** (the function doesn't exist
there yet). So instead of "couldn't check → let them in (RLS still protects
data)", it did "couldn't check → sign out + redirect" for *everyone*.

A UX-layer gate must never be able to lock everyone out — **RLS is the real
boundary (Invariant 1)**, the middleware is only a convenience.

## Fix

- `is_allowed` **RPC error → fail open** (proceed; log a warning). RLS still
  governs what the user can actually read/write.
- Explicit `is_allowed = false` → still deny (sign out → `/request-access`).

So admins and grandfathered users (always `true` via `is_admin` + the seed) are
unaffected, and an infra/migration hiccup can no longer override that.

## ⚠️ You still need to apply the #50 migration to prod

This stops the lockout, but the invite gate only actually *enforces* once the DB
has the migration. Apply it to the production Supabase:

```
supabase db push          # against the linked prod project
```
or paste `supabase/migrations/20260618000000_invite_only.sql` +
`20260618010000_service_role_grants.sql` into the dashboard SQL editor.

Quick check it's there (SQL editor): `select public.is_allowed();` should return
`t`/`f`, not "function does not exist". The seed grandfathers **every existing
profile** onto the allowlist, so current members keep access.

## Tests

`test/invited-middleware.nuxt.test.ts` updated: the former "fails closed on error"
case now asserts **fail-open** (no sign-out/redirect, verdict not cached so a
recovered nav re-checks). 7/7 pass; typecheck clean.

## Invariants

Invariant 1 reinforced: the middleware can no longer override RLS by locking
users out when it can't reach its (non-authoritative) check.
