### PR TITLE
feat: event-day weather forecast (Open-Meteo, no key)

### DIFF
--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -75,6 +75,11 @@ function downloadIcs(): void {
             >{{ event.location }}</a>
             <span v-else>{{ event.location }}</span>
           </p>
+          <WeatherForecast
+            v-if="isUpcoming(event.event_date) && event.location"
+            :location="event.location"
+            :date="event.event_date"
+          />
         </div>
 
         <!-- Add to calendar -->

--- a/app/components/WeatherForecast.vue
+++ b/app/components/WeatherForecast.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+// Outdoor movie night → "will it rain?". Shows the event-day forecast when one
+// is available (location set + within the forecast window); renders nothing
+// otherwise, so it never clutters the UI with a missing-data state.
+const props = defineProps<{ location: string | null, date: string }>()
+const { forecast } = useWeather(() => props.location, () => props.date)
+</script>
+
+<template>
+  <div
+    v-if="forecast?.available"
+    class="inline-flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted"
+  >
+    <span class="inline-flex items-center gap-1.5">
+      <UIcon :name="describeWeather(forecast.code ?? 0).icon" class="text-base text-primary" />
+      {{ describeWeather(forecast.code ?? 0).label }}
+    </span>
+    <span class="text-default font-medium">{{ forecast.high }}° / {{ forecast.low }}°</span>
+    <span v-if="forecast.precipProbability != null" class="inline-flex items-center gap-1">
+      <UIcon name="i-lucide-umbrella" /> {{ forecast.precipProbability }}% rain
+    </span>
+  </div>
+</template>

--- a/app/composables/useWeather.ts
+++ b/app/composables/useWeather.ts
@@ -1,0 +1,28 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Forecast } from '#shared/types/weather'
+
+/** Fetches the event-day forecast for a location, but only when the date is
+ *  inside Open-Meteo's forecast window (skips past/far-future events). */
+export function useWeather(location: MaybeRefOrGetter<string | null>, date: MaybeRefOrGetter<string | null>) {
+  const forecast = ref<Forecast | null>(null)
+  const pending = ref(false)
+
+  watchEffect(async () => {
+    const loc = toValue(location)
+    const day = toValue(date)
+    if (!loc || !day || !withinForecastWindow(day, new Date())) {
+      forecast.value = null
+      return
+    }
+    pending.value = true
+    try {
+      forecast.value = await $fetch<Forecast>('/api/weather', { query: { location: loc, date: day.slice(0, 10) } })
+    } catch {
+      forecast.value = null
+    } finally {
+      pending.value = false
+    }
+  })
+
+  return { forecast, pending }
+}

--- a/server/api/weather.get.ts
+++ b/server/api/weather.get.ts
@@ -1,0 +1,65 @@
+import type { Forecast } from '#shared/types/weather'
+
+// Proxies Open-Meteo (free, no API key) so the client gets a small, predictable
+// forecast and we can defend against the upstream's full payload. Treats the
+// external response as untrusted — any miss returns { available: false } rather
+// than throwing, so the UI degrades quietly.
+
+interface GeoResponse {
+  results?: Array<{ latitude: number, longitude: number, name: string }>
+}
+interface ForecastResponse {
+  daily?: {
+    weather_code?: number[]
+    temperature_2m_max?: number[]
+    temperature_2m_min?: number[]
+    precipitation_probability_max?: Array<number | null>
+  }
+}
+
+const UNAVAILABLE: Forecast = { available: false, high: null, low: null, precipProbability: null, code: null, place: null }
+
+export default defineEventHandler(async (event): Promise<Forecast> => {
+  const query = getQuery(event)
+  const location = (query.location ?? '').toString().trim().slice(0, 120)
+  const date = (query.date ?? '').toString().slice(0, 10)
+
+  if (!location || !/^\d{4}-\d{2}-\d{2}$/.test(date)) return UNAVAILABLE
+  if (!withinForecastWindow(date, new Date())) return UNAVAILABLE
+
+  try {
+    const geo = await $fetch<GeoResponse>('https://geocoding-api.open-meteo.com/v1/search', {
+      query: { name: location, count: 1, language: 'en', format: 'json' }
+    })
+    const place = geo.results?.[0]
+    if (!place) return UNAVAILABLE
+
+    const fc = await $fetch<ForecastResponse>('https://api.open-meteo.com/v1/forecast', {
+      query: {
+        latitude: place.latitude,
+        longitude: place.longitude,
+        daily: 'weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max',
+        temperature_unit: 'fahrenheit',
+        timezone: 'auto',
+        start_date: date,
+        end_date: date
+      }
+    })
+    const daily = fc.daily
+    const high = daily?.temperature_2m_max?.[0]
+    const low = daily?.temperature_2m_min?.[0]
+    const code = daily?.weather_code?.[0]
+    if (high == null || low == null || code == null) return UNAVAILABLE
+
+    return {
+      available: true,
+      high: Math.round(high),
+      low: Math.round(low),
+      precipProbability: daily?.precipitation_probability_max?.[0] ?? null,
+      code,
+      place: place.name
+    }
+  } catch {
+    return UNAVAILABLE
+  }
+})

--- a/shared/types/weather.ts
+++ b/shared/types/weather.ts
@@ -1,0 +1,11 @@
+/** A day's forecast for an event (from Open-Meteo, via /api/weather). When
+ *  `available` is false the forecast couldn't be resolved (no location, outside
+ *  the ~16-day window, or the upstream call failed) and the rest is null. */
+export interface Forecast {
+  available: boolean
+  high: number | null
+  low: number | null
+  precipProbability: number | null
+  code: number | null
+  place: string | null
+}

--- a/shared/utils/weather.ts
+++ b/shared/utils/weather.ts
@@ -1,0 +1,33 @@
+/** WMO weather code → human label + lucide icon (Open-Meteo returns WMO codes). */
+export interface WeatherDescription {
+  label: string
+  icon: string
+}
+
+export function describeWeather(code: number): WeatherDescription {
+  if (code === 0) return { label: 'Clear', icon: 'i-lucide-sun' }
+  if (code <= 2) return { label: 'Partly cloudy', icon: 'i-lucide-cloud-sun' }
+  if (code === 3) return { label: 'Overcast', icon: 'i-lucide-cloud' }
+  if (code <= 48) return { label: 'Fog', icon: 'i-lucide-cloud-fog' }
+  if (code <= 57) return { label: 'Drizzle', icon: 'i-lucide-cloud-drizzle' }
+  if (code <= 67) return { label: 'Rain', icon: 'i-lucide-cloud-rain' }
+  if (code <= 77) return { label: 'Snow', icon: 'i-lucide-cloud-snow' }
+  if (code <= 82) return { label: 'Showers', icon: 'i-lucide-cloud-rain-wind' }
+  if (code <= 86) return { label: 'Snow showers', icon: 'i-lucide-cloud-snow' }
+  return { label: 'Thunderstorm', icon: 'i-lucide-cloud-lightning' }
+}
+
+/** Whole days from `now` until the event date (negative = past). */
+export function forecastDaysAway(eventDate: string, now: Date): number | null {
+  const target = new Date(`${eventDate.slice(0, 10)}T00:00:00Z`)
+  if (Number.isNaN(target.getTime())) return null
+  const start = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  return Math.round((target.getTime() - start) / 86_400_000)
+}
+
+/** Open-Meteo gives daily forecasts ~16 days out — only fetch when the event is
+ *  today..15 days away (not past, not beyond the horizon). */
+export function withinForecastWindow(eventDate: string, now: Date): boolean {
+  const days = forecastDaysAway(eventDate, now)
+  return days !== null && days >= 0 && days <= 15
+}

--- a/test/WeatherForecast.nuxt.test.ts
+++ b/test/WeatherForecast.nuxt.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import WeatherForecast from '../app/components/WeatherForecast.vue'
+
+const forecast = ref<unknown>(null)
+mockNuxtImport('useWeather', () => () => ({ forecast, pending: ref(false) }))
+
+describe('WeatherForecast', () => {
+  it('shows the condition, temps and rain chance when available', async () => {
+    forecast.value = { available: true, high: 82, low: 61, precipProbability: 20, code: 61, place: 'Town' }
+    const w = await mountSuspended(WeatherForecast, { props: { location: 'Town', date: '2026-07-01' } })
+    expect(w.text()).toContain('Rain')
+    expect(w.text()).toContain('82')
+    expect(w.text()).toContain('20% rain')
+  })
+
+  it('renders nothing when no forecast is available', async () => {
+    forecast.value = { available: false, high: null, low: null, precipProbability: null, code: null, place: null }
+    const w = await mountSuspended(WeatherForecast, { props: { location: 'Town', date: '2026-07-01' } })
+    expect(w.text().trim()).toBe('')
+  })
+})

--- a/test/useWeather.nuxt.test.ts
+++ b/test/useWeather.nuxt.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment nuxt
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+
+const soon = new Date(Date.now() + 3 * 86_400_000).toISOString().slice(0, 10)
+const calls: Array<{ url: string, query: unknown }> = []
+
+beforeEach(() => {
+  calls.length = 0
+  vi.stubGlobal('$fetch', (url: string, opts: { query: unknown }) => {
+    calls.push({ url, query: opts.query })
+    return Promise.resolve({ available: true, high: 80, low: 60, precipProbability: 10, code: 0, place: 'Town' })
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('useWeather', () => {
+  it('fetches the forecast for a location within the window', async () => {
+    const { forecast } = useWeather('Birmingham, AL', soon)
+    await flushPromises()
+    expect(calls[0]?.url).toBe('/api/weather')
+    expect(forecast.value?.available).toBe(true)
+  })
+
+  it('skips the fetch when there is no location', async () => {
+    const { forecast } = useWeather(null, soon)
+    await flushPromises()
+    expect(calls).toHaveLength(0)
+    expect(forecast.value).toBeNull()
+  })
+
+  it('skips the fetch for a past date (outside the window)', async () => {
+    const { forecast } = useWeather('Birmingham, AL', '2000-01-01')
+    await flushPromises()
+    expect(calls).toHaveLength(0)
+    expect(forecast.value).toBeNull()
+  })
+})

--- a/test/weather.test.ts
+++ b/test/weather.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { describeWeather, forecastDaysAway, withinForecastWindow } from '../shared/utils/weather'
+
+describe('describeWeather', () => {
+  it('maps representative WMO codes to labels', () => {
+    expect(describeWeather(0).label).toBe('Clear')
+    expect(describeWeather(2).label).toBe('Partly cloudy')
+    expect(describeWeather(3).label).toBe('Overcast')
+    expect(describeWeather(61).label).toBe('Rain')
+    expect(describeWeather(71).label).toBe('Snow')
+    expect(describeWeather(95).label).toBe('Thunderstorm')
+  })
+
+  it('always returns a lucide icon', () => {
+    for (const code of [0, 2, 45, 61, 71, 82, 95]) {
+      expect(describeWeather(code).icon).toMatch(/^i-lucide-/)
+    }
+  })
+})
+
+describe('forecast window', () => {
+  const now = new Date('2026-06-16T12:00:00Z')
+
+  it('counts whole days to the event', () => {
+    expect(forecastDaysAway('2026-06-16', now)).toBe(0)
+    expect(forecastDaysAway('2026-06-19', now)).toBe(3)
+    expect(forecastDaysAway('2026-06-15', now)).toBe(-1)
+  })
+
+  it('is within window for today through 15 days out', () => {
+    expect(withinForecastWindow('2026-06-16', now)).toBe(true)
+    expect(withinForecastWindow('2026-07-01', now)).toBe(true) // 15 days
+    expect(withinForecastWindow('2026-07-02', now)).toBe(false) // 16 days — beyond
+    expect(withinForecastWindow('2026-06-15', now)).toBe(false) // past
+  })
+
+  it('tolerates a full timestamp and junk input', () => {
+    expect(withinForecastWindow('2026-06-19T19:00:00Z', now)).toBe(true)
+    expect(forecastDaysAway('not-a-date', now)).toBeNull()
+    expect(withinForecastWindow('not-a-date', now)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Scope

The weather feature 🌤️ — for an outdoor movie night, the key question is "will
it rain?". Shows the **event-day forecast** (condition, high/low, rain chance) on
the event detail.

## Implementation

- **`server/api/weather.get.ts`** — proxies **Open-Meteo** (free, *no API key*):
  geocodes the event's location, then fetches that day's daily forecast. Treats
  the upstream as untrusted — returns `{ available: false }` on any miss instead
  of throwing (defensive, per CLAUDE.md).
- **`useWeather`** — only fetches when the event is upcoming, has a location, and
  is inside Open-Meteo's ~16-day window (skips past / far-future events).
- **`WeatherForecast.vue`** — renders the forecast, or nothing when unavailable
  (never shows a broken/empty state). Shown in `EventInfoModal`.
- WMO code → label + lucide icon in `shared/utils/weather.ts` (pure).

## How to Test

- `npm test` → weather: code mapping + window math (`weather.test.ts`),
  fetch/skip logic (`useWeather`), available/empty rendering (`WeatherForecast`).
  Full suite 106 passing; typecheck clean.
- Manual: open an upcoming event with a location set → forecast appears under the
  location (if within ~2 weeks).

## Notes

- **No new env/secret** — Open-Meteo needs no key.
- Touches `EventInfoModal.vue` (adds the forecast in the logistics block). PR #58
  also touches `EventInfoModal` (adds `ShareEvent` lower down) — different
  regions, so they should auto-merge; trivial if not.

## Invariants

No auth/RLS/secret surfaces. External API treated as untrusted and rendered
defensively (missing fields never crash the UI).
