### PR TITLE
feat: email/password + Facebook sign-in (+ working password reset) — replaces #51

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -51,18 +51,26 @@ export function useAuth() {
     if (error) throw error
   }
 
-  async function signUpWithEmail(email: string, password: string): Promise<void> {
-    const { error } = await supabase.auth.signUp({
+  // Returns whether a confirmation email is pending. With email confirmation on,
+  // signUp returns no session (the user must confirm first); with it off, a live
+  // session comes back and they're signed in immediately — the caller branches
+  // on this so it never tells a signed-in user to "check your inbox".
+  async function signUpWithEmail(email: string, password: string): Promise<{ needsConfirmation: boolean }> {
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: { emailRedirectTo: callbackUrl() }
     })
     if (error) throw error
+    return { needsConfirmation: !data.session }
   }
 
+  // The recovery link lands on /reset-password (a public page that sets the new
+  // password), not /confirm — /confirm would just bounce the recovery session
+  // straight into the app without ever changing the password.
   async function sendPasswordReset(email: string): Promise<void> {
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: callbackUrl()
+      redirectTo: `${window.location.origin}/reset-password`
     })
     if (error) throw error
   }

--- a/app/middleware/invited.global.ts
+++ b/app/middleware/invited.global.ts
@@ -4,7 +4,7 @@ import type { Database } from '~/types/database.types'
 // module already bounces *unauthenticated* users to /login; this catches users
 // who are authenticated but whose email isn't on the allowlist (public.invites):
 // it ends their session and sends them to /request-access.
-const PUBLIC_PATHS = new Set(['/', '/about', '/login', '/confirm', '/request-access'])
+const PUBLIC_PATHS = new Set(['/', '/about', '/login', '/confirm', '/request-access', '/reset-password'])
 
 export default defineNuxtRouteMiddleware(async (to) => {
   if (PUBLIC_PATHS.has(to.path)) return

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -58,13 +58,18 @@ async function onSubmit(event: FormSubmitEvent<{ email: string, password: string
   const { email, password } = event.data
   try {
     if (mode.value === 'signup') {
-      await signUpWithEmail(email, password)
-      toast.add({
-        title: 'Check your email',
-        description: 'Confirm your address to finish signing up.',
-        color: 'success',
-        icon: 'i-lucide-mail-check'
-      })
+      const { needsConfirmation } = await signUpWithEmail(email, password)
+      if (needsConfirmation) {
+        // Email confirmation is on — there's no session yet; tell them to confirm.
+        toast.add({
+          title: 'Check your email',
+          description: 'Confirm your address to finish signing up.',
+          color: 'success',
+          icon: 'i-lucide-mail-check'
+        })
+      }
+      // Otherwise a session came back: the user is signed in and watchEffect
+      // routes them onward — no "check your inbox" prompt.
     } else {
       await signInWithEmail(email, password)
       // On success the user populates and watchEffect routes to /overview.
@@ -155,13 +160,22 @@ async function onForgotPassword(): Promise<void> {
           />
         </UForm>
 
-        <div class="w-full flex items-center justify-between text-sm">
-          <button type="button" class="text-primary hover:underline" @click="mode = mode === 'signup' ? 'signin' : 'signup'">
-            {{ mode === 'signup' ? 'Have an account? Sign in' : 'New here? Create an account' }}
-          </button>
-          <button v-if="mode === 'signin'" type="button" class="text-muted hover:underline" @click="onForgotPassword">
-            Forgot password?
-          </button>
+        <div class="w-full flex items-center justify-between gap-2">
+          <UButton
+            variant="link"
+            color="primary"
+            class="px-0"
+            :label="mode === 'signup' ? 'Have an account? Sign in' : 'New here? Create an account'"
+            @click="mode = mode === 'signup' ? 'signin' : 'signup'"
+          />
+          <UButton
+            v-if="mode === 'signin'"
+            variant="link"
+            color="neutral"
+            class="px-0"
+            label="Forgot password?"
+            @click="onForgotPassword"
+          />
         </div>
 
         <p class="text-xs text-dimmed">

--- a/app/pages/reset-password.vue
+++ b/app/pages/reset-password.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { z } from 'zod'
+import type { FormSubmitEvent } from '@nuxt/ui'
+
+// Landing page for the password-recovery link. The recovery token establishes a
+// session (handled by the Supabase module); here the user actually sets a new
+// password via updateUser, then continues into the app. Public + layout-less so
+// the invite gate and app shell don't interfere with the recovery session.
+definePageMeta({ layout: false })
+useSeoMeta({ title: 'Reset password · BSOTG' })
+
+const supabase = useSupabaseClient()
+const toast = useToast()
+const submitting = ref(false)
+
+const schema = z.object({
+  password: z.string().min(8, 'At least 8 characters')
+})
+const state = reactive({ password: '' })
+
+async function onSubmit(event: FormSubmitEvent<{ password: string }>): Promise<void> {
+  submitting.value = true
+  try {
+    const { error } = await supabase.auth.updateUser({ password: event.data.password })
+    if (error) throw error
+    toast.add({ title: 'Password updated', icon: 'i-lucide-check', color: 'success' })
+    await navigateTo('/overview')
+  } catch (error) {
+    toast.add({
+      title: 'Could not update your password',
+      description: error instanceof Error ? error.message : 'The link may have expired — request a new one.',
+      icon: 'i-lucide-circle-alert',
+      color: 'error'
+    })
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-500/10 via-default to-primary-500/5 px-4 py-10">
+    <UCard class="w-full max-w-md">
+      <div class="flex flex-col items-center text-center gap-4 py-2">
+        <img src="/img/logo.png" alt="Benteen Screen On The Green" class="h-16 w-auto">
+        <div>
+          <h1 class="text-2xl font-bold">
+            Set a new password
+          </h1>
+          <p class="mt-1 text-muted">
+            Choose a new password for your account.
+          </p>
+        </div>
+
+        <UForm :schema="schema" :state="state" class="w-full space-y-3 text-left" @submit="onSubmit">
+          <UFormField label="New password" name="password">
+            <UInput v-model="state.password" type="password" autocomplete="new-password" placeholder="••••••••" class="w-full" />
+          </UFormField>
+          <UButton type="submit" label="Update password" size="lg" block :loading="submitting" />
+        </UForm>
+
+        <UButton to="/login" color="neutral" variant="link" label="Back to sign in" />
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -47,9 +47,10 @@ export default defineNuxtConfig({
     redirectOptions: {
       login: '/login',
       callback: '/confirm',
-      // /request-access is shown to signed-out, non-invited users (the
-      // invite-only gate lives in RLS + middleware/invited.global.ts).
-      exclude: ['/', '/about', '/request-access']
+      // /request-access is shown to signed-out, non-invited users; /reset-password
+      // handles the recovery link. The invite-only gate lives in RLS +
+      // middleware/invited.global.ts.
+      exclude: ['/', '/about', '/request-access', '/reset-password']
     }
   }
 })

--- a/test/login.nuxt.test.ts
+++ b/test/login.nuxt.test.ts
@@ -11,8 +11,8 @@ const auth = {
   signInWithGoogle: async () => { calls.push('google') },
   signInWithFacebook: async () => { calls.push('facebook') },
   signInWithEmail: async (email: string) => { calls.push(`email:${email}`) },
-  signUpWithEmail: async (email: string) => { calls.push(`signup:${email}`) },
-  sendPasswordReset: async () => { calls.push('reset') }
+  signUpWithEmail: async (email: string) => { calls.push(`signup:${email}`); return { needsConfirmation: true } },
+  sendPasswordReset: async (email: string) => { calls.push(`reset:${email}`) }
 }
 
 mockNuxtImport('useAuth', () => () => auth)
@@ -64,5 +64,14 @@ describe('login page', () => {
     await w.find('form').trigger('submit')
     await flushPromises()
     expect(calls).toContain('signup:new@b.com')
+  })
+
+  it('sends a reset link from the forgot-password action', async () => {
+    const w = await mountSuspended(LoginPage)
+    await w.find('input[type="email"]').setValue('a@b.com')
+    const forgot = w.findAll('button').find(b => b.text().includes('Forgot password'))
+    await forgot?.trigger('click')
+    await flushPromises()
+    expect(calls).toContain('reset:a@b.com')
   })
 })

--- a/test/reset-password.nuxt.test.ts
+++ b/test/reset-password.nuxt.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import ResetPasswordPage from '../app/pages/reset-password.vue'
+
+const updateCalls: Array<{ password: string }> = []
+let navTarget: string | null = null
+
+mockNuxtImport('useSupabaseClient', () => () => ({
+  auth: {
+    updateUser: async (args: { password: string }) => { updateCalls.push(args); return { error: null } }
+  }
+}))
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+mockNuxtImport('navigateTo', () => (to: string) => { navTarget = to; return to })
+
+beforeEach(() => {
+  updateCalls.length = 0
+  navTarget = null
+})
+
+describe('reset-password page', () => {
+  it('sets the new password and continues into the app', async () => {
+    const w = await mountSuspended(ResetPasswordPage)
+    await w.find('input[type="password"]').setValue('newsecret8')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(updateCalls[0]?.password).toBe('newsecret8')
+    expect(navTarget).toBe('/overview')
+  })
+
+  it('does not submit a too-short password', async () => {
+    const w = await mountSuspended(ResetPasswordPage)
+    await w.find('input[type="password"]').setValue('short')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(updateCalls).toHaveLength(0)
+  })
+})

--- a/test/useAuth.nuxt.test.ts
+++ b/test/useAuth.nuxt.test.ts
@@ -6,11 +6,12 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 interface Call { fn: string, args: unknown[] }
 const calls: Call[] = []
 let nextError: Error | null = null
+let nextSession: unknown = null // what signUp returns as data.session
 
 const auth = {
   signInWithOAuth: (args: unknown) => { calls.push({ fn: 'signInWithOAuth', args: [args] }); return Promise.resolve({ error: nextError }) },
   signInWithPassword: (args: unknown) => { calls.push({ fn: 'signInWithPassword', args: [args] }); return Promise.resolve({ error: nextError }) },
-  signUp: (args: unknown) => { calls.push({ fn: 'signUp', args: [args] }); return Promise.resolve({ error: nextError }) },
+  signUp: (args: unknown) => { calls.push({ fn: 'signUp', args: [args] }); return Promise.resolve({ data: { session: nextSession }, error: nextError }) },
   resetPasswordForEmail: (email: string, opts: unknown) => { calls.push({ fn: 'resetPasswordForEmail', args: [email, opts] }); return Promise.resolve({ error: nextError }) },
   signOut: () => { calls.push({ fn: 'signOut', args: [] }); return Promise.resolve({ error: null }) }
 }
@@ -21,6 +22,7 @@ mockNuxtImport('useSupabaseUser', () => () => ref(null))
 beforeEach(() => {
   calls.length = 0
   nextError = null
+  nextSession = null
 })
 
 describe('useAuth providers', () => {
@@ -51,10 +53,23 @@ describe('useAuth providers', () => {
     expect(arg.options.emailRedirectTo).toContain('/confirm')
   })
 
-  it('sendPasswordReset calls resetPasswordForEmail', async () => {
+  it('signUpWithEmail reports needsConfirmation when no session comes back', async () => {
+    nextSession = null
+    const res = await useAuth().signUpWithEmail('a@b.com', 'pw12345678')
+    expect(res.needsConfirmation).toBe(true)
+  })
+
+  it('signUpWithEmail reports no confirmation needed when a session is returned', async () => {
+    nextSession = { access_token: 'x' }
+    const res = await useAuth().signUpWithEmail('a@b.com', 'pw12345678')
+    expect(res.needsConfirmation).toBe(false)
+  })
+
+  it('sendPasswordReset sends the recovery link to /reset-password', async () => {
     await useAuth().sendPasswordReset('a@b.com')
     expect(calls[0].fn).toBe('resetPasswordForEmail')
     expect(calls[0].args[0]).toBe('a@b.com')
+    expect((calls[0].args[1] as { redirectTo: string }).redirectTo).toContain('/reset-password')
   })
 
   it('surfaces supabase auth errors by throwing', async () => {


### PR DESCRIPTION
## Scope

Email/password sign-up + Facebook sign-in beyond Google, **invite-gated** like
everything else.

> Replaces **#51**, which GitHub auto-marked "merged" when its base
> (`feat/invite-only`) was deleted on #50's merge — the code never actually
> reached `main`. Same branch, now correctly based on `main`, with the #51 review
> fixes folded in.

- **Email + password** — sign-in / sign-up toggle with a **working**
  forgot-password reset.
- **Facebook** — "Continue with Facebook" OAuth alongside Google.
- All paths still flow through the invite-only gate after auth.

## Implementation

- `useAuth`: `signInWithFacebook`, `signInWithEmail`, `signUpWithEmail`,
  `sendPasswordReset` (OAuth DRY'd into one `oauth()` helper); errors throw.
- `login.vue`: both OAuth buttons + a zod-validated email/password form.

## Review fixes from #51 (all addressed)

- 🔴 **Forgot-password is no longer a dead-end.** New `/reset-password` page calls
  `updateUser({ password })` then continues; `sendPasswordReset` targets it
  (not `/confirm`, which just bounced the recovery session into the app); added
  to the invite gate's `PUBLIC_PATHS` + the Supabase redirect `exclude`.
- 🟡 **Sign-up toast keyed on session.** `signUpWithEmail` returns
  `{ needsConfirmation }`; the "check your email" toast only shows when
  confirmation is actually pending (otherwise the user is signed in and routed
  on).
- 🟡 **Link-style auth toggles.** Mode toggle + forgot-password are now
  `UButton variant="link"` (focus rings, Nuxt UI convention).

## ⚙️ Required Supabase dashboard config (out-of-band)

1. Auth → Providers → **Email** (decide on email confirmation).
2. Auth → Providers → **Facebook** (app id/secret + callback URL).
3. Auth → **SMTP** sender so confirmation/reset emails actually send.

## How to Test

- **Automated:** `useAuth` (each provider/method + `/confirm` & `/reset-password`
  redirects + `needsConfirmation` + throw-on-error), `login` (OAuth buttons,
  mode toggle, email sign-in/up, forgot-password), `reset-password` (update +
  short-password guard). `npm test` → 101 passing, typecheck clean.
- **Manual:** with providers enabled — sign up, confirm, land on `/overview`
  (or `/request-access` if not invited); Forgot password → email → set a new one.

## Invariants

No RLS/authz change (the #50 gate enforces); no secrets client-side (OAuth +
anon key only).
