### PR TITLE
ci: auto-apply Supabase migrations to prod on merge

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,49 @@
+name: Deploy DB migrations
+
+# Applies new Supabase migrations to the production database when they land on
+# main, so the app and its schema ship together (the #54 lockout happened because
+# app code went live while the migration hadn't been applied to the prod DB).
+#
+# Required repo secrets (Settings → Secrets and variables → Actions):
+#   SUPABASE_ACCESS_TOKEN  — personal access token (supabase.com → Account → Access Tokens)
+#   SUPABASE_PROJECT_REF   — the prod project ref (the <ref> in <ref>.supabase.co)
+#   SUPABASE_DB_PASSWORD   — the prod database password
+#
+# `supabase db push` is idempotent: it only applies migrations missing from the
+# remote schema_migrations history, so re-runs are safe. (If a migration was once
+# applied by hand via the dashboard, mark it applied with
+# `supabase migration repair --status applied <version>` so push skips it.)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/migrations/**'
+  workflow_dispatch:
+
+# Never run two migration pushes concurrently, and never cancel one mid-apply.
+concurrency:
+  group: db-migrate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Push migrations to production
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          supabase link --project-ref "${{ secrets.SUPABASE_PROJECT_REF }}"
+          supabase db push


### PR DESCRIPTION
## Scope

App + DB now ship together. On merge to `main`, if anything under
`supabase/migrations/**` changed, a workflow runs `supabase db push` against
production — so the schema is applied with the deploy instead of being a manual
step that's easy to forget (exactly what caused the #54 lockout).

## How it works

- Triggers on `push` to `main` filtered to `supabase/migrations/**` (plus manual
  `workflow_dispatch`).
- `concurrency: db-migrate`, `cancel-in-progress: false` — never two pushes at
  once, never cancelled mid-apply.
- `supabase db push` is idempotent (only applies migrations missing from the
  remote history), so re-runs are safe.

## ⚙️ Required before this works — add 3 repo secrets

**Settings → Secrets and variables → Actions:**
| Secret | Where to get it |
|--------|-----------------|
| `SUPABASE_ACCESS_TOKEN` | supabase.com → Account → Access Tokens |
| `SUPABASE_PROJECT_REF` | your prod project ref (`<ref>.supabase.co`) |
| `SUPABASE_DB_PASSWORD` | prod database password |

## Pairs with #54

This Action runs alongside Vercel's deploy, so the app could briefly come up
before the migration finishes — but with #54 the gate **fails open** on an
`is_allowed` error during that window, so there's no lockout. Together they make
app/DB drift self-healing.

> Note: if you applied the current migration by hand via the dashboard (not via
> `supabase db push`), run `supabase migration repair --status applied
> 20260618000000 20260618010000` once so push doesn't try to re-apply it.

## Test plan

CI infra only — no app code. Validate by merging, then watching the workflow
run green in the Actions tab (or trigger `workflow_dispatch` manually).
