### PR TITLE
feat: weather on hero + almanac, drop pizza-dough, fix CI lint

### DIFF
--- a/app/components/BringList.vue
+++ b/app/components/BringList.vue
@@ -3,7 +3,7 @@ import type { BringItem } from '#shared/types/bring'
 
 // `manage` = admin curation (add + remove items); otherwise it's the public
 // claim view (volunteer for an open slot, or unclaim your own).
-defineProps<{ items: BringItem[], doughs?: number, manage?: boolean }>()
+defineProps<{ items: BringItem[], manage?: boolean }>()
 const emit = defineEmits<{
   add: [label: string]
   claim: [item: BringItem]
@@ -28,11 +28,6 @@ function mine(item: BringItem): boolean {
 
 <template>
   <div class="space-y-3">
-    <div v-if="doughs !== undefined" class="text-sm font-medium flex items-center gap-1.5">
-      🍕 {{ doughs }} pizza dough{{ doughs === 1 ? '' : 's' }} needed
-      <span class="text-xs text-muted font-normal">(one per "Going")</span>
-    </div>
-
     <ul v-if="items.length" class="divide-y divide-default rounded-lg ring ring-default overflow-hidden">
       <li v-for="item in items" :key="item.id" class="flex items-center gap-2 p-3">
         <UIcon

--- a/app/components/EventHero.vue
+++ b/app/components/EventHero.vue
@@ -13,7 +13,7 @@ const upcoming = computed(() => isUpcoming(props.event.event_date))
 <template>
   <button
     type="button"
-    class="group relative block w-full overflow-hidden rounded-xl text-left ring ring-default min-h-44 sm:min-h-56 transition group-hover:ring-primary/30"
+    class="group relative block w-full cursor-pointer overflow-hidden rounded-xl text-left ring ring-default min-h-44 sm:min-h-56 transition hover:ring-primary/40"
     :aria-label="`${event.title} — view event details`"
     @click="$emit('open')"
   >
@@ -40,9 +40,16 @@ const upcoming = computed(() => isUpcoming(props.event.event_date))
         />
         <span class="text-sm text-white/80">{{ formatDate(event.event_date) }}</span>
       </div>
-      <h1 class="text-2xl sm:text-3xl font-bold text-white drop-shadow-md text-balance">
+      <h1 class="text-2xl sm:text-3xl font-bold text-white drop-shadow-md text-balance underline-offset-4 decoration-2 decoration-white/40 group-hover:underline">
         {{ event.title }}
       </h1>
+      <WeatherForecast
+        v-if="upcoming && event.location"
+        :location="event.location"
+        :date="event.event_date"
+        tone="light"
+        class="mt-2"
+      />
       <p class="mt-1.5 inline-flex items-center gap-1 text-xs text-white/70">
         <UIcon name="i-lucide-info" /> Tap for details
       </p>

--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -9,9 +9,6 @@ const eventId = computed(() => props.event?.id ?? null)
 const { myStatus, counts, setStatus } = useRsvp(eventId)
 const { items, claim, unclaim } = useBringList(eventId)
 
-// One pizza dough per person who's "Going".
-const doughs = computed(() => counts.value.going)
-
 const calEvent = computed<CalendarEvent | null>(() => {
   const e = props.event
   if (!e) return null
@@ -137,7 +134,6 @@ function downloadIcs(): void {
           </h3>
           <BringList
             :items="items"
-            :doughs="doughs"
             @claim="claim"
             @unclaim="unclaim"
           />

--- a/app/components/InviteLimitSetting.vue
+++ b/app/components/InviteLimitSetting.vue
@@ -6,7 +6,9 @@ const toast = useToast()
 const draft = ref<number | null>(null)
 const saving = ref(false)
 
-watch(maxInvites, value => { draft.value = value }, { immediate: true })
+watch(maxInvites, (value) => {
+  draft.value = value
+}, { immediate: true })
 
 async function save(): Promise<void> {
   saving.value = true

--- a/app/components/PeopleList.vue
+++ b/app/components/PeopleList.vue
@@ -12,9 +12,9 @@ const emit = defineEmits<{
   revoke: [invite: Invite]
 }>()
 
-type Row =
-  | { kind: 'member', key: string, name: string, email: string, profile: Profile }
-  | { kind: 'pending', key: string, name: string, email: string, invite: Invite }
+type Row
+  = | { kind: 'member', key: string, name: string, email: string, profile: Profile }
+    | { kind: 'pending', key: string, name: string, email: string, invite: Invite }
 
 const query = ref('')
 

--- a/app/components/WeatherForecast.vue
+++ b/app/components/WeatherForecast.vue
@@ -1,23 +1,49 @@
 <script setup lang="ts">
-// Outdoor movie night → "will it rain?". Shows the event-day forecast when one
-// is available (location set + within the forecast window); renders nothing
-// otherwise, so it never clutters the UI with a missing-data state.
-const props = defineProps<{ location: string | null, date: string }>()
+// Outdoor movie night → "will it rain?". Within Open-Meteo's ~2-week window we
+// show the real event-day forecast; further out (no real data yet) a Farmer's
+// Almanac quip; nothing for past events. `tone="light"` for dark backgrounds
+// (the overview poster hero); default is muted theme text (the details modal).
+const props = defineProps<{ location: string | null, date: string, tone?: 'muted' | 'light' }>()
 const { forecast } = useWeather(() => props.location, () => props.date)
+
+const ALMANAC = [
+  'weather will be perfect! ☀️',
+  'clear skies and a gentle breeze 🌤️',
+  'a fine night for a film under the stars ✨',
+  'warm, dry, and worth the wait 🌙'
+]
+const daysAway = computed(() => forecastDaysAway(props.date, new Date()))
+// Upcoming but beyond the forecast horizon → no real data yet.
+const tooFarOut = computed(() => (daysAway.value ?? -1) > 15)
+const almanac = computed(() => ALMANAC[(daysAway.value ?? 0) % ALMANAC.length])
+
+const textClass = computed(() => (props.tone === 'light' ? 'text-white/85' : 'text-muted'))
+const strongClass = computed(() => (props.tone === 'light' ? 'text-white' : 'text-default'))
+const iconClass = computed(() => (props.tone === 'light' ? 'text-white' : 'text-primary'))
 </script>
 
 <template>
   <div
     v-if="forecast?.available"
-    class="inline-flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted"
+    class="inline-flex flex-wrap items-center gap-x-2 gap-y-1 text-sm"
+    :class="textClass"
   >
     <span class="inline-flex items-center gap-1.5">
-      <UIcon :name="describeWeather(forecast.code ?? 0).icon" class="text-base text-primary" />
+      <UIcon :name="describeWeather(forecast.code ?? 0).icon" class="text-base" :class="iconClass" />
       {{ describeWeather(forecast.code ?? 0).label }}
     </span>
-    <span class="text-default font-medium">{{ forecast.high }}° / {{ forecast.low }}°</span>
+    <span class="font-medium" :class="strongClass">{{ forecast.high }}° / {{ forecast.low }}°</span>
     <span v-if="forecast.precipProbability != null" class="inline-flex items-center gap-1">
       <UIcon name="i-lucide-umbrella" /> {{ forecast.precipProbability }}% rain
     </span>
   </div>
+
+  <p
+    v-else-if="tooFarOut"
+    class="inline-flex items-center gap-1.5 text-sm italic"
+    :class="textClass"
+  >
+    <UIcon name="i-lucide-wheat" class="text-base" />
+    The Farmer's Almanac says: {{ almanac }}
+  </p>
 </template>

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -294,7 +294,9 @@ async function onRevoke(invite: Invite): Promise<void> {
           <div class="flex flex-wrap items-center justify-between gap-3">
             <p class="text-sm text-muted">
               {{ people.length }} member{{ people.length === 1 ? '' : 's' }}
-              <template v-if="pendingInvites.length">· {{ pendingInvites.length }} pending</template>
+              <template v-if="pendingInvites.length">
+                · {{ pendingInvites.length }} pending
+              </template>
             </p>
             <UButton label="Invite someone" icon="i-lucide-user-plus" size="sm" @click="inviteOpen = true" />
           </div>
@@ -407,7 +409,6 @@ async function onRevoke(invite: Invite): Promise<void> {
         <div v-if="selectedEventId" class="max-w-xl">
           <BringList
             :items="bringItems"
-            :doughs="rsvpCounts.going"
             manage
             @add="onAddBring"
             @remove="onRemoveBring"

--- a/test/BringList.nuxt.test.ts
+++ b/test/BringList.nuxt.test.ts
@@ -12,36 +12,40 @@ const items = [
 ]
 
 describe('BringList (public claim view)', () => {
-  it('shows the pizza-dough count and every item label', async () => {
-    const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
-    expect(w.text()).toContain('2 pizza doughs needed')
+  it('shows every item label', async () => {
+    const w = await mountSuspended(BringList, { props: { items } })
     expect(w.text()).toContain('Chips')
     expect(w.text()).toContain('Drinks')
   })
 
+  it('no longer shows a pizza-dough count', async () => {
+    const w = await mountSuspended(BringList, { props: { items } })
+    expect(w.text().toLowerCase()).not.toContain('pizza dough')
+  })
+
   it('emits claim for an open item', async () => {
-    const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
+    const w = await mountSuspended(BringList, { props: { items } })
     const claimBtn = w.findAll('button').find(b => b.text().includes('I\'ll bring it'))
     await claimBtn?.trigger('click')
     expect(w.emitted('claim')?.[0]).toEqual([items[0]])
   })
 
   it('emits unclaim for an item I already own', async () => {
-    const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
+    const w = await mountSuspended(BringList, { props: { items } })
     const unclaimBtn = w.findAll('button').find(b => b.text().includes('Unclaim'))
     await unclaimBtn?.trigger('click')
     expect(w.emitted('unclaim')?.[0]).toEqual([items[1]])
   })
 
   it('has no add input — the list is admin-curated', async () => {
-    const w = await mountSuspended(BringList, { props: { items, doughs: 2 } })
+    const w = await mountSuspended(BringList, { props: { items } })
     expect(w.find('input').exists()).toBe(false)
   })
 })
 
 describe('BringList (admin manage view)', () => {
   it('emits add for a newly typed item', async () => {
-    const w = await mountSuspended(BringList, { props: { items, doughs: 2, manage: true } })
+    const w = await mountSuspended(BringList, { props: { items, manage: true } })
     await w.find('input').setValue('Blanket')
     const addBtn = w.findAll('button').find(b => b.text().trim() === 'Add')
     await addBtn?.trigger('click')
@@ -49,14 +53,14 @@ describe('BringList (admin manage view)', () => {
   })
 
   it('emits remove for an item', async () => {
-    const w = await mountSuspended(BringList, { props: { items, doughs: 2, manage: true } })
+    const w = await mountSuspended(BringList, { props: { items, manage: true } })
     const removeBtn = w.findAll('button').find(b => b.attributes('aria-label') === 'Remove item')
     await removeBtn?.trigger('click')
     expect(w.emitted('remove')?.[0]).toEqual([items[0]])
   })
 
   it('shows no claim buttons in manage mode', async () => {
-    const w = await mountSuspended(BringList, { props: { items, doughs: 2, manage: true } })
+    const w = await mountSuspended(BringList, { props: { items, manage: true } })
     expect(w.findAll('button').some(b => b.text().includes('I\'ll bring it'))).toBe(false)
   })
 })

--- a/test/EventHero.nuxt.test.ts
+++ b/test/EventHero.nuxt.test.ts
@@ -44,4 +44,26 @@ describe('EventHero', () => {
     await w.find('button').trigger('click')
     expect(w.emitted('open')).toHaveLength(1)
   })
+
+  it('signals it is clickable (cursor + link-styled title)', async () => {
+    const w = await mountSuspended(EventHero, { props: { event: baseEvent, backdrop: null } })
+    expect(w.find('button').classes()).toContain('cursor-pointer')
+    expect(w.find('h1').classes()).toContain('group-hover:underline')
+  })
+
+  it('surfaces the weather line for an upcoming event with a location', async () => {
+    const w = await mountSuspended(EventHero, {
+      props: { event: { ...baseEvent, location: 'The Green' }, backdrop: null },
+      global: { stubs: { WeatherForecast: { template: '<div class="wf-stub" />' } } }
+    })
+    expect(w.find('.wf-stub').exists()).toBe(true)
+  })
+
+  it('omits the weather line when the event has no location', async () => {
+    const w = await mountSuspended(EventHero, {
+      props: { event: baseEvent, backdrop: null },
+      global: { stubs: { WeatherForecast: { template: '<div class="wf-stub" />' } } }
+    })
+    expect(w.find('.wf-stub').exists()).toBe(false)
+  })
 })

--- a/test/InviteLimitSetting.nuxt.test.ts
+++ b/test/InviteLimitSetting.nuxt.test.ts
@@ -12,7 +12,9 @@ mockNuxtImport('useAppSettings', () => () => ({
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
 
-beforeEach(() => { saved = undefined })
+beforeEach(() => {
+  saved = undefined
+})
 
 async function clickSave(w: { findAll: (s: string) => Array<{ text: () => string, trigger: (e: string) => Promise<void> }> }): Promise<void> {
   const btn = w.findAll('button').find(b => b.text().includes('Save'))

--- a/test/WeatherForecast.nuxt.test.ts
+++ b/test/WeatherForecast.nuxt.test.ts
@@ -4,21 +4,31 @@ import { ref } from 'vue'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import WeatherForecast from '../app/components/WeatherForecast.vue'
 
+const soon = new Date(Date.now() + 5 * 86_400_000).toISOString().slice(0, 10)
+const farOut = new Date(Date.now() + 60 * 86_400_000).toISOString().slice(0, 10)
+const unavailable = { available: false, high: null, low: null, precipProbability: null, code: null, place: null }
+
 const forecast = ref<unknown>(null)
 mockNuxtImport('useWeather', () => () => ({ forecast, pending: ref(false) }))
 
 describe('WeatherForecast', () => {
-  it('shows the condition, temps and rain chance when available', async () => {
+  it('shows the condition, temps and rain chance when a forecast is available', async () => {
     forecast.value = { available: true, high: 82, low: 61, precipProbability: 20, code: 61, place: 'Town' }
-    const w = await mountSuspended(WeatherForecast, { props: { location: 'Town', date: '2026-07-01' } })
+    const w = await mountSuspended(WeatherForecast, { props: { location: 'Town', date: soon } })
     expect(w.text()).toContain('Rain')
     expect(w.text()).toContain('82')
     expect(w.text()).toContain('20% rain')
   })
 
-  it('renders nothing when no forecast is available', async () => {
-    forecast.value = { available: false, high: null, low: null, precipProbability: null, code: null, place: null }
-    const w = await mountSuspended(WeatherForecast, { props: { location: 'Town', date: '2026-07-01' } })
+  it('renders nothing inside the window when no forecast is available', async () => {
+    forecast.value = unavailable
+    const w = await mountSuspended(WeatherForecast, { props: { location: 'Town', date: soon } })
     expect(w.text().trim()).toBe('')
+  })
+
+  it('shows a Farmer\'s Almanac quip for events beyond the forecast window', async () => {
+    forecast.value = unavailable
+    const w = await mountSuspended(WeatherForecast, { props: { location: 'Town', date: farOut } })
+    expect(w.text()).toContain('Farmer\'s Almanac')
   })
 })

--- a/test/login.nuxt.test.ts
+++ b/test/login.nuxt.test.ts
@@ -11,7 +11,10 @@ const auth = {
   signInWithGoogle: async () => { calls.push('google') },
   signInWithFacebook: async () => { calls.push('facebook') },
   signInWithEmail: async (email: string) => { calls.push(`email:${email}`) },
-  signUpWithEmail: async (email: string) => { calls.push(`signup:${email}`); return { needsConfirmation: true } },
+  signUpWithEmail: async (email: string) => {
+    calls.push(`signup:${email}`)
+    return { needsConfirmation: true }
+  },
   sendPasswordReset: async (email: string) => { calls.push(`reset:${email}`) }
 }
 

--- a/test/reset-password.nuxt.test.ts
+++ b/test/reset-password.nuxt.test.ts
@@ -9,11 +9,17 @@ let navTarget: string | null = null
 
 mockNuxtImport('useSupabaseClient', () => () => ({
   auth: {
-    updateUser: async (args: { password: string }) => { updateCalls.push(args); return { error: null } }
+    updateUser: async (args: { password: string }) => {
+      updateCalls.push(args)
+      return { error: null }
+    }
   }
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
-mockNuxtImport('navigateTo', () => (to: string) => { navTarget = to; return to })
+mockNuxtImport('navigateTo', () => (to: string) => {
+  navTarget = to
+  return to
+})
 
 beforeEach(() => {
   updateCalls.length = 0

--- a/test/useAdminPeople.nuxt.test.ts
+++ b/test/useAdminPeople.nuxt.test.ts
@@ -18,14 +18,20 @@ function from(table: string) {
     order: () => result,
     is: () => chain,
     delete: () => chain,
-    eq: (col: string, val: unknown) => { calls.del.push({ col, val }); return Promise.resolve({ error: null }) }
+    eq: (col: string, val: unknown) => {
+      calls.del.push({ col, val })
+      return Promise.resolve({ error: null })
+    }
   }
   return chain
 }
 
 const supabase = {
   from,
-  rpc: (fn: string, args: unknown) => { calls.rpc.push({ fn, args }); return Promise.resolve({ error: null }) }
+  rpc: (fn: string, args: unknown) => {
+    calls.rpc.push({ fn, args })
+    return Promise.resolve({ error: null })
+  }
 }
 
 mockNuxtImport('useSupabaseClient', () => () => supabase)

--- a/test/useAppSettings.nuxt.test.ts
+++ b/test/useAppSettings.nuxt.test.ts
@@ -7,13 +7,18 @@ const supabase = {
   from() {
     return {
       select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { max_invites: 10 } }) }) }),
-      update: (payload: unknown) => { updates.push(payload); return { eq: () => Promise.resolve({ error: null }) } }
+      update: (payload: unknown) => {
+        updates.push(payload)
+        return { eq: () => Promise.resolve({ error: null }) }
+      }
     }
   }
 }
 mockNuxtImport('useSupabaseClient', () => () => supabase)
 
-beforeEach(() => { updates.length = 0 })
+beforeEach(() => {
+  updates.length = 0
+})
 
 describe('useAppSettings', () => {
   it('setMaxInvites updates the singleton and reflects the new value', async () => {

--- a/test/useAuth.nuxt.test.ts
+++ b/test/useAuth.nuxt.test.ts
@@ -8,12 +8,17 @@ const calls: Call[] = []
 let nextError: Error | null = null
 let nextSession: unknown = null // what signUp returns as data.session
 
+function record(fn: string, args: unknown[], result: unknown): Promise<unknown> {
+  calls.push({ fn, args })
+  return Promise.resolve(result)
+}
+
 const auth = {
-  signInWithOAuth: (args: unknown) => { calls.push({ fn: 'signInWithOAuth', args: [args] }); return Promise.resolve({ error: nextError }) },
-  signInWithPassword: (args: unknown) => { calls.push({ fn: 'signInWithPassword', args: [args] }); return Promise.resolve({ error: nextError }) },
-  signUp: (args: unknown) => { calls.push({ fn: 'signUp', args: [args] }); return Promise.resolve({ data: { session: nextSession }, error: nextError }) },
-  resetPasswordForEmail: (email: string, opts: unknown) => { calls.push({ fn: 'resetPasswordForEmail', args: [email, opts] }); return Promise.resolve({ error: nextError }) },
-  signOut: () => { calls.push({ fn: 'signOut', args: [] }); return Promise.resolve({ error: null }) }
+  signInWithOAuth: (args: unknown) => record('signInWithOAuth', [args], { error: nextError }),
+  signInWithPassword: (args: unknown) => record('signInWithPassword', [args], { error: nextError }),
+  signUp: (args: unknown) => record('signUp', [args], { data: { session: nextSession }, error: nextError }),
+  resetPasswordForEmail: (email: string, opts: unknown) => record('resetPasswordForEmail', [email, opts], { error: nextError }),
+  signOut: () => record('signOut', [], { error: null })
 }
 
 mockNuxtImport('useSupabaseClient', () => () => ({ auth }))


### PR DESCRIPTION
## Scope

Your three asks, plus two things I found stranded (never reached `main` after
earlier merges):

- **Weather on the overview hero** ☀️ — the forecast now shows on the poster
  hero (under the event title), not just inside the details popup. New `light`
  tone on `WeatherForecast` so it reads over the dark poster.
- **Farmer's Almanac quip** 🌾 — for events **beyond** Open-Meteo's ~2-week
  window it shows e.g. *"The Farmer's Almanac says: weather will be perfect!"*,
  then flips to the real forecast once it's in range. (This was stranded — it
  merged-after on #59, so it wasn't actually in prod.)
- **Drop the pizza-dough count** 🍕 — removed the "N pizza doughs needed" readout
  from `BringList` and the `doughs` prop everywhere (also stranded from #49).
- **Re-added the hero click affordances** (cursor-pointer + link-styled title) —
  also stranded from #49.

## Plus: greens CI

`main` is currently **lint-red** — the one-statement-per-line test mocks + a
couple of formatting nits from earlier PRs (whose fixes got stranded the same
way). Since CI lints the whole repo, this PR includes those fixes (separate
commit, formatting-only) so its CI passes and `main` goes clean on merge.

## On the Node "bump"

Nothing to change — `.nvmrc` is **already `22`** and `engines` is `>=22.0.0`, which
is why CI's lint runs fine. The local crash you/I saw was just a dev machine on
Node 20 (`Object.groupBy` needs 21+). Fix is `nvm use` / install Node 22 locally;
I verified lint via a local polyfill (0 errors).

## How to Test

- `npm test` → 140 passing; typecheck clean; lint clean (verified locally).
- Manual: overview → the hero shows the forecast (or the Almanac quip for far-out
  events); the cursor changes + title underlines on hover; the bring list no
  longer mentions pizza dough.

## Note on stranding

Several earlier follow-up commits never reached `main` because their PR merged
before the follow-up was pushed (#49 affordances/dough, #59 almanac). This PR
re-lands them off current `main`. Worth a glance at the deploy/merge flow so
late pushes to an already-merged PR don't get lost.
