### PR TITLE
fix: Evite send/invite 403 (service role) + pull-from-last-event

### DIFF
--- a/app/composables/useEventInvites.ts
+++ b/app/composables/useEventInvites.ts
@@ -60,28 +60,31 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
     await refresh()
   }
 
-  /** Copy the previous event's guest list onto this one (skipping anyone already
-   *  here) — the "auto-add from last event unless we remove them" behavior. */
+  /** Copy the guest list from the most recent OTHER event that actually has one
+   *  onto this event (skipping anyone already here) — the "auto-add from the last
+   *  event unless we remove them" behavior. Walks past events with no list and
+   *  tolerates events added out of date order, instead of only checking the single
+   *  chronologically-previous event. */
   async function seedFromLastEvent(): Promise<number> {
     const id = toValue(eventId)
     if (!id) return 0
-    const { data: current } = await supabase.from('events').select('event_date').eq('id', id).single()
-    if (!current) return 0
-    const { data: prev } = await supabase
+    const { data: others } = await supabase
       .from('events')
       .select('id')
-      .lt('event_date', current.event_date)
+      .neq('id', id)
       .order('event_date', { ascending: false })
-      .limit(1)
-      .maybeSingle()
-    if (!prev) return 0
-    const { data: prevInvites } = await supabase
+    const otherIds = (others ?? []).map(e => e.id)
+    if (!otherIds.length) return 0
+    const { data: pool } = await supabase
       .from('event_invites')
-      .select('email, display_name')
-      .eq('event_id', prev.id)
+      .select('event_id, email, display_name')
+      .in('event_id', otherIds)
+    // otherIds is newest-first; take the first that has any invites.
+    const sourceId = otherIds.find(eid => (pool ?? []).some(p => p.event_id === eid))
+    if (!sourceId) return 0
     const existing = new Set(invites.value.map(i => i.email))
-    const toAdd = (prevInvites ?? [])
-      .filter(p => !existing.has(p.email))
+    const toAdd = (pool ?? [])
+      .filter(p => p.event_id === sourceId && !existing.has(p.email))
       .map(p => ({ event_id: id, email: p.email, display_name: p.display_name }))
     if (!toAdd.length) return 0
     const { error } = await supabase.from('event_invites').insert(toAdd)

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -1,12 +1,13 @@
-import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server'
+import { serverSupabaseServiceRole, serverSupabaseUser } from '#supabase/server'
 import type { Database } from '~/types/database.types'
 
 /**
- * Sends (or re-sends) the tokenized e-vites for an event's guest list. Admin-only
- * (checked via the caller's own profile). For each not-yet-sent invitee we email
- * the one-click RSVP links, add them to the allowlist so they can also sign in
- * (per the product decision), and stamp sent_at + the Resend message id (used to
- * correlate open/click webhooks). Runs under the admin's session — RLS holds.
+ * Sends (or re-sends) the tokenized e-vites for an event's guest list. Admin-only,
+ * verified explicitly via is_admin. Uses the service role for the DB work because
+ * the caller's session isn't reliably available inside the serverless function
+ * (an RLS-scoped client there read no rows and 403'd a real admin). For each
+ * not-yet-sent invitee we email the one-click RSVP links, add them to the
+ * allowlist so they can sign in too, and stamp sent_at + the Resend message id.
  */
 export default defineEventHandler(async (event) => {
   const user = await serverSupabaseUser(event)
@@ -15,14 +16,14 @@ export default defineEventHandler(async (event) => {
   const eventId = getRouterParam(event, 'id')
   if (!eventId) throw createError({ statusCode: 400, statusMessage: 'Missing event id' })
 
-  const client = await serverSupabaseClient<Database>(event)
-  const { data: me } = await client.from('profiles').select('is_admin').eq('id', user.id).single()
+  const db = serverSupabaseServiceRole<Database>(event)
+  const { data: me } = await db.from('profiles').select('is_admin').eq('id', user.id).single()
   if (!me?.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
 
-  const { data: ev } = await client.from('events').select('title, event_date, location').eq('id', eventId).single()
+  const { data: ev } = await db.from('events').select('title, event_date, location').eq('id', eventId).single()
   if (!ev) throw createError({ statusCode: 404, statusMessage: 'Event not found' })
 
-  const { data: invites } = await client
+  const { data: invites } = await db
     .from('event_invites')
     .select('id, email, display_name, token')
     .eq('event_id', eventId)
@@ -54,11 +55,11 @@ export default defineEventHandler(async (event) => {
         replyTo: user.email ?? undefined
       })
       // Allowlist them so they can sign in too (idempotent).
-      await client.from('invites').upsert(
+      await db.from('invites').upsert(
         { email: invite.email, display_name: invite.display_name, invited_by: user.id },
         { onConflict: 'email', ignoreDuplicates: true }
       )
-      await client
+      await db
         .from('event_invites')
         .update({ sent_at: new Date().toISOString(), resend_id: resendId })
         .eq('id', invite.id)

--- a/server/api/invites/send.post.ts
+++ b/server/api/invites/send.post.ts
@@ -1,4 +1,4 @@
-import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server'
+import { serverSupabaseServiceRole, serverSupabaseUser } from '#supabase/server'
 import { z } from 'zod'
 import type { Database } from '~/types/database.types'
 
@@ -8,11 +8,11 @@ const bodySchema = z.object({
 })
 
 /**
- * Invite a friend: any allowlisted member adds an email to the allowlist and we
- * send them an e-vite. The insert runs under the member's own session so RLS
- * (must be allowlisted + not blocked) and the total-invite cap trigger apply —
- * the route never bypasses the authorization boundary (Invariant 1). The Resend
- * key stays server-only (Invariant 2).
+ * Invite a friend: an allowlisted, non-blocked member adds an email to the
+ * allowlist and we send them an e-vite. Uses the service role (the caller's
+ * session isn't reliably available in the serverless fn), so we re-check the
+ * inviter is allowed + not blocked here — the same gate RLS would apply
+ * (Invariant 1). The Resend key stays server-only (Invariant 2).
  */
 export default defineEventHandler(async (event) => {
   const user = await serverSupabaseUser(event)
@@ -24,20 +24,31 @@ export default defineEventHandler(async (event) => {
   }
   const { email, name } = parsed.data
 
-  const client = await serverSupabaseClient<Database>(event)
-  const { error: insertError } = await client.from('invites').insert({
+  const db = serverSupabaseServiceRole<Database>(event)
+
+  // The inviter must be an allowlisted (admin or on the list), non-blocked member.
+  const { data: me } = await db.from('profiles').select('is_admin, blocked').eq('id', user.id).single()
+  if (!me || me.blocked) throw createError({ statusCode: 403, statusMessage: 'Not allowed to invite' })
+  let allowed = me.is_admin
+  const inviterEmail = (user.email ?? '').trim().toLowerCase()
+  if (!allowed && inviterEmail) {
+    const { data: onList } = await db.from('invites').select('email').eq('email', inviterEmail).maybeSingle()
+    allowed = Boolean(onList)
+  }
+  if (!allowed) throw createError({ statusCode: 403, statusMessage: 'Not allowed to invite' })
+
+  // 23505 = already on the allowlist; that's fine, we still (re)send the e-vite.
+  const { error: insertError } = await db.from('invites').insert({
     email,
     display_name: name ?? null,
     invited_by: user.id
   })
-  // 23505 = already on the allowlist; that's fine, we still (re)send the e-vite.
   if (insertError && insertError.code !== '23505') {
-    // RLS denial / cap reached / blocked all surface here.
-    throw createError({ statusCode: 403, statusMessage: insertError.message || 'Could not add invite' })
+    throw createError({ statusCode: 400, statusMessage: insertError.message || 'Could not add invite' })
   }
 
-  // Enrich the e-vite with the next upcoming event, if any (read is RLS-gated).
-  const { data: nextEvent } = await client
+  // Enrich the e-vite with the next upcoming event, if any.
+  const { data: nextEvent } = await db
     .from('events')
     .select('title, event_date')
     .gte('event_date', new Date().toISOString())

--- a/test/useEventInvites.nuxt.test.ts
+++ b/test/useEventInvites.nuxt.test.ts
@@ -4,12 +4,16 @@ import { ref } from 'vue'
 import { flushPromises } from '@vue/test-utils'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
-let list: Array<Record<string, unknown>> = []
+let list: Array<Record<string, unknown>> = [] // current event's invites (refresh)
+let eventsList: Array<Record<string, unknown>> = [] // other events (seed)
+let poolList: Array<Record<string, unknown>> = [] // invites across other events (seed pool)
 const ops = { inserted: [] as unknown[], deleted: [] as unknown[] }
 
-// Thenable + chainable stub mirroring the PostgREST builder: awaiting the chain
-// resolves to { data: list }; terminal single()/maybeSingle() resolve explicitly.
+// Thenable + chainable stub mirroring the PostgREST builder. event_invites resolves
+// to the seed `poolList` when filtered with .in() (the pool query) and `list`
+// otherwise (the per-event refresh); events resolves to `eventsList`.
 function builder(table: string) {
+  let usedIn = false
   const c: Record<string, unknown> = {
     select: () => c,
     eq: () => c,
@@ -17,6 +21,11 @@ function builder(table: string) {
     lt: () => c,
     limit: () => c,
     is: () => c,
+    neq: () => c,
+    in: () => {
+      usedIn = true
+      return c
+    },
     single: () => Promise.resolve({ data: { event_date: '2026-01-01' } }),
     maybeSingle: () => Promise.resolve({ data: null }),
     insert: (v: unknown) => {
@@ -29,7 +38,10 @@ function builder(table: string) {
         return Promise.resolve({ error: null })
       }
     }),
-    then: (resolve: (v: unknown) => void) => resolve({ data: table === 'event_invites' ? list : [] })
+    then: (resolve: (v: unknown) => void) => {
+      const data = table === 'events' ? eventsList : table === 'event_invites' ? (usedIn ? poolList : list) : []
+      resolve({ data })
+    }
   }
   return c
 }
@@ -43,6 +55,8 @@ mockNuxtImport('useSupabaseClient', () => () => supabase)
 
 beforeEach(() => {
   list = []
+  eventsList = []
+  poolList = []
   ops.inserted = []
   ops.deleted = []
 })
@@ -73,5 +87,25 @@ describe('useEventInvites', () => {
     await flushPromises()
     await removeInvite('a')
     expect(ops.deleted).toContain('a')
+  })
+
+  it('seedFromLastEvent pulls from the most recent other event that has a list', async () => {
+    // Current event ('e') has no invites; an older event ('prev') does.
+    list = []
+    eventsList = [{ id: 'prev' }]
+    poolList = [{ event_id: 'prev', email: 'guest@x', display_name: 'Guest' }]
+    const { seedFromLastEvent } = useEventInvites(ref('e'))
+    await flushPromises()
+    const added = await seedFromLastEvent()
+    expect(added).toBe(1)
+    expect(ops.inserted.flat().some(i => (i as { email?: string }).email === 'guest@x')).toBe(true)
+  })
+
+  it('seedFromLastEvent returns 0 when no other event has a list', async () => {
+    eventsList = [{ id: 'prev' }]
+    poolList = []
+    const { seedFromLastEvent } = useEventInvites(ref('e'))
+    await flushPromises()
+    expect(await seedFromLastEvent()).toBe(0)
   })
 })


### PR DESCRIPTION
## Scope

Two prod bugs you just hit in the Evite flow:

### 🔴 403 "Admins only" on send (and invite-a-friend)
Both `/api/events/[id]/invites/send` and the member `/api/invites/send` checked
auth via **`serverSupabaseClient`** (the caller's session). In the Vercel
serverless function that session isn't reliably available, so the RLS-scoped read
came back **empty** and the route rejected you — a real admin — with 403.

Fix: both routes now use the **service role** and verify the gate **explicitly**
in code (the announce route already does this):
- send → `is_admin` check
- invite-a-friend → allowlisted (admin or on the list) **and** not blocked

Same authorization, just enforced in the handler instead of relying on a session
that isn't there.

### 🔴 "Pull from last event" said "nothing new"
`seedFromLastEvent` only checked the **single chronologically-previous event**.
If that one had no guest list (an empty event in between, or events added out of
date order), it stopped and pulled nothing. Now it walks other events
**newest-first and pulls from the most recent one that actually has a list**.

## Tests

`useEventInvites` gains coverage for the seed path (pulls from the most-recent
event-with-a-list; returns 0 when none). `npm test` → 155 passing; typecheck +
lint clean.

## Deploy

Needs `NUXT_SUPABASE_SECRET_KEY` (service role) set in Vercel — you already added
the env vars, so this should just work once deployed.

## Invariants

Authorization is unchanged in substance — the routes still gate on the same
admin/allowlisted/not-blocked conditions; they just check them in the handler
(service role below RLS) because the session-scoped client wasn't usable in the
serverless runtime.
