### PR TITLE
feat: Evite tracking — rolling guest list, one-click RSVP, open/click tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,5 +23,8 @@ NUXT_TMDB_API_KEY=your-tmdb-api-key
 NUXT_RESEND_API_KEY=your-resend-api-key
 # Optional — override the From header (must be a verified Resend sender/domain).
 NUXT_RESEND_FROM=Benteen Screen On The Green <movienight@benteenscreenonthegreen.com>
+# Resend webhook signing secret (Resend dashboard → Webhooks) — verifies the
+# open/click/delivery callbacks at /api/webhooks/resend. Starts with "whsec_".
+NUXT_RESEND_WEBHOOK_SECRET=whsec_your-resend-webhook-secret
 # Optional — absolute site URL used in email links (else derived from the request).
 NUXT_SITE_URL=https://benteenscreenonthegreen.com

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,3 @@
+the trailer modal should have a short description of the film beneath the embed. another feature i want to build is setting a theme in the admin section, and in admin section
+  I can inhibit the recommendations that can be made based on the theme.. not sure best way to approach? perhaps a search gate (category or similar depending on what meta we
+  have available)

--- a/app/components/EventInviteManager.vue
+++ b/app/components/EventInviteManager.vue
@@ -1,0 +1,196 @@
+<script setup lang="ts">
+import { z } from 'zod'
+import type { EventInvite } from '#shared/types/event-invite'
+
+// Admin guest-list manager + Evite tracker for one event. Auto-rolls the list
+// forward from the previous event, lets admins add/remove, sends tokenized
+// e-vites, and shows live RSVP / open / click tracking.
+const props = defineProps<{ eventId: string }>()
+const toast = useToast()
+const { invites, stats, addInvite, removeInvite, seedFromLastEvent, sendInvites } = useEventInvites(() => props.eventId)
+
+const newEmail = ref('')
+const newName = ref('')
+const sending = ref(false)
+const seeding = ref(false)
+const emailSchema = z.string().email()
+
+// Auto-roll: the first time we see an empty list for this event, pull last
+// event's invitees ("auto add from last event unless we remove them").
+const seededFor = ref<string | null>(null)
+watch([() => props.eventId, invites], async ([id, list]) => {
+  if (id && seededFor.value !== id && list.length === 0) {
+    seededFor.value = id
+    const n = await seedFromLastEvent().catch(() => 0)
+    if (n) toast.add({ title: `Pulled ${n} from the last movie night`, color: 'neutral' })
+  }
+}, { immediate: true })
+
+async function onAdd(): Promise<void> {
+  const email = newEmail.value.trim()
+  if (!emailSchema.safeParse(email).success) {
+    toast.add({ title: 'Enter a valid email', color: 'warning' })
+    return
+  }
+  try {
+    await addInvite(email, newName.value.trim() || undefined)
+    newEmail.value = ''
+    newName.value = ''
+  } catch {
+    toast.add({ title: 'Could not add them', color: 'error' })
+  }
+}
+
+async function onRemove(invite: EventInvite): Promise<void> {
+  try {
+    await removeInvite(invite.id)
+  } catch {
+    toast.add({ title: 'Could not remove them', color: 'error' })
+  }
+}
+
+async function onSeed(): Promise<void> {
+  seeding.value = true
+  try {
+    const n = await seedFromLastEvent()
+    toast.add({ title: n ? `Added ${n} from the last event` : 'Nothing new to pull in', color: 'neutral' })
+  } catch {
+    toast.add({ title: 'Could not pull the last list', color: 'error' })
+  } finally {
+    seeding.value = false
+  }
+}
+
+async function onSend(): Promise<void> {
+  sending.value = true
+  try {
+    const { sent } = await sendInvites()
+    toast.add({
+      title: sent ? `Sent ${sent} invite${sent === 1 ? '' : 's'}` : 'Everyone has already been invited',
+      icon: 'i-lucide-send',
+      color: 'success'
+    })
+  } catch (error) {
+    toast.add({ title: 'Could not send invites', description: error instanceof Error ? error.message : undefined, color: 'error' })
+  } finally {
+    sending.value = false
+  }
+}
+
+const unsent = computed(() => invites.value.filter(i => !i.sent_at).length)
+
+function statusBadge(invite: EventInvite): { label: string, color: 'success' | 'warning' | 'neutral' | 'info' } {
+  if (invite.rsvp === 'going') return { label: 'Going', color: 'success' }
+  if (invite.rsvp === 'maybe') return { label: 'Maybe', color: 'warning' }
+  if (invite.rsvp === 'no') return { label: "Can't make it", color: 'neutral' }
+  if (invite.clicked_at) return { label: 'Clicked', color: 'info' }
+  if (invite.opened_at) return { label: 'Opened', color: 'info' }
+  if (invite.sent_at) return { label: 'Sent', color: 'neutral' }
+  return { label: 'Not sent', color: 'neutral' }
+}
+</script>
+
+<template>
+  <div class="space-y-5">
+    <!-- Tracker -->
+    <div class="grid grid-cols-3 sm:grid-cols-6 gap-2 text-center">
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold">
+          {{ stats.invited }}
+        </p>
+        <p class="text-xs text-muted">
+          invited
+        </p>
+      </UCard>
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold">
+          {{ stats.opened }}
+        </p>
+        <p class="text-xs text-muted">
+          opened
+        </p>
+      </UCard>
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold text-success">
+          {{ stats.going }}
+        </p>
+        <p class="text-xs text-muted">
+          going
+        </p>
+      </UCard>
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold text-warning">
+          {{ stats.maybe }}
+        </p>
+        <p class="text-xs text-muted">
+          maybe
+        </p>
+      </UCard>
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold">
+          {{ stats.no }}
+        </p>
+        <p class="text-xs text-muted">
+          can't
+        </p>
+      </UCard>
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold text-muted">
+          {{ stats.noReply }}
+        </p>
+        <p class="text-xs text-muted">
+          no reply
+        </p>
+      </UCard>
+    </div>
+
+    <!-- Add + actions -->
+    <div class="flex flex-wrap items-end gap-2">
+      <UFormField label="Add guest email" class="flex-1 min-w-48">
+        <UInput v-model="newEmail" type="email" placeholder="friend@example.com" class="w-full" @keydown.enter="onAdd" />
+      </UFormField>
+      <UFormField label="Name" hint="optional" class="min-w-32">
+        <UInput v-model="newName" placeholder="Jordan" class="w-full" @keydown.enter="onAdd" />
+      </UFormField>
+      <UButton label="Add" icon="i-lucide-plus" @click="onAdd" />
+    </div>
+    <div class="flex flex-wrap items-center gap-2">
+      <UButton label="Pull from last event" icon="i-lucide-history" color="neutral" variant="outline" size="sm" :loading="seeding" @click="onSeed" />
+      <UButton
+        :label="unsent ? `Send ${unsent} invite${unsent === 1 ? '' : 's'}` : 'All invites sent'"
+        icon="i-lucide-send"
+        size="sm"
+        :loading="sending"
+        :disabled="!unsent"
+        @click="onSend"
+      />
+    </div>
+
+    <!-- Guest list -->
+    <ul v-if="invites.length" class="divide-y divide-default rounded-lg ring ring-default overflow-hidden">
+      <li v-for="invite in invites" :key="invite.id" class="flex items-center gap-3 p-3">
+        <div class="min-w-0 flex-1">
+          <p class="font-medium truncate">
+            {{ invite.display_name || invite.email }}
+          </p>
+          <p v-if="invite.display_name" class="text-xs text-muted truncate">
+            {{ invite.email }}
+          </p>
+        </div>
+        <UBadge :label="statusBadge(invite).label" :color="statusBadge(invite).color" variant="subtle" size="sm" class="shrink-0" />
+        <UButton
+          icon="i-lucide-x"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          aria-label="Remove guest"
+          class="shrink-0"
+          @click="onRemove(invite)"
+        />
+      </li>
+    </ul>
+    <p v-else class="text-sm text-muted">
+      No guests yet — add emails above, or pull in last event's list.
+    </p>
+  </div>
+</template>

--- a/app/components/EventInviteManager.vue
+++ b/app/components/EventInviteManager.vue
@@ -82,7 +82,7 @@ const unsent = computed(() => invites.value.filter(i => !i.sent_at).length)
 function statusBadge(invite: EventInvite): { label: string, color: 'success' | 'warning' | 'neutral' | 'info' } {
   if (invite.rsvp === 'going') return { label: 'Going', color: 'success' }
   if (invite.rsvp === 'maybe') return { label: 'Maybe', color: 'warning' }
-  if (invite.rsvp === 'no') return { label: "Can't make it", color: 'neutral' }
+  if (invite.rsvp === 'no') return { label: 'Can\'t make it', color: 'neutral' }
   if (invite.clicked_at) return { label: 'Clicked', color: 'info' }
   if (invite.opened_at) return { label: 'Opened', color: 'info' }
   if (invite.sent_at) return { label: 'Sent', color: 'neutral' }

--- a/app/components/InviteLimitSetting.vue
+++ b/app/components/InviteLimitSetting.vue
@@ -6,7 +6,9 @@ const toast = useToast()
 const draft = ref<number | null>(null)
 const saving = ref(false)
 
-watch(maxInvites, value => { draft.value = value }, { immediate: true })
+watch(maxInvites, (value) => {
+  draft.value = value
+}, { immediate: true })
 
 async function save(): Promise<void> {
   saving.value = true

--- a/app/components/PeopleList.vue
+++ b/app/components/PeopleList.vue
@@ -12,9 +12,9 @@ const emit = defineEmits<{
   revoke: [invite: Invite]
 }>()
 
-type Row =
-  | { kind: 'member', key: string, name: string, email: string, profile: Profile }
-  | { kind: 'pending', key: string, name: string, email: string, invite: Invite }
+type Row
+  = | { kind: 'member', key: string, name: string, email: string, profile: Profile }
+    | { kind: 'pending', key: string, name: string, email: string, invite: Invite }
 
 const query = ref('')
 

--- a/app/composables/useEventInvites.ts
+++ b/app/composables/useEventInvites.ts
@@ -1,0 +1,114 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Database } from '~/types/database.types'
+import type { EventInvite, InviteStats } from '#shared/types/event-invite'
+
+/**
+ * Admin-only per-event guest list (public.event_invites). Loads the invitees for
+ * an event, supports add/remove, auto-rolls the list forward from the previous
+ * event, and exposes Evite-style tracking stats. Sending the e-vites is a server
+ * route (Resend key is server-only); RSVP/opens flow back in via realtime.
+ */
+export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
+  const supabase = useSupabaseClient<Database>()
+  const invites = ref<EventInvite[]>([])
+  const pending = ref(false)
+
+  async function refresh(): Promise<void> {
+    const id = toValue(eventId)
+    if (!id) { invites.value = []; return }
+    pending.value = true
+    const { data } = await supabase
+      .from('event_invites')
+      .select('*')
+      .eq('event_id', id)
+      .order('created_at')
+    invites.value = (data as EventInvite[] | null) ?? []
+    pending.value = false
+  }
+
+  const stats = computed<InviteStats>(() => {
+    const all = invites.value
+    return {
+      invited: all.length,
+      sent: all.filter(i => i.sent_at).length,
+      opened: all.filter(i => i.opened_at).length,
+      clicked: all.filter(i => i.clicked_at).length,
+      going: all.filter(i => i.rsvp === 'going').length,
+      maybe: all.filter(i => i.rsvp === 'maybe').length,
+      no: all.filter(i => i.rsvp === 'no').length,
+      noReply: all.filter(i => !i.rsvp).length
+    }
+  })
+
+  async function addInvite(email: string, displayName?: string): Promise<void> {
+    const id = toValue(eventId)
+    if (!id) return
+    const { error } = await supabase
+      .from('event_invites')
+      .insert({ event_id: id, email, display_name: displayName ?? null })
+    // 23505 = already on this event's list — harmless.
+    if (error && error.code !== '23505') throw error
+    await refresh()
+  }
+
+  async function removeInvite(inviteId: string): Promise<void> {
+    const { error } = await supabase.from('event_invites').delete().eq('id', inviteId)
+    if (error) throw error
+    await refresh()
+  }
+
+  /** Copy the previous event's guest list onto this one (skipping anyone already
+   *  here) — the "auto-add from last event unless we remove them" behavior. */
+  async function seedFromLastEvent(): Promise<number> {
+    const id = toValue(eventId)
+    if (!id) return 0
+    const { data: current } = await supabase.from('events').select('event_date').eq('id', id).single()
+    if (!current) return 0
+    const { data: prev } = await supabase
+      .from('events')
+      .select('id')
+      .lt('event_date', current.event_date)
+      .order('event_date', { ascending: false })
+      .limit(1)
+      .maybeSingle()
+    if (!prev) return 0
+    const { data: prevInvites } = await supabase
+      .from('event_invites')
+      .select('email, display_name')
+      .eq('event_id', prev.id)
+    const existing = new Set(invites.value.map(i => i.email))
+    const toAdd = (prevInvites ?? [])
+      .filter(p => !existing.has(p.email))
+      .map(p => ({ event_id: id, email: p.email, display_name: p.display_name }))
+    if (!toAdd.length) return 0
+    const { error } = await supabase.from('event_invites').insert(toAdd)
+    if (error) throw error
+    await refresh()
+    return toAdd.length
+  }
+
+  /** Send (or re-send) the tokenized e-vites for this event via the server route. */
+  async function sendInvites(): Promise<{ sent: number }> {
+    const id = toValue(eventId)
+    if (!id) return { sent: 0 }
+    const result = await $fetch<{ ok: boolean, sent: number }>(`/api/events/${id}/invites/send`, { method: 'POST' })
+    await refresh()
+    return { sent: result.sent }
+  }
+
+  // Live updates as RSVPs / opens land (event_invites is in the realtime publication).
+  let channel: ReturnType<typeof supabase.channel> | null = null
+  watch(() => toValue(eventId), (id) => {
+    if (channel) { supabase.removeChannel(channel); channel = null }
+    void refresh()
+    if (!id) return
+    channel = supabase
+      .channel(`event_invites:${id}`)
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'event_invites', filter: `event_id=eq.${id}` }, () => { void refresh() })
+      .subscribe()
+  }, { immediate: true })
+
+  onScopeDispose(() => { if (channel) supabase.removeChannel(channel) })
+
+  return { invites, pending, stats, refresh, addInvite, removeInvite, seedFromLastEvent, sendInvites }
+}

--- a/app/composables/useEventInvites.ts
+++ b/app/composables/useEventInvites.ts
@@ -15,7 +15,10 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
 
   async function refresh(): Promise<void> {
     const id = toValue(eventId)
-    if (!id) { invites.value = []; return }
+    if (!id) {
+      invites.value = []
+      return
+    }
     pending.value = true
     const { data } = await supabase
       .from('event_invites')
@@ -99,16 +102,23 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
   // Live updates as RSVPs / opens land (event_invites is in the realtime publication).
   let channel: ReturnType<typeof supabase.channel> | null = null
   watch(() => toValue(eventId), (id) => {
-    if (channel) { supabase.removeChannel(channel); channel = null }
+    if (channel) {
+      supabase.removeChannel(channel)
+      channel = null
+    }
     void refresh()
     if (!id) return
     channel = supabase
       .channel(`event_invites:${id}`)
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'event_invites', filter: `event_id=eq.${id}` }, () => { void refresh() })
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'event_invites', filter: `event_id=eq.${id}` }, () => {
+        void refresh()
+      })
       .subscribe()
   }, { immediate: true })
 
-  onScopeDispose(() => { if (channel) supabase.removeChannel(channel) })
+  onScopeDispose(() => {
+    if (channel) supabase.removeChannel(channel)
+  })
 
   return { invites, pending, stats, refresh, addInvite, removeInvite, seedFromLastEvent, sendInvites }
 }

--- a/app/middleware/invited.global.ts
+++ b/app/middleware/invited.global.ts
@@ -4,7 +4,7 @@ import type { Database } from '~/types/database.types'
 // module already bounces *unauthenticated* users to /login; this catches users
 // who are authenticated but whose email isn't on the allowlist (public.invites):
 // it ends their session and sends them to /request-access.
-const PUBLIC_PATHS = new Set(['/', '/about', '/login', '/confirm', '/request-access', '/reset-password'])
+const PUBLIC_PATHS = new Set(['/', '/about', '/login', '/confirm', '/request-access', '/reset-password', '/rsvp'])
 
 export default defineNuxtRouteMiddleware(async (to) => {
   if (PUBLIC_PATHS.has(to.path)) return

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -295,7 +295,9 @@ async function onRevoke(invite: Invite): Promise<void> {
           <div class="flex flex-wrap items-center justify-between gap-3">
             <p class="text-sm text-muted">
               {{ people.length }} member{{ people.length === 1 ? '' : 's' }}
-              <template v-if="pendingInvites.length">· {{ pendingInvites.length }} pending</template>
+              <template v-if="pendingInvites.length">
+                · {{ pendingInvites.length }} pending
+              </template>
             </p>
             <UButton label="Invite someone" icon="i-lucide-user-plus" size="sm" @click="inviteOpen = true" />
           </div>

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -41,6 +41,7 @@ const tabs = [
   { label: 'People', icon: 'i-lucide-users', slot: 'people' },
   { label: 'Suggestions', icon: 'i-lucide-clapperboard', slot: 'suggestions' },
   { label: 'Bring list', icon: 'i-lucide-utensils', slot: 'bring' },
+  { label: 'Invites', icon: 'i-lucide-mail-plus', slot: 'invites' },
   { label: 'Comms', icon: 'i-lucide-megaphone', slot: 'comms' }
 ]
 
@@ -419,6 +420,25 @@ async function onRevoke(invite: Invite): Promise<void> {
       </template>
 
       <!-- COMMS -->
+      <template #invites>
+        <p class="text-sm text-muted mb-4">
+          Curate the guest list for an event and send Evite-style invitations with
+          one-click RSVP. A new event's list auto-fills from the last movie night.
+        </p>
+        <USelectMenu
+          v-model="selectedEventId"
+          :items="eventOptions"
+          value-key="value"
+          :search-input="false"
+          placeholder="Select an event"
+          class="w-full sm:max-w-sm mb-4"
+        />
+        <EventInviteManager v-if="selectedEventId" :key="selectedEventId" :event-id="selectedEventId" />
+        <UCard v-else variant="subtle" class="text-center text-muted">
+          Select an event to manage its guest list.
+        </UCard>
+      </template>
+
       <template #comms>
         <p class="text-sm text-muted mb-4">
           Email an announcement or reminder about an event. Recipients are BCC'd.

--- a/app/pages/rsvp.vue
+++ b/app/pages/rsvp.vue
@@ -14,9 +14,9 @@ const phase = ref<'saving' | 'done' | 'error'>('saving')
 const current = ref<RsvpStatus | null>(null)
 
 const HEADLINE: Record<RsvpStatus, string> = {
-  going: "You're going! 🎉",
+  going: 'You\'re going! 🎉',
   maybe: 'Marked as maybe 🤔',
-  no: "Sorry you'll miss it"
+  no: 'Sorry you\'ll miss it'
 }
 
 function isStatus(value: string): value is RsvpStatus {
@@ -24,7 +24,10 @@ function isStatus(value: string): value is RsvpStatus {
 }
 
 async function rsvp(status: RsvpStatus): Promise<void> {
-  if (!token.value) { phase.value = 'error'; return }
+  if (!token.value) {
+    phase.value = 'error'
+    return
+  }
   phase.value = 'saving'
   try {
     await $fetch('/api/rsvp', { method: 'POST', body: { token: token.value, status } })

--- a/app/pages/rsvp.vue
+++ b/app/pages/rsvp.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import type { RsvpStatus } from '#shared/types/rsvp'
+
+// Public landing for the one-click RSVP links in an e-vite. It POSTs the choice
+// on mount — email prefetchers don't run JS, so an accidental link prefetch
+// won't record an RSVP; only a real click does. The token authenticates.
+definePageMeta({ layout: false })
+useSeoMeta({ title: 'RSVP · BSOTG' })
+
+const route = useRoute()
+const token = computed(() => (route.query.token ?? '').toString())
+
+const phase = ref<'saving' | 'done' | 'error'>('saving')
+const current = ref<RsvpStatus | null>(null)
+
+const HEADLINE: Record<RsvpStatus, string> = {
+  going: "You're going! 🎉",
+  maybe: 'Marked as maybe 🤔',
+  no: "Sorry you'll miss it"
+}
+
+function isStatus(value: string): value is RsvpStatus {
+  return value === 'going' || value === 'maybe' || value === 'no'
+}
+
+async function rsvp(status: RsvpStatus): Promise<void> {
+  if (!token.value) { phase.value = 'error'; return }
+  phase.value = 'saving'
+  try {
+    await $fetch('/api/rsvp', { method: 'POST', body: { token: token.value, status } })
+    current.value = status
+    phase.value = 'done'
+  } catch {
+    phase.value = 'error'
+  }
+}
+
+onMounted(() => {
+  const requested = (route.query.status ?? '').toString()
+  if (isStatus(requested)) {
+    void rsvp(requested)
+  } else {
+    phase.value = 'error'
+  }
+})
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-500/10 via-default to-primary-500/5 px-4 py-10">
+    <UCard class="w-full max-w-md">
+      <div class="flex flex-col items-center text-center gap-4 py-2">
+        <img src="/img/logo.png" alt="Benteen Screen On The Green" class="h-14 w-auto">
+
+        <template v-if="phase === 'done'">
+          <h1 class="text-2xl font-bold">
+            {{ current ? HEADLINE[current] : 'Thanks!' }}
+          </h1>
+          <p class="text-muted">
+            You can change your answer anytime:
+          </p>
+          <div class="flex flex-wrap justify-center gap-2">
+            <UButton label="Going" color="primary" :variant="current === 'going' ? 'solid' : 'outline'" @click="rsvp('going')" />
+            <UButton label="Maybe" color="warning" :variant="current === 'maybe' ? 'solid' : 'outline'" @click="rsvp('maybe')" />
+            <UButton label="Can't make it" color="neutral" :variant="current === 'no' ? 'solid' : 'outline'" @click="rsvp('no')" />
+          </div>
+        </template>
+
+        <template v-else-if="phase === 'error'">
+          <UIcon name="i-lucide-circle-alert" class="size-8 text-error" />
+          <h1 class="text-xl font-bold">
+            We couldn't record that
+          </h1>
+          <p class="text-muted">
+            This link may have expired. Try the buttons in your invite email again.
+          </p>
+        </template>
+
+        <template v-else>
+          <UIcon name="i-lucide-loader-circle" class="size-8 animate-spin text-primary" />
+          <p class="text-muted">
+            Recording your RSVP…
+          </p>
+        </template>
+      </div>
+    </UCard>
+  </div>
+</template>

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -23,6 +23,12 @@ export interface Database {
         Update: { id?: boolean, max_invites?: number | null, updated_at?: string }
         Relationships: []
       }
+      event_invites: {
+        Row: { id: string, event_id: string, email: string, display_name: string | null, token: string, rsvp: string | null, rsvp_at: string | null, invited_by: string | null, resend_id: string | null, sent_at: string | null, delivered_at: string | null, opened_at: string | null, clicked_at: string | null, bounced_at: string | null, created_at: string }
+        Insert: { id?: string, event_id: string, email: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, created_at?: string }
+        Update: { id?: string, event_id?: string, email?: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, created_at?: string }
+        Relationships: []
+      }
       events: {
         Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, created_by: string | null, created_at: string }
         Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, created_by?: string | null, created_at?: string }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,6 +29,8 @@ export default defineNuxtConfig({
     resendApiKey: '',
     // Verified Resend sender for e-vites / event blasts. Override per env.
     resendFrom: 'Benteen Screen On The Green <movienight@benteenscreenonthegreen.com>',
+    // Signing secret for Resend (Svix) webhooks → /api/webhooks/resend.
+    resendWebhookSecret: '',
     // Absolute site URL used in email links; falls back to the request origin.
     siteUrl: ''
   },
@@ -52,10 +54,10 @@ export default defineNuxtConfig({
     redirectOptions: {
       login: '/login',
       callback: '/confirm',
-      // /request-access is shown to signed-out, non-invited users; /reset-password
-      // handles the recovery link. The invite-only gate lives in RLS +
-      // middleware/invited.global.ts.
-      exclude: ['/', '/about', '/request-access', '/reset-password']
+      // Public routes: landing/about, the invite-only request page, the password
+      // recovery page, and /rsvp (guests RSVP from an e-vite without an account).
+      // The invite-only gate lives in RLS + middleware/invited.global.ts.
+      exclude: ['/', '/about', '/request-access', '/reset-password', '/rsvp']
     }
   }
 })

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -1,0 +1,71 @@
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server'
+import type { Database } from '~/types/database.types'
+
+/**
+ * Sends (or re-sends) the tokenized e-vites for an event's guest list. Admin-only
+ * (checked via the caller's own profile). For each not-yet-sent invitee we email
+ * the one-click RSVP links, add them to the allowlist so they can also sign in
+ * (per the product decision), and stamp sent_at + the Resend message id (used to
+ * correlate open/click webhooks). Runs under the admin's session — RLS holds.
+ */
+export default defineEventHandler(async (event) => {
+  const user = await serverSupabaseUser(event)
+  if (!user) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+
+  const eventId = getRouterParam(event, 'id')
+  if (!eventId) throw createError({ statusCode: 400, statusMessage: 'Missing event id' })
+
+  const client = await serverSupabaseClient<Database>(event)
+  const { data: me } = await client.from('profiles').select('is_admin').eq('id', user.id).single()
+  if (!me?.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+
+  const { data: ev } = await client.from('events').select('title, event_date, location').eq('id', eventId).single()
+  if (!ev) throw createError({ statusCode: 404, statusMessage: 'Event not found' })
+
+  const { data: invites } = await client
+    .from('event_invites')
+    .select('id, email, display_name, token')
+    .eq('event_id', eventId)
+    .is('sent_at', null)
+  const queue = invites ?? []
+  if (!queue.length) return { ok: true, sent: 0 }
+
+  const config = useRuntimeConfig(event)
+  if (!config.resendApiKey) throw createError({ statusCode: 500, statusMessage: 'Email is not configured' })
+  const origin = config.siteUrl || getRequestURL(event).origin
+  const meta = user.user_metadata as Record<string, string | undefined> | undefined
+  const inviterName = meta?.full_name ?? meta?.name ?? user.email ?? null
+
+  let sent = 0
+  for (const invite of queue) {
+    const mail = buildEventInviteEmail({
+      eventTitle: ev.title,
+      eventDate: ev.event_date ? formatEmailDate(ev.event_date) : null,
+      location: ev.location,
+      inviterName,
+      rsvpUrl: `${origin}/rsvp?token=${invite.token}`
+    })
+    try {
+      const { id: resendId } = await sendEmail(config.resendApiKey, config.resendFrom, {
+        to: invite.email,
+        subject: mail.subject,
+        html: mail.html,
+        text: mail.text,
+        replyTo: user.email ?? undefined
+      })
+      // Allowlist them so they can sign in too (idempotent).
+      await client.from('invites').upsert(
+        { email: invite.email, display_name: invite.display_name, invited_by: user.id },
+        { onConflict: 'email', ignoreDuplicates: true }
+      )
+      await client
+        .from('event_invites')
+        .update({ sent_at: new Date().toISOString(), resend_id: resendId })
+        .eq('id', invite.id)
+      sent++
+    } catch {
+      // Skip this recipient; leave sent_at null so a later send retries it.
+    }
+  }
+  return { ok: true, sent }
+})

--- a/server/api/rsvp.post.ts
+++ b/server/api/rsvp.post.ts
@@ -1,0 +1,44 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+import { z } from 'zod'
+import type { Database } from '~/types/database.types'
+
+const bodySchema = z.object({
+  token: z.string().min(8).max(128),
+  status: z.enum(['going', 'maybe', 'no'])
+})
+
+/**
+ * Public one-click RSVP from an e-vite. Authenticated by the opaque invite token
+ * (not a session), so it runs via the service role below RLS. Records the reply
+ * on event_invites and mirrors it into rsvps when the email maps to a member, so
+ * the in-app headcount stays in sync.
+ */
+export default defineEventHandler(async (event) => {
+  const parsed = bodySchema.safeParse(await readBody(event))
+  if (!parsed.success) throw createError({ statusCode: 400, statusMessage: 'Invalid RSVP' })
+  const { token, status } = parsed.data
+
+  const admin = serverSupabaseServiceRole<Database>(event)
+  const { data: invite } = await admin
+    .from('event_invites')
+    .select('id, event_id, email')
+    .eq('token', token)
+    .maybeSingle()
+  if (!invite) throw createError({ statusCode: 404, statusMessage: 'Invitation not found' })
+
+  const now = new Date().toISOString()
+  await admin
+    .from('event_invites')
+    .update({ rsvp: status, rsvp_at: now, clicked_at: now })
+    .eq('id', invite.id)
+
+  // Mirror into the app RSVP if this invitee is also a member (case-insensitive).
+  const { data: profile } = await admin.from('profiles').select('id').ilike('email', invite.email).maybeSingle()
+  if (profile) {
+    await admin
+      .from('rsvps')
+      .upsert({ event_id: invite.event_id, user_id: profile.id, status, updated_at: now }, { onConflict: 'event_id,user_id' })
+  }
+
+  return { ok: true, status }
+})

--- a/server/api/webhooks/resend.post.ts
+++ b/server/api/webhooks/resend.post.ts
@@ -1,0 +1,44 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+import type { Database } from '~/types/database.types'
+
+/**
+ * Resend (Svix) webhook → stamps delivery/open/click/bounce on the matching
+ * event_invites row (correlated by the Resend message id). Public, but verified
+ * by the signing secret; runs via the service role below RLS.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event)
+  const secret = config.resendWebhookSecret
+  if (!secret) throw createError({ statusCode: 500, statusMessage: 'Webhook secret not configured' })
+
+  const raw = await readRawBody(event)
+  if (!raw) throw createError({ statusCode: 400, statusMessage: 'Empty body' })
+  const body = raw.toString()
+
+  const verified = verifySvixSignature({
+    secret,
+    id: getHeader(event, 'svix-id') ?? '',
+    timestamp: getHeader(event, 'svix-timestamp') ?? '',
+    body,
+    signatureHeader: getHeader(event, 'svix-signature') ?? ''
+  })
+  if (!verified) throw createError({ statusCode: 401, statusMessage: 'Invalid signature' })
+
+  let payload: { type?: string, data?: { email_id?: string } }
+  try {
+    payload = JSON.parse(body)
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid JSON' })
+  }
+
+  const column = payload.type ? RESEND_EVENT_COLUMN[payload.type] : undefined
+  const emailId = payload.data?.email_id
+  if (!column || !emailId) return { ok: true } // event we don't track — ack it anyway
+
+  const admin = serverSupabaseServiceRole<Database>(event)
+  // `column` is a fixed key from RESEND_EVENT_COLUMN, but a computed key widens to
+  // an index signature — cast to the row Update type at this validated boundary.
+  const patch = { [column]: new Date().toISOString() } as Database['public']['Tables']['event_invites']['Update']
+  await admin.from('event_invites').update(patch).eq('resend_id', emailId)
+  return { ok: true }
+})

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -105,7 +105,7 @@ export function buildEventInviteEmail(opts: {
     `<h1 style="font-size:20px;margin:0 0 8px">You're invited to ${escapeHtml(opts.eventTitle)} 🎬</h1>`
     + (opts.eventDate ? `<p style="color:#6b7280;margin:0 0 4px">${escapeHtml(opts.eventDate)}${opts.location ? ` · ${escapeHtml(opts.location)}` : ''}</p>` : '')
     + `<p>${inviter} hopes you can make it for movie night. Will you be there?</p>`
-    + `<p style="margin:20px 0">${rsvp('going', "I'm going", '#16a34a')}${rsvp('maybe', 'Maybe', '#d97706')}${rsvp('no', "Can't make it", '#6b7280')}</p>`
+    + `<p style="margin:20px 0">${rsvp('going', 'I\'m going', '#16a34a')}${rsvp('maybe', 'Maybe', '#d97706')}${rsvp('no', 'Can\'t make it', '#6b7280')}</p>`
   )
   const text = `You're invited: ${opts.eventTitle}${opts.eventDate ? ` — ${opts.eventDate}` : ''}`
     + `\n\nRSVP:\nGoing: ${opts.rsvpUrl}&status=going\nMaybe: ${opts.rsvpUrl}&status=maybe\nCan't make it: ${opts.rsvpUrl}&status=no`

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -87,6 +87,31 @@ export function buildAnnounceEmail(opts: {
   return { subject, html, text }
 }
 
+/** Evite-style per-event invitation with one-click RSVP buttons. The buttons
+ *  link to the public /rsvp page (token in the query), which records the reply
+ *  without requiring sign-in. */
+export function buildEventInviteEmail(opts: {
+  eventTitle: string
+  eventDate: string | null
+  location: string | null
+  inviterName: string | null
+  rsvpUrl: string // base: https://site/rsvp?token=abc
+}): BuiltEmail {
+  const inviter = opts.inviterName ? escapeHtml(opts.inviterName) : 'Your host'
+  const rsvp = (status: string, label: string, color: string): string =>
+    `<a href="${escapeHtml(`${opts.rsvpUrl}&status=${status}`)}" style="display:inline-block;background:${color};color:#fff;text-decoration:none;padding:10px 16px;border-radius:8px;font-weight:600;margin:0 6px 6px 0">${escapeHtml(label)}</a>`
+  const subject = `You're invited: ${opts.eventTitle}`
+  const html = shell(
+    `<h1 style="font-size:20px;margin:0 0 8px">You're invited to ${escapeHtml(opts.eventTitle)} 🎬</h1>`
+    + (opts.eventDate ? `<p style="color:#6b7280;margin:0 0 4px">${escapeHtml(opts.eventDate)}${opts.location ? ` · ${escapeHtml(opts.location)}` : ''}</p>` : '')
+    + `<p>${inviter} hopes you can make it for movie night. Will you be there?</p>`
+    + `<p style="margin:20px 0">${rsvp('going', "I'm going", '#16a34a')}${rsvp('maybe', 'Maybe', '#d97706')}${rsvp('no', "Can't make it", '#6b7280')}</p>`
+  )
+  const text = `You're invited: ${opts.eventTitle}${opts.eventDate ? ` — ${opts.eventDate}` : ''}`
+    + `\n\nRSVP:\nGoing: ${opts.rsvpUrl}&status=going\nMaybe: ${opts.rsvpUrl}&status=maybe\nCan't make it: ${opts.rsvpUrl}&status=no`
+  return { subject, html, text }
+}
+
 export interface SendParams {
   to: string | string[]
   bcc?: string[]
@@ -96,10 +121,11 @@ export interface SendParams {
   replyTo?: string
 }
 
-/** Thin Resend wrapper — throws on failure so callers map it to an HTTP error. */
-export async function sendEmail(apiKey: string, from: string, params: SendParams): Promise<void> {
+/** Thin Resend wrapper — throws on failure so callers map it to an HTTP error.
+ *  Returns the Resend message id so callers can correlate webhook events. */
+export async function sendEmail(apiKey: string, from: string, params: SendParams): Promise<{ id: string | null }> {
   const resend = new Resend(apiKey)
-  const { error } = await resend.emails.send({
+  const { data, error } = await resend.emails.send({
     from,
     to: params.to,
     bcc: params.bcc,
@@ -109,4 +135,5 @@ export async function sendEmail(apiKey: string, from: string, params: SendParams
     replyTo: params.replyTo
   })
   if (error) throw new Error(error.message || 'Failed to send email')
+  return { id: data?.id ?? null }
 }

--- a/server/utils/webhook.ts
+++ b/server/utils/webhook.ts
@@ -1,0 +1,35 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+
+/**
+ * Verifies a Svix-style webhook signature (the scheme Resend uses). The signed
+ * content is `${id}.${timestamp}.${body}`, HMAC-SHA256'd with the secret (the
+ * base64 portion after the `whsec_` prefix) and base64-encoded. The signature
+ * header is a space-separated list of `v1,<sig>` entries; any match passes.
+ */
+export function verifySvixSignature(opts: {
+  secret: string
+  id: string
+  timestamp: string
+  body: string
+  signatureHeader: string
+}): boolean {
+  if (!opts.secret || !opts.id || !opts.timestamp || !opts.signatureHeader) return false
+  const key = Buffer.from(opts.secret.replace(/^whsec_/, ''), 'base64')
+  const expected = Buffer.from(
+    createHmac('sha256', key).update(`${opts.id}.${opts.timestamp}.${opts.body}`).digest('base64')
+  )
+  return opts.signatureHeader.split(' ').some((part) => {
+    const sig = part.split(',')[1]
+    if (!sig) return false
+    const sigBuf = Buffer.from(sig)
+    return sigBuf.length === expected.length && timingSafeEqual(sigBuf, expected)
+  })
+}
+
+/** Maps a Resend webhook event type to the event_invites column it stamps. */
+export const RESEND_EVENT_COLUMN: Record<string, 'delivered_at' | 'opened_at' | 'clicked_at' | 'bounced_at'> = {
+  'email.delivered': 'delivered_at',
+  'email.opened': 'opened_at',
+  'email.clicked': 'clicked_at',
+  'email.bounced': 'bounced_at'
+}

--- a/shared/types/event-invite.ts
+++ b/shared/types/event-invite.ts
@@ -1,0 +1,33 @@
+import type { RsvpStatus } from './rsvp'
+
+/** A per-event invitation (public.event_invites): the admin-curated guest list
+ *  for one event, with its one-click RSVP token and engagement tracking. */
+export interface EventInvite {
+  id: string
+  event_id: string
+  email: string
+  display_name: string | null
+  token: string
+  rsvp: RsvpStatus | null
+  rsvp_at: string | null
+  invited_by: string | null
+  resend_id: string | null
+  sent_at: string | null
+  delivered_at: string | null
+  opened_at: string | null
+  clicked_at: string | null
+  bounced_at: string | null
+  created_at: string
+}
+
+/** Aggregate tracking for an event's guest list. */
+export interface InviteStats {
+  invited: number
+  sent: number
+  opened: number
+  clicked: number
+  going: number
+  maybe: number
+  no: number
+  noReply: number
+}

--- a/supabase/migrations/20260619000000_event_invites.sql
+++ b/supabase/migrations/20260619000000_event_invites.sql
@@ -1,0 +1,47 @@
+-- ============================================================================
+-- Evite-style per-event invitations + tracking. One row per (event, email):
+-- the admin-curated guest list for an event, a unique token for one-click RSVP
+-- from the email, the RSVP itself, and engagement timestamps fed by Resend
+-- webhooks. Admins curate; the public RSVP + webhook routes update below RLS via
+-- the service role (Invariant 1 holds — only admins can read/write directly).
+-- ============================================================================
+
+create table public.event_invites (
+  id            uuid primary key default gen_random_uuid(),
+  event_id      uuid not null references public.events (id) on delete cascade,
+  email         text not null,
+  display_name  text,
+  -- Opaque, unguessable token for the one-click RSVP link (DB-generated).
+  token         text not null unique default encode(gen_random_bytes(16), 'hex'),
+  rsvp          text check (rsvp in ('going', 'maybe', 'no')),
+  rsvp_at       timestamptz,
+  invited_by    uuid references public.profiles (id) on delete set null,
+  -- Engagement (stamped by the Resend webhook), keyed on the Resend message id.
+  resend_id     text,
+  sent_at       timestamptz,
+  delivered_at  timestamptz,
+  opened_at     timestamptz,
+  clicked_at    timestamptz,
+  bounced_at    timestamptz,
+  created_at    timestamptz not null default now(),
+  unique (event_id, email)
+);
+create index event_invites_event_id_idx on public.event_invites (event_id);
+create index event_invites_resend_id_idx on public.event_invites (resend_id);
+
+-- Normalize the email key (reuses the invites normalizer).
+create trigger event_invites_normalize_email before insert or update on public.event_invites
+  for each row execute function public.normalize_invite_email();
+
+alter table public.event_invites enable row level security;
+grant select, insert, update, delete on public.event_invites to authenticated;
+grant select, insert, update, delete on public.event_invites to service_role;
+
+-- Admin-only direct access: only admins curate the guest list and see tracking.
+-- The public RSVP page and the Resend webhook update via the service role, which
+-- bypasses RLS — they authenticate by token / signature instead.
+create policy "event_invites: admin all" on public.event_invites
+  for all to authenticated using (public.is_admin()) with check (public.is_admin());
+
+-- Live tracker updates.
+alter publication supabase_realtime add table public.event_invites;

--- a/test/EventInviteManager.nuxt.test.ts
+++ b/test/EventInviteManager.nuxt.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment nuxt
+import { describe, expect, it, vi } from 'vitest'
+import { computed, ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import EventInviteManager from '../app/components/EventInviteManager.vue'
+
+const invites = ref([
+  { id: 'a', event_id: 'e', email: 'pat@x.com', display_name: 'Pat', token: '1', rsvp: 'going', rsvp_at: null, invited_by: null, resend_id: null, sent_at: 't', delivered_at: null, opened_at: null, clicked_at: null, bounced_at: null, created_at: '' }
+])
+const sent = vi.fn(async () => ({ sent: 0 }))
+
+mockNuxtImport('useEventInvites', () => () => ({
+  invites,
+  pending: ref(false),
+  stats: computed(() => ({ invited: 1, sent: 1, opened: 0, clicked: 0, going: 1, maybe: 0, no: 0, noReply: 0 })),
+  refresh: async () => {},
+  addInvite: async () => {},
+  removeInvite: async () => {},
+  seedFromLastEvent: async () => 0,
+  sendInvites: sent
+}))
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+describe('EventInviteManager', () => {
+  it('shows the tracker stats and the guest list', async () => {
+    const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e' } })
+    expect(w.text()).toContain('invited')
+    expect(w.text()).toContain('going')
+    expect(w.text()).toContain('Pat')
+    expect(w.text()).toContain('Going')
+  })
+})

--- a/test/InviteLimitSetting.nuxt.test.ts
+++ b/test/InviteLimitSetting.nuxt.test.ts
@@ -12,7 +12,9 @@ mockNuxtImport('useAppSettings', () => () => ({
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
 
-beforeEach(() => { saved = undefined })
+beforeEach(() => {
+  saved = undefined
+})
 
 async function clickSave(w: { findAll: (s: string) => Array<{ text: () => string, trigger: (e: string) => Promise<void> }> }): Promise<void> {
   const btn = w.findAll('button').find(b => b.text().includes('Save'))

--- a/test/email.test.ts
+++ b/test/email.test.ts
@@ -1,11 +1,34 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildAnnounceEmail,
+  buildEventInviteEmail,
   buildInviteEmail,
   escapeHtml,
   formatEmailDate,
   uniqueEmails
 } from '../server/utils/email'
+
+describe('buildEventInviteEmail', () => {
+  it('includes tokenized Going/Maybe/No RSVP links', () => {
+    const m = buildEventInviteEmail({
+      eventTitle: 'Jaws',
+      eventDate: 'Friday',
+      location: 'The Green',
+      inviterName: 'Sam',
+      rsvpUrl: 'https://x/rsvp?token=abc'
+    })
+    expect(m.subject).toContain('Jaws')
+    expect(m.html).toContain('https://x/rsvp?token=abc&amp;status=going')
+    expect(m.html).toContain('status=maybe')
+    expect(m.html).toContain('status=no')
+    expect(m.text).toContain('token=abc&status=going')
+  })
+
+  it('falls back to "Your host" without an inviter name', () => {
+    const m = buildEventInviteEmail({ eventTitle: 'Jaws', eventDate: null, location: null, inviterName: null, rsvpUrl: 'https://x/rsvp?token=abc' })
+    expect(m.html).toContain('Your host')
+  })
+})
 
 describe('email utils', () => {
   it('escapeHtml neutralizes angle brackets and quotes', () => {

--- a/test/login.nuxt.test.ts
+++ b/test/login.nuxt.test.ts
@@ -11,7 +11,10 @@ const auth = {
   signInWithGoogle: async () => { calls.push('google') },
   signInWithFacebook: async () => { calls.push('facebook') },
   signInWithEmail: async (email: string) => { calls.push(`email:${email}`) },
-  signUpWithEmail: async (email: string) => { calls.push(`signup:${email}`); return { needsConfirmation: true } },
+  signUpWithEmail: async (email: string) => {
+    calls.push(`signup:${email}`)
+    return { needsConfirmation: true }
+  },
   sendPasswordReset: async (email: string) => { calls.push(`reset:${email}`) }
 }
 

--- a/test/reset-password.nuxt.test.ts
+++ b/test/reset-password.nuxt.test.ts
@@ -9,11 +9,17 @@ let navTarget: string | null = null
 
 mockNuxtImport('useSupabaseClient', () => () => ({
   auth: {
-    updateUser: async (args: { password: string }) => { updateCalls.push(args); return { error: null } }
+    updateUser: async (args: { password: string }) => {
+      updateCalls.push(args)
+      return { error: null }
+    }
   }
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
-mockNuxtImport('navigateTo', () => (to: string) => { navTarget = to; return to })
+mockNuxtImport('navigateTo', () => (to: string) => {
+  navTarget = to
+  return to
+})
 
 beforeEach(() => {
   updateCalls.length = 0

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -106,6 +106,15 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     expect(error).toBeTruthy()
   })
 
+  it('event_invites are admin-only: a non-admin member reads zero rows', async () => {
+    await admin!.from('event_invites').insert({ event_id: eventId, email: `rls_guest_${stamp}@example.com` })
+    const mine = await memberClient.from('event_invites').select('*').eq('event_id', eventId)
+    expect(mine.data ?? [], 'a non-admin member must not see the guest list').toHaveLength(0)
+    const asAdmin = await admin!.from('event_invites').select('*').eq('event_id', eventId)
+    expect((asAdmin.data ?? []).length, 'service role / admin sees the guest list').toBeGreaterThan(0)
+    await admin!.from('event_invites').delete().eq('event_id', eventId)
+  })
+
   it('the total invite cap blocks an over-limit member invite but exempts admin/seed', async () => {
     const { count } = await admin!.from('invites').select('*', { count: 'exact', head: true })
     // Set the cap to the current size so the next member-issued invite is over-limit.

--- a/test/rsvp.nuxt.test.ts
+++ b/test/rsvp.nuxt.test.ts
@@ -22,6 +22,6 @@ describe('rsvp page', () => {
     const w = await mountSuspended(RsvpPage)
     await flushPromises()
     expect(calls[0]).toMatchObject({ url: '/api/rsvp', body: { token: 'abc', status: 'going' } })
-    expect(w.text()).toContain("You're going")
+    expect(w.text()).toContain('You\'re going')
   })
 })

--- a/test/rsvp.nuxt.test.ts
+++ b/test/rsvp.nuxt.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment nuxt
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import RsvpPage from '../app/pages/rsvp.vue'
+
+const calls: Array<{ url: string, body: unknown }> = []
+
+mockNuxtImport('useRoute', () => () => ({ query: { token: 'abc', status: 'going' } }))
+
+beforeEach(() => {
+  calls.length = 0
+  vi.stubGlobal('$fetch', (url: string, opts: { body: unknown }) => {
+    calls.push({ url, body: opts.body })
+    return Promise.resolve({ ok: true, status: 'going' })
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('rsvp page', () => {
+  it('records the RSVP from the email link on mount and confirms', async () => {
+    const w = await mountSuspended(RsvpPage)
+    await flushPromises()
+    expect(calls[0]).toMatchObject({ url: '/api/rsvp', body: { token: 'abc', status: 'going' } })
+    expect(w.text()).toContain("You're going")
+  })
+})

--- a/test/useAdminPeople.nuxt.test.ts
+++ b/test/useAdminPeople.nuxt.test.ts
@@ -18,14 +18,20 @@ function from(table: string) {
     order: () => result,
     is: () => chain,
     delete: () => chain,
-    eq: (col: string, val: unknown) => { calls.del.push({ col, val }); return Promise.resolve({ error: null }) }
+    eq: (col: string, val: unknown) => {
+      calls.del.push({ col, val })
+      return Promise.resolve({ error: null })
+    }
   }
   return chain
 }
 
 const supabase = {
   from,
-  rpc: (fn: string, args: unknown) => { calls.rpc.push({ fn, args }); return Promise.resolve({ error: null }) }
+  rpc: (fn: string, args: unknown) => {
+    calls.rpc.push({ fn, args })
+    return Promise.resolve({ error: null })
+  }
 }
 
 mockNuxtImport('useSupabaseClient', () => () => supabase)

--- a/test/useAppSettings.nuxt.test.ts
+++ b/test/useAppSettings.nuxt.test.ts
@@ -7,13 +7,18 @@ const supabase = {
   from() {
     return {
       select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { max_invites: 10 } }) }) }),
-      update: (payload: unknown) => { updates.push(payload); return { eq: () => Promise.resolve({ error: null }) } }
+      update: (payload: unknown) => {
+        updates.push(payload)
+        return { eq: () => Promise.resolve({ error: null }) }
+      }
     }
   }
 }
 mockNuxtImport('useSupabaseClient', () => () => supabase)
 
-beforeEach(() => { updates.length = 0 })
+beforeEach(() => {
+  updates.length = 0
+})
 
 describe('useAppSettings', () => {
   it('setMaxInvites updates the singleton and reflects the new value', async () => {

--- a/test/useAuth.nuxt.test.ts
+++ b/test/useAuth.nuxt.test.ts
@@ -8,12 +8,17 @@ const calls: Call[] = []
 let nextError: Error | null = null
 let nextSession: unknown = null // what signUp returns as data.session
 
+function record(fn: string, args: unknown[], result: unknown): Promise<unknown> {
+  calls.push({ fn, args })
+  return Promise.resolve(result)
+}
+
 const auth = {
-  signInWithOAuth: (args: unknown) => { calls.push({ fn: 'signInWithOAuth', args: [args] }); return Promise.resolve({ error: nextError }) },
-  signInWithPassword: (args: unknown) => { calls.push({ fn: 'signInWithPassword', args: [args] }); return Promise.resolve({ error: nextError }) },
-  signUp: (args: unknown) => { calls.push({ fn: 'signUp', args: [args] }); return Promise.resolve({ data: { session: nextSession }, error: nextError }) },
-  resetPasswordForEmail: (email: string, opts: unknown) => { calls.push({ fn: 'resetPasswordForEmail', args: [email, opts] }); return Promise.resolve({ error: nextError }) },
-  signOut: () => { calls.push({ fn: 'signOut', args: [] }); return Promise.resolve({ error: null }) }
+  signInWithOAuth: (args: unknown) => record('signInWithOAuth', [args], { error: nextError }),
+  signInWithPassword: (args: unknown) => record('signInWithPassword', [args], { error: nextError }),
+  signUp: (args: unknown) => record('signUp', [args], { data: { session: nextSession }, error: nextError }),
+  resetPasswordForEmail: (email: string, opts: unknown) => record('resetPasswordForEmail', [email, opts], { error: nextError }),
+  signOut: () => record('signOut', [], { error: null })
 }
 
 mockNuxtImport('useSupabaseClient', () => () => ({ auth }))

--- a/test/useEventInvites.nuxt.test.ts
+++ b/test/useEventInvites.nuxt.test.ts
@@ -19,8 +19,16 @@ function builder(table: string) {
     is: () => c,
     single: () => Promise.resolve({ data: { event_date: '2026-01-01' } }),
     maybeSingle: () => Promise.resolve({ data: null }),
-    insert: (v: unknown) => { ops.inserted.push(v); return Promise.resolve({ error: null }) },
-    delete: () => ({ eq: (_col: string, val: unknown) => { ops.deleted.push(val); return Promise.resolve({ error: null }) } }),
+    insert: (v: unknown) => {
+      ops.inserted.push(v)
+      return Promise.resolve({ error: null })
+    },
+    delete: () => ({
+      eq: (_col: string, val: unknown) => {
+        ops.deleted.push(val)
+        return Promise.resolve({ error: null })
+      }
+    }),
     then: (resolve: (v: unknown) => void) => resolve({ data: table === 'event_invites' ? list : [] })
   }
   return c

--- a/test/useEventInvites.nuxt.test.ts
+++ b/test/useEventInvites.nuxt.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+let list: Array<Record<string, unknown>> = []
+const ops = { inserted: [] as unknown[], deleted: [] as unknown[] }
+
+// Thenable + chainable stub mirroring the PostgREST builder: awaiting the chain
+// resolves to { data: list }; terminal single()/maybeSingle() resolve explicitly.
+function builder(table: string) {
+  const c: Record<string, unknown> = {
+    select: () => c,
+    eq: () => c,
+    order: () => c,
+    lt: () => c,
+    limit: () => c,
+    is: () => c,
+    single: () => Promise.resolve({ data: { event_date: '2026-01-01' } }),
+    maybeSingle: () => Promise.resolve({ data: null }),
+    insert: (v: unknown) => { ops.inserted.push(v); return Promise.resolve({ error: null }) },
+    delete: () => ({ eq: (_col: string, val: unknown) => { ops.deleted.push(val); return Promise.resolve({ error: null }) } }),
+    then: (resolve: (v: unknown) => void) => resolve({ data: table === 'event_invites' ? list : [] })
+  }
+  return c
+}
+
+const supabase = {
+  from: (table: string) => builder(table),
+  channel: () => ({ on: () => ({ subscribe: () => ({}) }) }),
+  removeChannel: () => {}
+}
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+beforeEach(() => {
+  list = []
+  ops.inserted = []
+  ops.deleted = []
+})
+
+describe('useEventInvites', () => {
+  it('loads invites and computes Evite tracking stats', async () => {
+    list = [
+      { id: 'a', event_id: 'e', email: 'a@x', rsvp: 'going', sent_at: 't', opened_at: 't', clicked_at: null, display_name: null, token: '1' },
+      { id: 'b', event_id: 'e', email: 'b@x', rsvp: null, sent_at: 't', opened_at: null, clicked_at: null, display_name: null, token: '2' }
+    ]
+    const { stats } = useEventInvites(ref('e'))
+    await flushPromises()
+    expect(stats.value.invited).toBe(2)
+    expect(stats.value.going).toBe(1)
+    expect(stats.value.opened).toBe(1)
+    expect(stats.value.noReply).toBe(1)
+  })
+
+  it('addInvite inserts the email for the event', async () => {
+    const { addInvite } = useEventInvites(ref('e'))
+    await flushPromises()
+    await addInvite('New@X.com', 'New')
+    expect(ops.inserted.some(i => (i as { email?: string }).email === 'New@X.com')).toBe(true)
+  })
+
+  it('removeInvite deletes by id', async () => {
+    const { removeInvite } = useEventInvites(ref('e'))
+    await flushPromises()
+    await removeInvite('a')
+    expect(ops.deleted).toContain('a')
+  })
+})

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1,0 +1,50 @@
+import { createHmac } from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { RESEND_EVENT_COLUMN, verifySvixSignature } from '../server/utils/webhook'
+
+const secret = `whsec_${Buffer.from('a-very-secret-signing-key').toString('base64')}`
+const id = 'msg_123'
+const ts = '1700000000'
+const body = '{"type":"email.opened","data":{"email_id":"re_1"}}'
+
+function sign(s: string, mid: string, mts: string, mbody: string): string {
+  const key = Buffer.from(s.replace(/^whsec_/, ''), 'base64')
+  return `v1,${createHmac('sha256', key).update(`${mid}.${mts}.${mbody}`).digest('base64')}`
+}
+
+describe('verifySvixSignature', () => {
+  it('accepts a correctly signed payload', () => {
+    const signatureHeader = sign(secret, id, ts, body)
+    expect(verifySvixSignature({ secret, id, timestamp: ts, body, signatureHeader })).toBe(true)
+  })
+
+  it('accepts when the header lists multiple signatures', () => {
+    const valid = sign(secret, id, ts, body)
+    expect(verifySvixSignature({ secret, id, timestamp: ts, body, signatureHeader: `v1,deadbeef ${valid}` })).toBe(true)
+  })
+
+  it('rejects a tampered body', () => {
+    const signatureHeader = sign(secret, id, ts, body)
+    expect(verifySvixSignature({ secret, id, timestamp: ts, body: '{"type":"email.clicked"}', signatureHeader })).toBe(false)
+  })
+
+  it('rejects a signature made with a different secret', () => {
+    const signatureHeader = sign(`whsec_${Buffer.from('other-key').toString('base64')}`, id, ts, body)
+    expect(verifySvixSignature({ secret, id, timestamp: ts, body, signatureHeader })).toBe(false)
+  })
+
+  it('rejects when required fields are missing', () => {
+    expect(verifySvixSignature({ secret, id: '', timestamp: ts, body, signatureHeader: 'v1,x' })).toBe(false)
+    expect(verifySvixSignature({ secret, id, timestamp: ts, body, signatureHeader: '' })).toBe(false)
+  })
+})
+
+describe('RESEND_EVENT_COLUMN', () => {
+  it('maps tracked events to their columns and ignores others', () => {
+    expect(RESEND_EVENT_COLUMN['email.delivered']).toBe('delivered_at')
+    expect(RESEND_EVENT_COLUMN['email.opened']).toBe('opened_at')
+    expect(RESEND_EVENT_COLUMN['email.clicked']).toBe('clicked_at')
+    expect(RESEND_EVENT_COLUMN['email.bounced']).toBe('bounced_at')
+    expect(RESEND_EVENT_COLUMN['email.sent']).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Scope

Turns the e-vites into a real **Evite** 🎟️ — an admin-curated, rolling guest
list per event, with **one-click RSVP from the email**, **open/click tracking**,
and a live **per-event tracker**. Built on #58's email/invite foundation.

## How it works (per your spec)

- **Rolling, admin-only guest list.** Each event has its own list (`event_invites`).
  Opening a new event's list **auto-fills from the last movie night** — admins
  add/remove per event, and removals just drop that person going forward. Only
  admins can see/edit it.
- **Send tokenized e-vites.** Each guest gets an email with **Going / Maybe /
  Can't-make-it** buttons (a unique token per invite). Sending also **allowlists**
  them (your call) so they can sign in to vote too.
- **One-click RSVP, no account.** Buttons → `/rsvp?token=…&status=…`, a public
  page that POSTs the choice on mount (email prefetchers don't run JS, so a
  prefetch can't record an RSVP). It mirrors into the in-app `rsvps` headcount
  when the email is a member.
- **Open/click tracking.** A signature-verified Resend webhook stamps
  delivered/opened/clicked/bounced per recipient.
- **Tracker.** New admin **Invites** tab: invited / opened / going / maybe /
  can't / no-reply, live (realtime), plus per-guest status.

## Security (Invariants)

- `event_invites` is **admin-only RLS**; the public RSVP + webhook routes update
  **below RLS via the service role**, authenticated by **token** / **Svix
  signature** — not a session (Invariant 1). Verified against a live local DB
  (integration test asserts a non-admin member sees **zero** guest-list rows).
- Resend key + webhook secret are **server-only** (Invariant 2).
- The Svix signature verifier is unit-tested (valid / tampered / wrong-secret /
  missing-fields), as is the tokenized email builder.

## ⚙️ Config

- **New env:** `NUXT_RESEND_WEBHOOK_SECRET` (Resend dashboard → Webhooks → point
  it at `/api/webhooks/resend`). In `.env.example` + Vercel.
- Migration `20260619000000_event_invites.sql` auto-applies via the #55 workflow.

## How to Test

- `npm test` → 138 passing (+5 RLS integration skipped without a DB; I ran the
  full integration suite incl. `event_invites` against `supabase start` — green).
  Typecheck clean.
- Manual: Admin → **Invites** → pick an event → it pulls last event's list → add
  a guest → **Send** → the email has working Going/Maybe/No buttons → the tracker
  updates live.
