### PR TITLE
feat: lock voting + admin stats drill-downs (people & events)

### DIFF
--- a/app/components/EventStatsModal.vue
+++ b/app/components/EventStatsModal.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import type { MovieEvent } from '#shared/types/event'
+
+const open = defineModel<boolean>('open', { default: false })
+const props = defineProps<{ event: MovieEvent | null }>()
+
+// Only query while the modal is open for a real event.
+const targetId = computed(() => (open.value ? props.event?.id ?? null : null))
+const { stats, pending, error } = useEventStats(targetId)
+
+const locked = computed(() => Boolean(props.event?.voting_locked_at))
+const title = computed(() => props.event?.title || 'Event')
+const tiles = computed(() => [
+  { label: 'Movies', value: stats.value?.suggestionCount ?? 0, icon: 'i-lucide-film' },
+  { label: 'Votes', value: stats.value?.voteCount ?? 0, icon: 'i-lucide-heart' },
+  { label: 'Submitters', value: stats.value?.submitterCount ?? 0, icon: 'i-lucide-user-pen' },
+  { label: 'Voters', value: stats.value?.voterCount ?? 0, icon: 'i-lucide-users' }
+])
+const rsvp = computed(() => [
+  { label: 'Going', value: stats.value?.going ?? 0 },
+  { label: 'Maybe', value: stats.value?.maybe ?? 0 },
+  { label: 'Declined', value: stats.value?.declined ?? 0 }
+])
+</script>
+
+<template>
+  <UModal v-model:open="open" :title="title" description="Event stats" :ui="{ content: 'sm:max-w-lg' }">
+    <template #body>
+      <div v-if="pending" class="py-10 text-center text-muted">
+        <UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" />
+        <p class="mt-2 text-sm">
+          Loading stats…
+        </p>
+      </div>
+
+      <p v-else-if="error" class="py-6 text-center text-sm text-error">
+        {{ error }}
+      </p>
+
+      <div v-else-if="stats" class="space-y-5">
+        <!-- Headline counts -->
+        <div class="grid grid-cols-4 gap-2 text-center">
+          <div v-for="t in tiles" :key="t.label" class="rounded-lg ring ring-default p-2">
+            <UIcon :name="t.icon" class="text-muted" />
+            <p class="text-xl font-bold leading-tight">
+              {{ t.value }}
+            </p>
+            <p class="text-[11px] text-muted leading-tight">
+              {{ t.label }}
+            </p>
+          </div>
+        </div>
+
+        <!-- RSVP split -->
+        <section>
+          <h3 class="text-sm font-semibold mb-2 flex items-center gap-1.5">
+            <UIcon name="i-lucide-calendar-check" /> RSVPs
+          </h3>
+          <div class="flex gap-2">
+            <UBadge v-for="r in rsvp" :key="r.label" :label="`${r.label}: ${r.value}`" color="neutral" variant="subtle" />
+          </div>
+        </section>
+
+        <!-- Bring list progress -->
+        <section>
+          <h3 class="text-sm font-semibold mb-2 flex items-center gap-1.5">
+            <UIcon name="i-lucide-utensils" /> Bring list
+          </h3>
+          <p class="text-sm text-muted">
+            {{ stats.bringClaimed }} of {{ stats.bringTotal }} item{{ stats.bringTotal === 1 ? '' : 's' }} claimed
+          </p>
+        </section>
+
+        <!-- Top picks / winners -->
+        <section v-if="stats.topPicks.length">
+          <h3 class="text-sm font-semibold mb-2 flex items-center gap-1.5">
+            <UIcon name="i-lucide-trophy" class="text-amber-400" />
+            {{ locked ? 'Winners 🍿' : 'Leading' }}
+          </h3>
+          <ol class="space-y-1">
+            <li
+              v-for="(pick, i) in stats.topPicks"
+              :key="i"
+              class="text-sm flex items-center justify-between gap-2"
+            >
+              <span class="truncate">{{ i + 1 }}. {{ pick.title }}</span>
+              <span class="text-muted shrink-0">{{ pick.votes }} vote{{ pick.votes === 1 ? '' : 's' }}</span>
+            </li>
+          </ol>
+        </section>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/app/components/PeopleList.vue
+++ b/app/components/PeopleList.vue
@@ -10,6 +10,7 @@ const emit = defineEmits<{
   block: [person: Profile]
   unblock: [person: Profile]
   revoke: [invite: Invite]
+  select: [person: Profile]
 }>()
 
 type Row
@@ -78,7 +79,15 @@ function initials(name: string, email: string): string {
           size="sm"
           class="shrink-0"
         />
-        <div class="min-w-0 flex-1">
+        <!-- Member rows open a stats drill-down; pending invites have no activity yet. -->
+        <component
+          :is="row.kind === 'member' ? 'button' : 'div'"
+          :type="row.kind === 'member' ? 'button' : undefined"
+          class="min-w-0 flex-1 text-left"
+          :class="row.kind === 'member' ? 'hover:opacity-80 cursor-pointer' : ''"
+          :aria-label="row.kind === 'member' ? `View ${row.name}'s activity` : undefined"
+          @click="row.kind === 'member' && emit('select', row.profile)"
+        >
           <p class="font-medium truncate flex items-center gap-1.5">
             {{ row.name }}
             <UBadge v-if="row.kind === 'member' && row.profile.is_admin" label="Admin" color="primary" variant="subtle" size="xs" />
@@ -88,7 +97,7 @@ function initials(name: string, email: string): string {
           <p class="text-xs text-muted truncate">
             {{ row.email || '—' }}
           </p>
-        </div>
+        </component>
 
         <!-- Member actions: ban/unban (admins can't be banned from the UI). -->
         <template v-if="row.kind === 'member'">

--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Suggestion } from '#shared/types/suggestion'
 
-const props = defineProps<{ suggestion: Suggestion, rank: number, maxVotes: number }>()
+const props = defineProps<{ suggestion: Suggestion, rank: number, maxVotes: number, locked?: boolean }>()
 const emit = defineEmits<{ vote: [], unvote: [], remove: [], trailer: [] }>()
 
 const { myId } = useAuth()
@@ -59,7 +59,17 @@ const highlight = computed(() => props.rank === 1 && voteCount.value > 0)
             {{ movie.title }}
             <span v-if="year" class="text-muted font-normal">({{ year }})</span>
           </h3>
+          <UBadge
+            v-if="locked"
+            icon="i-lucide-heart"
+            :label="String(voteCount)"
+            :color="highlight ? 'primary' : 'neutral'"
+            variant="subtle"
+            size="md"
+            class="shrink-0"
+          />
           <UButton
+            v-else
             :color="hasVoted ? 'error' : 'neutral'"
             :variant="hasVoted ? 'soft' : 'outline'"
             icon="i-lucide-heart"
@@ -86,7 +96,7 @@ const highlight = computed(() => props.rank === 1 && voteCount.value > 0)
             @click="emit('trailer')"
           />
           <UButton
-            v-if="isOwner"
+            v-if="isOwner && !locked"
             icon="i-lucide-trash-2"
             color="neutral"
             variant="ghost"

--- a/app/components/UserStatsModal.vue
+++ b/app/components/UserStatsModal.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import type { Profile } from '#shared/types/user'
+
+const open = defineModel<boolean>('open', { default: false })
+const props = defineProps<{ person: Profile | null }>()
+
+// Only query while the modal is open for a real person.
+const targetId = computed(() => (open.value ? props.person?.id ?? null : null))
+const { stats, pending, error } = useUserStats(targetId)
+
+const name = computed(() => props.person?.display_name || props.person?.email || 'Member')
+const summary = computed(() => [
+  { label: 'Going', value: stats.value?.going ?? 0, icon: 'i-lucide-check' },
+  { label: 'Maybe', value: stats.value?.maybe ?? 0, icon: 'i-lucide-help-circle' },
+  { label: 'Declined', value: stats.value?.declined ?? 0, icon: 'i-lucide-x' },
+  { label: 'Votes cast', value: stats.value?.votesCast ?? 0, icon: 'i-lucide-heart' }
+])
+</script>
+
+<template>
+  <UModal v-model:open="open" :title="name" :description="`${name}'s activity`" :ui="{ content: 'sm:max-w-lg' }">
+    <template #body>
+      <div v-if="pending" class="py-10 text-center text-muted">
+        <UIcon name="i-lucide-loader-circle" class="size-6 animate-spin" />
+        <p class="mt-2 text-sm">
+          Loading activity…
+        </p>
+      </div>
+
+      <p v-else-if="error" class="py-6 text-center text-sm text-error">
+        {{ error }}
+      </p>
+
+      <div v-else-if="stats" class="space-y-5">
+        <!-- RSVP + voting summary -->
+        <div class="grid grid-cols-4 gap-2 text-center">
+          <div v-for="s in summary" :key="s.label" class="rounded-lg ring ring-default p-2">
+            <UIcon :name="s.icon" class="text-muted" />
+            <p class="text-xl font-bold leading-tight">
+              {{ s.value }}
+            </p>
+            <p class="text-[11px] text-muted leading-tight">
+              {{ s.label }}
+            </p>
+          </div>
+        </div>
+
+        <!-- Movies suggested -->
+        <section>
+          <h3 class="text-sm font-semibold mb-2 flex items-center gap-1.5">
+            <UIcon name="i-lucide-film" /> Movies suggested
+            <UBadge :label="String(stats.submitted.length)" color="neutral" variant="subtle" size="xs" />
+            <UBadge v-if="stats.wins" :label="`${stats.wins} won 🏆`" color="primary" variant="subtle" size="xs" />
+          </h3>
+          <ul v-if="stats.submitted.length" class="space-y-1">
+            <li
+              v-for="m in stats.submitted"
+              :key="m.id"
+              class="text-sm flex items-center gap-2 justify-between"
+            >
+              <span class="truncate">{{ m.title }}</span>
+              <UBadge v-if="m.won" label="Winner" icon="i-lucide-trophy" color="primary" variant="subtle" size="xs" class="shrink-0" />
+            </li>
+          </ul>
+          <p v-else class="text-sm text-muted">
+            None yet.
+          </p>
+        </section>
+
+        <!-- Brought to the potluck -->
+        <section>
+          <h3 class="text-sm font-semibold mb-2 flex items-center gap-1.5">
+            <UIcon name="i-lucide-utensils" /> Brought
+            <UBadge :label="String(stats.brought.length)" color="neutral" variant="subtle" size="xs" />
+          </h3>
+          <div v-if="stats.brought.length" class="flex flex-wrap gap-1.5">
+            <UBadge v-for="(item, i) in stats.brought" :key="i" :label="item" color="neutral" variant="subtle" />
+          </div>
+          <p v-else class="text-sm text-muted">
+            Nothing yet.
+          </p>
+        </section>
+      </div>
+    </template>
+  </UModal>
+</template>

--- a/app/components/WinnersBanner.vue
+++ b/app/components/WinnersBanner.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import type { Suggestion } from '#shared/types/suggestion'
+
+// The "double feature" — shown once voting is locked.
+defineProps<{ winners: Suggestion[] }>()
+const { posterUrl } = useTmdb()
+</script>
+
+<template>
+  <div v-if="winners.length" class="rounded-xl ring ring-default overflow-hidden">
+    <div class="bg-primary/10 px-4 py-2 text-sm font-semibold inline-flex items-center gap-1.5 w-full">
+      <UIcon name="i-lucide-trophy" class="text-amber-400" />
+      Voting has ended — {{ winners.length > 1 ? 'Double Feature 🍿' : 'Winner 🍿' }}
+    </div>
+    <div class="p-4 grid gap-4" :class="winners.length > 1 ? 'sm:grid-cols-2' : ''">
+      <div v-for="(winner, i) in winners" :key="winner.id" class="flex gap-3 items-center min-w-0">
+        <img
+          v-if="posterUrl(winner.tmdb_movie.poster_path, 'w185')"
+          :src="posterUrl(winner.tmdb_movie.poster_path, 'w185') ?? undefined"
+          :alt="`${winner.tmdb_movie.title} poster`"
+          class="w-14 rounded ring ring-default shrink-0"
+        >
+        <div class="min-w-0">
+          <p class="text-xs text-muted">
+            {{ i === 0 ? '🥇 Top pick' : '🥈 Also showing' }}
+          </p>
+          <p class="font-bold truncate">
+            {{ winner.tmdb_movie.title }}
+          </p>
+          <p class="text-xs text-muted">
+            {{ winner.votes?.length ?? 0 }} vote{{ (winner.votes?.length ?? 0) === 1 ? '' : 's' }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/composables/useEventAdmin.ts
+++ b/app/composables/useEventAdmin.ts
@@ -46,6 +46,15 @@ export function useEventAdmin() {
     if (error) throw error
   }
 
+  /** End voting for an event (locks new votes/suggestions via RLS), or reopen it. */
+  async function setVotingLocked(id: string, locked: boolean): Promise<void> {
+    const { error } = await supabase
+      .from('events')
+      .update({ voting_locked_at: locked ? new Date().toISOString() : null })
+      .eq('id', id)
+    if (error) throw error
+  }
+
   /** Upload a poster image to the public `event-posters` bucket; returns its public URL. */
   async function uploadPoster(file: File): Promise<string> {
     const ext = file.name.split('.').pop()?.toLowerCase() || 'jpg'
@@ -60,5 +69,5 @@ export function useEventAdmin() {
     return data.publicUrl
   }
 
-  return { createEvent, updateEvent, deleteEvent, uploadPoster }
+  return { createEvent, updateEvent, deleteEvent, setVotingLocked, uploadPoster }
 }

--- a/app/composables/useEventInvites.ts
+++ b/app/composables/useEventInvites.ts
@@ -60,32 +60,44 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
     await refresh()
   }
 
-  /** Copy the guest list from the most recent OTHER event that actually has one
-   *  onto this event (skipping anyone already here) — the "auto-add from the last
-   *  event unless we remove them" behavior. Walks past events with no list and
-   *  tolerates events added out of date order, instead of only checking the single
-   *  chronologically-previous event. */
+  /** Build this event's guest list from the most recent OTHER event that has one
+   *  (newest-first, skipping empty events). Falls back to the household roster
+   *  (everyone on the allowlist) when no prior event has a guest list yet — so the
+   *  first time you use it, you still get your people. Skips anyone already here. */
   async function seedFromLastEvent(): Promise<number> {
     const id = toValue(eventId)
     if (!id) return 0
+
+    let candidates: Array<{ email: string, display_name: string | null }> = []
     const { data: others } = await supabase
       .from('events')
       .select('id')
       .neq('id', id)
       .order('event_date', { ascending: false })
     const otherIds = (others ?? []).map(e => e.id)
-    if (!otherIds.length) return 0
-    const { data: pool } = await supabase
-      .from('event_invites')
-      .select('event_id, email, display_name')
-      .in('event_id', otherIds)
-    // otherIds is newest-first; take the first that has any invites.
-    const sourceId = otherIds.find(eid => (pool ?? []).some(p => p.event_id === eid))
-    if (!sourceId) return 0
+    if (otherIds.length) {
+      const { data: pool } = await supabase
+        .from('event_invites')
+        .select('event_id, email, display_name')
+        .in('event_id', otherIds)
+      // otherIds is newest-first; take the first event that actually has invites.
+      const sourceId = otherIds.find(eid => (pool ?? []).some(p => p.event_id === eid))
+      if (sourceId) {
+        candidates = (pool ?? [])
+          .filter(p => p.event_id === sourceId)
+          .map(p => ({ email: p.email, display_name: p.display_name }))
+      }
+    }
+    // Fallback: no prior event guest list → pull the whole allowlist roster.
+    if (!candidates.length) {
+      const { data: roster } = await supabase.from('invites').select('email, display_name')
+      candidates = (roster ?? []).map(r => ({ email: r.email, display_name: r.display_name }))
+    }
+
     const existing = new Set(invites.value.map(i => i.email))
-    const toAdd = (pool ?? [])
-      .filter(p => p.event_id === sourceId && !existing.has(p.email))
-      .map(p => ({ event_id: id, email: p.email, display_name: p.display_name }))
+    const toAdd = candidates
+      .filter(c => !existing.has(c.email))
+      .map(c => ({ event_id: id, email: c.email, display_name: c.display_name }))
     if (!toAdd.length) return 0
     const { error } = await supabase.from('event_invites').insert(toAdd)
     if (error) throw error

--- a/app/composables/useEventStats.ts
+++ b/app/composables/useEventStats.ts
@@ -1,0 +1,58 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Database } from '~/types/database.types'
+import type { Suggestion } from '#shared/types/suggestion'
+import type { EventStats } from '#shared/utils/eventStats'
+
+/**
+ * Key participation stats for one event, for the admin events drill-down:
+ * suggestions, votes, distinct submitters/voters, RSVP split, bring-list
+ * progress, and the top picks. A snapshot loaded on demand — no realtime.
+ */
+export function useEventStats(eventId: MaybeRefOrGetter<string | null>) {
+  const supabase = useSupabaseClient<Database>()
+  const stats = ref<EventStats | null>(null)
+  const pending = ref(false)
+  const error = ref<string | null>(null)
+
+  async function load(id: string): Promise<void> {
+    pending.value = true
+    error.value = null
+    try {
+      const [suggestions, rsvps, bring] = await Promise.all([
+        supabase
+          .from('suggestions')
+          .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
+          .eq('event_id', id),
+        supabase.from('rsvps').select('status').eq('event_id', id),
+        supabase.from('bring_items').select('user_id').eq('event_id', id)
+      ])
+      const firstError = suggestions.error ?? rsvps.error ?? bring.error
+      if (firstError) throw firstError
+      // Drop a stale response if the selected event changed mid-flight.
+      if (toValue(eventId) !== id) return
+
+      stats.value = computeEventStats({
+        // The votes embed isn't declared in the generated types, so cast as
+        // useSuggestions does (the inferred shape doesn't match).
+        suggestions: (suggestions.data ?? []) as unknown as Suggestion[],
+        rsvps: rsvps.data ?? [],
+        bringItems: bring.data ?? []
+      })
+    } catch (e) {
+      error.value = errorMessage(e, 'Failed to load stats')
+      stats.value = null
+    } finally {
+      pending.value = false
+    }
+  }
+
+  watch(() => toValue(eventId), (id) => {
+    if (!id) {
+      stats.value = null
+      return
+    }
+    void load(id)
+  }, { immediate: true })
+
+  return { stats, pending, error }
+}

--- a/app/composables/useUserStats.ts
+++ b/app/composables/useUserStats.ts
@@ -1,0 +1,102 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Database } from '~/types/database.types'
+import type { Suggestion } from '#shared/types/suggestion'
+import type { UserStats } from '#shared/utils/userStats'
+
+/**
+ * Participation stats for one person, for the admin people drill-down: RSVPs,
+ * movies they suggested (and which won), votes cast, and what they've brought.
+ * A snapshot loaded on demand when a userId is set — no realtime.
+ *
+ * "Wins" are computed from finished (vote-locked) events only: a suggestion
+ * counts as a win when it's a top-2 vote-getter in a locked event, mirroring the
+ * double-feature winners shown on the overview.
+ */
+export function useUserStats(userId: MaybeRefOrGetter<string | null>) {
+  const supabase = useSupabaseClient<Database>()
+  const stats = ref<UserStats | null>(null)
+  const pending = ref(false)
+  const error = ref<string | null>(null)
+
+  async function load(id: string): Promise<void> {
+    pending.value = true
+    error.value = null
+    try {
+      const [rsvps, submissions, votes, brought] = await Promise.all([
+        supabase.from('rsvps').select('status').eq('user_id', id),
+        supabase
+          .from('suggestions')
+          .select('id, event_id, tmdb_movie, created_at')
+          .eq('user_id', id)
+          .eq('deleted', false),
+        supabase.from('votes').select('suggestion_id', { count: 'exact', head: true }).eq('user_id', id),
+        supabase.from('bring_items').select('label').eq('user_id', id)
+      ])
+      const firstError = rsvps.error ?? submissions.error ?? votes.error ?? brought.error
+      if (firstError) throw firstError
+
+      const winningSuggestionIds = await computeWins(id, submissions.data ?? [])
+      // Drop a stale response if the selected user changed mid-flight.
+      if (toValue(userId) !== id) return
+
+      stats.value = computeUserStats({
+        rsvps: rsvps.data ?? [],
+        submissions: submissions.data ?? [],
+        votesCast: votes.count ?? 0,
+        brought: brought.data ?? [],
+        winningSuggestionIds
+      })
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load stats'
+      stats.value = null
+    } finally {
+      pending.value = false
+    }
+  }
+
+  /** For the events this person suggested in, find which of their suggestions won
+   *  (top-2 voted) once that event's voting is locked. */
+  async function computeWins(
+    id: string,
+    submissions: ReadonlyArray<{ id: string, event_id: string }>
+  ): Promise<Set<string>> {
+    const winners = new Set<string>()
+    const eventIds = [...new Set(submissions.map(s => s.event_id))]
+    if (!eventIds.length) return winners
+
+    const { data: lockedEvents } = await supabase
+      .from('events')
+      .select('id')
+      .in('id', eventIds)
+      .not('voting_locked_at', 'is', null)
+    const lockedIds = (lockedEvents ?? []).map(e => e.id)
+    if (!lockedIds.length) return winners
+
+    const { data: pool } = await supabase
+      .from('suggestions')
+      .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
+      .in('event_id', lockedIds)
+    // The votes embed isn't declared in the generated types (no FK relationship
+    // row), so PostgREST's inferred shape doesn't match — cast as useSuggestions does.
+    const byEvent = new Map<string, Suggestion[]>()
+    for (const s of (pool ?? []) as unknown as Suggestion[]) {
+      const list = byEvent.get(s.event_id) ?? []
+      list.push(s)
+      byEvent.set(s.event_id, list)
+    }
+    for (const list of byEvent.values()) {
+      for (const w of topWinners(list)) winners.add(w.id)
+    }
+    return winners
+  }
+
+  watch(() => toValue(userId), (id) => {
+    if (!id) {
+      stats.value = null
+      return
+    }
+    void load(id)
+  }, { immediate: true })
+
+  return { stats, pending, error }
+}

--- a/app/composables/useUserStats.ts
+++ b/app/composables/useUserStats.ts
@@ -47,7 +47,7 @@ export function useUserStats(userId: MaybeRefOrGetter<string | null>) {
         winningSuggestionIds
       })
     } catch (e) {
-      error.value = e instanceof Error ? e.message : 'Failed to load stats'
+      error.value = errorMessage(e, 'Failed to load stats')
       stats.value = null
     } finally {
       pending.value = false

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -17,6 +17,10 @@ const inviteOpen = ref(false)
 const editingEvent = ref<MovieEvent | null>(null)
 const eventPendingDelete = ref<MovieEvent | null>(null)
 
+// People drill-down: the member whose activity stats are open.
+const statsPerson = ref<Profile | null>(null)
+const statsOpen = ref(false)
+
 const selectedEventId = ref<string>()
 const { suggestions, setDeleted, voterNames } = useAdminSuggestions(selectedEventId)
 
@@ -211,6 +215,10 @@ async function onRevoke(invite: Invite): Promise<void> {
     toast.add({ title: 'Could not revoke invite', color: 'error' })
   }
 }
+function onSelectPerson(person: Profile): void {
+  statsPerson.value = person
+  statsOpen.value = true
+}
 </script>
 
 <template>
@@ -372,6 +380,7 @@ async function onRevoke(invite: Invite): Promise<void> {
             @block="onBlock"
             @unblock="onUnblock"
             @revoke="onRevoke"
+            @select="onSelectPerson"
           />
         </div>
       </template>
@@ -546,6 +555,8 @@ async function onRevoke(invite: Invite): Promise<void> {
 
     <!-- Admin invite a friend -->
     <InviteFriendModal v-model:open="inviteOpen" />
+
+    <UserStatsModal v-model:open="statsOpen" :person="statsPerson" />
 
     <!-- Delete confirmation -->
     <UModal

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -21,6 +21,10 @@ const eventPendingDelete = ref<MovieEvent | null>(null)
 const statsPerson = ref<Profile | null>(null)
 const statsOpen = ref(false)
 
+// Event drill-down: the event whose stats are open.
+const statsEvent = ref<MovieEvent | null>(null)
+const eventStatsOpen = ref(false)
+
 const selectedEventId = ref<string>()
 const { suggestions, setDeleted, voterNames } = useAdminSuggestions(selectedEventId)
 
@@ -219,6 +223,10 @@ function onSelectPerson(person: Profile): void {
   statsPerson.value = person
   statsOpen.value = true
 }
+function onSelectEvent(event: MovieEvent): void {
+  statsEvent.value = event
+  eventStatsOpen.value = true
+}
 </script>
 
 <template>
@@ -325,6 +333,14 @@ function onSelectPerson(person: Profile): void {
                 </h3>
               </div>
               <div class="flex gap-1 shrink-0">
+                <UButton
+                  icon="i-lucide-bar-chart-3"
+                  color="neutral"
+                  variant="ghost"
+                  size="sm"
+                  aria-label="View event stats"
+                  @click="onSelectEvent(event)"
+                />
                 <UButton
                   icon="i-lucide-pencil"
                   color="neutral"
@@ -557,6 +573,8 @@ function onSelectPerson(person: Profile): void {
     <InviteFriendModal v-model:open="inviteOpen" />
 
     <UserStatsModal v-model:open="statsOpen" :person="statsPerson" />
+
+    <EventStatsModal v-model:open="eventStatsOpen" :event="statsEvent" />
 
     <!-- Delete confirmation -->
     <UModal

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -9,7 +9,7 @@ useSeoMeta({ title: 'Admin · BSOTG' })
 
 const toast = useToast()
 const { events } = useEvents()
-const { createEvent, updateEvent, deleteEvent } = useEventAdmin()
+const { createEvent, updateEvent, deleteEvent, setVotingLocked } = useEventAdmin()
 const { people, pendingInvites, loadError, setBlocked, revokeInvite } = useAdminPeople()
 
 const modalOpen = ref(false)
@@ -131,6 +131,50 @@ async function onRemoveBring(item: BringItem): Promise<void> {
     toast.add({ title: 'Item removed', color: 'neutral' })
   } catch {
     toast.add({ title: 'Could not remove item', color: 'error' })
+  }
+}
+
+const votingLocked = computed(() => Boolean(selectedEvent.value?.voting_locked_at))
+const winners = computed(() => topWinners(suggestions.value))
+
+async function onLockVoting(): Promise<void> {
+  const ev = selectedEvent.value
+  if (!ev) return
+  try {
+    await setVotingLocked(ev.id, true)
+    toast.add({ title: 'Voting ended', icon: 'i-lucide-lock', color: 'success' })
+    // Auto-announce the winners (best-effort — needs Resend + service key).
+    const won = winners.value
+    if (won.length) {
+      const list = won.map(s => s.tmdb_movie.title).join(' and ')
+      try {
+        await $fetch('/api/events/announce', {
+          method: 'POST',
+          body: {
+            eventId: ev.id,
+            subject: `🍿 ${ev.title} — the winners are in!`,
+            message: `Voting has ended! The ${won.length > 1 ? 'double feature' : 'movie'} is: ${list}. See you there!`,
+            scope: 'members'
+          }
+        })
+        toast.add({ title: 'Winners announcement sent', icon: 'i-lucide-send', color: 'success' })
+      } catch {
+        toast.add({ title: 'Voting locked, but the announcement could not be sent', color: 'warning' })
+      }
+    }
+  } catch {
+    toast.add({ title: 'Could not end voting', color: 'error' })
+  }
+}
+
+async function onReopenVoting(): Promise<void> {
+  const ev = selectedEvent.value
+  if (!ev) return
+  try {
+    await setVotingLocked(ev.id, false)
+    toast.add({ title: 'Voting reopened', color: 'neutral' })
+  } catch {
+    toast.add({ title: 'Could not reopen voting', color: 'error' })
   }
 }
 
@@ -342,6 +386,34 @@ async function onRevoke(invite: Invite): Promise<void> {
           placeholder="Select an event"
           class="w-full sm:max-w-sm mb-4"
         />
+
+        <!-- End / reopen voting -->
+        <div v-if="selectedEvent" class="mb-4 space-y-3">
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <p class="text-sm" :class="votingLocked ? 'text-muted' : ''">
+              <UIcon :name="votingLocked ? 'i-lucide-lock' : 'i-lucide-vote'" class="align-text-bottom" />
+              {{ votingLocked ? 'Voting has ended for this event.' : 'Voting is open.' }}
+            </p>
+            <UButton
+              v-if="!votingLocked"
+              label="End voting"
+              icon="i-lucide-lock"
+              color="primary"
+              size="sm"
+              @click="onLockVoting"
+            />
+            <UButton
+              v-else
+              label="Reopen voting"
+              icon="i-lucide-lock-open"
+              color="neutral"
+              variant="outline"
+              size="sm"
+              @click="onReopenVoting"
+            />
+          </div>
+          <WinnersBanner v-if="votingLocked && winners.length" :winners="winners" />
+        </div>
 
         <div v-if="suggestions.length" class="space-y-3">
           <UCard

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -34,6 +34,10 @@ const leadPoster = computed(() => (totalVotes.value > 0 ? posterUrl(suggestions.
 // Prefer the event's own poster; fall back to the current leader's movie poster.
 const cardBackdrop = computed(() => currentEvent.value?.poster_url || leadPoster.value)
 
+// Voting ended → show the double-feature winners and hide vote/suggest controls.
+const votingLocked = computed(() => Boolean(currentEvent.value?.voting_locked_at))
+const winners = computed(() => topWinners(suggestions.value))
+
 const eventOptions = computed(() =>
   events.value.map((event, index) => ({
     // Date only — the full (often long) title is shown on the event card below,
@@ -189,40 +193,48 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
             </template>
           </UCard>
 
-          <!-- Suggest (desktop inline) -->
-          <div class="hidden lg:block">
-            <h2 class="text-sm font-semibold text-muted mb-2">
-              Suggest a movie
-            </h2>
-            <SuggestSection :suggested-movie-ids="suggestedMovieIds" @suggest="onSuggest" />
-          </div>
+          <!-- Suggest + finder (hidden once voting is locked) -->
+          <template v-if="!votingLocked">
+            <!-- Suggest (desktop inline) -->
+            <div class="hidden lg:block">
+              <h2 class="text-sm font-semibold text-muted mb-2">
+                Suggest a movie
+              </h2>
+              <SuggestSection :suggested-movie-ids="suggestedMovieIds" @suggest="onSuggest" />
+            </div>
 
-          <!-- Suggest (mobile) -->
-          <UButton
-            class="lg:hidden justify-center"
-            block
-            label="Suggest a movie"
-            icon="i-lucide-plus"
-            @click="suggestOpen = true"
-          />
+            <!-- Suggest (mobile) -->
+            <UButton
+              class="lg:hidden justify-center"
+              block
+              label="Suggest a movie"
+              icon="i-lucide-plus"
+              @click="suggestOpen = true"
+            />
 
-          <!-- Movie finder (all sizes) -->
-          <UButton
-            class="justify-center"
-            block
-            color="neutral"
-            variant="outline"
-            label="Help me find a movie"
-            icon="i-lucide-clapperboard"
-            @click="finderOpen = true"
-          />
+            <!-- Movie finder (all sizes) -->
+            <UButton
+              class="justify-center"
+              block
+              color="neutral"
+              variant="outline"
+              label="Help me find a movie"
+              icon="i-lucide-clapperboard"
+              @click="finderOpen = true"
+            />
+          </template>
+          <p v-else class="text-sm text-muted text-center inline-flex items-center justify-center gap-1.5">
+            <UIcon name="i-lucide-lock" /> Voting has ended for this movie night.
+          </p>
         </aside>
 
         <!-- RIGHT: rankings -->
         <section class="lg:col-span-2 min-w-0">
+          <WinnersBanner v-if="votingLocked && winners.length" :winners="winners" class="mb-4" />
+
           <div class="flex items-center justify-between mb-4">
             <h2 class="text-xl font-semibold">
-              Rankings
+              {{ votingLocked ? 'Final results' : 'Rankings' }}
             </h2>
             <UBadge :label="`${suggestions.length}`" color="neutral" variant="subtle" />
           </div>
@@ -234,6 +246,7 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
               :suggestion="suggestion"
               :rank="index + 1"
               :max-votes="maxVotes"
+              :locked="votingLocked"
               @vote="onVote(suggestion)"
               @unvote="onUnvote(suggestion)"
               @remove="onRemove(suggestion)"

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -30,9 +30,9 @@ export interface Database {
         Relationships: []
       }
       events: {
-        Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, created_by: string | null, created_at: string }
-        Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, created_by?: string | null, created_at?: string }
-        Update: { id?: string, title?: string, description?: string, event_date?: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, created_by?: string | null, created_at?: string }
+        Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, voting_locked_at: string | null, created_by: string | null, created_at: string }
+        Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, created_by?: string | null, created_at?: string }
+        Update: { id?: string, title?: string, description?: string, event_date?: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, created_by?: string | null, created_at?: string }
         Relationships: []
       }
       rsvps: {

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -17,8 +17,13 @@ export default defineEventHandler(async (event) => {
   if (!eventId) throw createError({ statusCode: 400, statusMessage: 'Missing event id' })
 
   const db = serverSupabaseServiceRole<Database>(event)
-  const { data: me } = await db.from('profiles').select('is_admin').eq('id', user.id).single()
-  if (!me?.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+  const { data: me, error: meError } = await db.from('profiles').select('is_admin').eq('id', user.id).single()
+  // If the service-role read fails outright, NUXT_SUPABASE_SECRET_KEY is wrong
+  // (it should be the service-role / sb_secret_ key) — surface that, not "Admins only".
+  if (meError || !me) {
+    throw createError({ statusCode: 500, statusMessage: 'Could not verify admin — check NUXT_SUPABASE_SECRET_KEY (must be the service-role key)' })
+  }
+  if (!me.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
 
   const { data: ev } = await db.from('events').select('title, event_date, location').eq('id', eventId).single()
   if (!ev) throw createError({ statusCode: 404, statusMessage: 'Event not found' })

--- a/shared/types/event.ts
+++ b/shared/types/event.ts
@@ -8,6 +8,8 @@ export interface MovieEvent {
   location: string | null
   location_url: string | null
   poster_url: string | null
+  /** When voting was ended (locked) by an admin; null = voting is open. */
+  voting_locked_at: string | null
   created_at: string
 }
 

--- a/shared/utils/errorMessage.ts
+++ b/shared/utils/errorMessage.ts
@@ -1,0 +1,11 @@
+/** Best-effort human message from a thrown value. Covers `Error` and the
+ *  `{ message }` shape Supabase / PostgREST errors use (which are plain objects,
+ *  not `Error` instances), falling back when neither applies. */
+export function errorMessage(e: unknown, fallback = 'Something went wrong'): string {
+  if (e instanceof Error) return e.message
+  if (typeof e === 'object' && e !== null && 'message' in e) {
+    const message = (e as { message: unknown }).message
+    if (typeof message === 'string' && message) return message
+  }
+  return fallback
+}

--- a/shared/utils/eventStats.ts
+++ b/shared/utils/eventStats.ts
@@ -1,0 +1,44 @@
+import type { Suggestion } from '#shared/types/suggestion'
+
+/** Key stats for one event's admin drill-down. */
+export interface EventStats {
+  suggestionCount: number
+  voteCount: number
+  submitterCount: number
+  voterCount: number
+  going: number
+  maybe: number
+  declined: number
+  bringTotal: number
+  bringClaimed: number
+  /** Top-2 vote-getters (the "double feature"), most votes first. */
+  topPicks: { title: string, votes: number }[]
+}
+
+/** Aggregate one event's participation. Pure — the composable does the I/O and
+ *  hands the rows in, so the counting is unit-testable. */
+export function computeEventStats(input: {
+  suggestions: ReadonlyArray<Suggestion>
+  rsvps: ReadonlyArray<{ status: string }>
+  bringItems: ReadonlyArray<{ user_id: string | null }>
+}): EventStats {
+  const live = input.suggestions.filter(s => !s.deleted)
+  const submitters = new Set(live.map(s => s.user_id))
+  const voters = new Set<string>()
+  for (const s of live) {
+    for (const v of s.votes ?? []) voters.add(v.user_id)
+  }
+  const countStatus = (status: string): number => input.rsvps.filter(r => r.status === status).length
+  return {
+    suggestionCount: live.length,
+    voteCount: live.reduce((n, s) => n + (s.votes?.length ?? 0), 0),
+    submitterCount: submitters.size,
+    voterCount: voters.size,
+    going: countStatus('going'),
+    maybe: countStatus('maybe'),
+    declined: countStatus('no'),
+    bringTotal: input.bringItems.length,
+    bringClaimed: input.bringItems.filter(b => b.user_id !== null).length,
+    topPicks: topWinners([...live]).map(s => ({ title: s.tmdb_movie.title, votes: s.votes?.length ?? 0 }))
+  }
+}

--- a/shared/utils/userStats.ts
+++ b/shared/utils/userStats.ts
@@ -1,0 +1,48 @@
+/** A movie a person suggested, plus whether it ended up a "winner" (top-voted in
+ *  a finished/locked event). */
+export interface SubmittedMovie {
+  id: string
+  eventId: string
+  title: string
+  won: boolean
+}
+
+/** Everything the admin people drill-down shows for one person. */
+export interface UserStats {
+  going: number
+  maybe: number
+  declined: number
+  votesCast: number
+  submitted: SubmittedMovie[]
+  wins: number
+  brought: string[]
+}
+
+/** Aggregate one person's participation across the app. Pure — the composable
+ *  does the I/O and hands the rows in, so the counting logic is unit-testable.
+ *  `winningSuggestionIds` is the set of suggestion ids that won their event
+ *  (computed from locked events only — see useUserStats). */
+export function computeUserStats(input: {
+  rsvps: ReadonlyArray<{ status: string }>
+  submissions: ReadonlyArray<{ id: string, event_id: string, tmdb_movie: { title: string } }>
+  votesCast: number
+  brought: ReadonlyArray<{ label: string }>
+  winningSuggestionIds: ReadonlySet<string>
+}): UserStats {
+  const countStatus = (status: string): number => input.rsvps.filter(r => r.status === status).length
+  const submitted: SubmittedMovie[] = input.submissions.map(s => ({
+    id: s.id,
+    eventId: s.event_id,
+    title: s.tmdb_movie.title,
+    won: input.winningSuggestionIds.has(s.id)
+  }))
+  return {
+    going: countStatus('going'),
+    maybe: countStatus('maybe'),
+    declined: countStatus('no'),
+    votesCast: input.votesCast,
+    submitted,
+    wins: submitted.filter(s => s.won).length,
+    brought: input.brought.map(b => b.label)
+  }
+}

--- a/shared/utils/winners.ts
+++ b/shared/utils/winners.ts
@@ -1,0 +1,15 @@
+import type { Suggestion } from '#shared/types/suggestion'
+
+/** The top-voted suggestions, most votes first — the "double feature" is the
+ *  top 2. Excludes deleted and zero-vote entries; ties break by earliest
+ *  suggested so the result is stable. */
+export function topWinners(suggestions: Suggestion[], count = 2): Suggestion[] {
+  return suggestions
+    .filter(s => !s.deleted && (s.votes?.length ?? 0) > 0)
+    .slice()
+    .sort((a, b) =>
+      (b.votes?.length ?? 0) - (a.votes?.length ?? 0)
+      || (a.created_at ?? '').localeCompare(b.created_at ?? '')
+    )
+    .slice(0, count)
+}

--- a/supabase/migrations/20260620000000_lock_voting.sql
+++ b/supabase/migrations/20260620000000_lock_voting.sql
@@ -1,0 +1,45 @@
+-- ============================================================================
+-- Lock voting / end voting. An admin can end voting for an event: no more votes
+-- or suggestions, and the top-voted films become the "double feature" winners.
+-- RLS is the boundary (Invariant 1) — the lock is enforced in the policies, not
+-- just hidden in the UI.
+-- ============================================================================
+
+alter table public.events add column if not exists voting_locked_at timestamptz;
+
+-- Is voting locked for the event this suggestion belongs to? SECURITY DEFINER so
+-- it can resolve the event behind RLS (votes carry no event_id).
+create function public.is_voting_locked(sid uuid) returns boolean
+  language sql security definer set search_path = '' stable as $$
+  select exists (
+    select 1
+    from public.suggestions s
+    join public.events e on e.id = s.event_id
+    where s.id = sid and e.voting_locked_at is not null
+  );
+$$;
+revoke all on function public.is_voting_locked(uuid) from public;
+grant execute on function public.is_voting_locked(uuid) to authenticated;
+
+-- No new votes once voting is locked (and no un-voting — results are final).
+drop policy "votes: insert own" on public.votes;
+create policy "votes: insert own" on public.votes
+  for insert to authenticated
+  with check (
+    user_id = auth.uid() and public.is_allowed() and not public.is_blocked()
+    and not public.is_voting_locked(suggestion_id)
+  );
+
+drop policy "votes: delete own" on public.votes;
+create policy "votes: delete own" on public.votes
+  for delete to authenticated
+  using (user_id = auth.uid() and not public.is_voting_locked(suggestion_id));
+
+-- No new suggestions once voting is locked.
+drop policy "suggestions: create own" on public.suggestions;
+create policy "suggestions: create own" on public.suggestions
+  for insert to authenticated
+  with check (
+    user_id = auth.uid() and deleted = false and public.is_allowed() and not public.is_blocked()
+    and (select voting_locked_at from public.events where id = event_id) is null
+  );

--- a/test/EventStatsModal.nuxt.test.ts
+++ b/test/EventStatsModal.nuxt.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import EventStatsModal from '../app/components/EventStatsModal.vue'
+import type { EventStats } from '../shared/utils/eventStats'
+
+const statsRef = ref<EventStats | null>(null)
+const pendingRef = ref(false)
+const errorRef = ref<string | null>(null)
+
+mockNuxtImport('useEventStats', () => () => ({ stats: statsRef, pending: pendingRef, error: errorRef }))
+
+const stats: EventStats = {
+  suggestionCount: 4,
+  voteCount: 11,
+  submitterCount: 3,
+  voterCount: 5,
+  going: 6,
+  maybe: 1,
+  declined: 2,
+  bringTotal: 5,
+  bringClaimed: 3,
+  topPicks: [{ title: 'Heat', votes: 6 }, { title: 'Casino', votes: 5 }]
+}
+
+const event = (locked = false) => ({
+  id: 'e1',
+  title: 'Movie Night',
+  description: '',
+  event_date: '2026-07-01',
+  start_time: null,
+  location: null,
+  location_url: null,
+  poster_url: null,
+  voting_locked_at: locked ? '2026-07-02T00:00:00Z' : null,
+  created_at: ''
+})
+
+const bodyText = (): string => document.body.textContent ?? ''
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  statsRef.value = null
+  pendingRef.value = false
+  errorRef.value = null
+})
+
+describe('EventStatsModal', () => {
+  it('renders the headline counts, rsvp split, bring progress and top picks', async () => {
+    statsRef.value = stats
+    await mountSuspended(EventStatsModal, { props: { event: event(), open: true } })
+    await flushPromises()
+    const text = bodyText()
+    expect(text).toContain('Movie Night')
+    expect(text).toContain('Heat')
+    expect(text).toContain('Casino')
+    expect(text).toContain('3 of 5') // bring claimed/total
+    expect(text).toContain('Leading') // not locked
+  })
+
+  it('labels the top picks as winners once voting is locked', async () => {
+    statsRef.value = stats
+    await mountSuspended(EventStatsModal, { props: { event: event(true), open: true } })
+    await flushPromises()
+    expect(bodyText()).toContain('Winners')
+    expect(bodyText()).not.toContain('Leading')
+  })
+
+  it('shows a loading state while pending', async () => {
+    pendingRef.value = true
+    await mountSuspended(EventStatsModal, { props: { event: event(), open: true } })
+    await flushPromises()
+    expect(bodyText()).toContain('Loading')
+  })
+})

--- a/test/PeopleList.nuxt.test.ts
+++ b/test/PeopleList.nuxt.test.ts
@@ -74,4 +74,15 @@ describe('PeopleList', () => {
     const w = await mountSuspended(PeopleList, { props: { people, pending: dupe } })
     expect(w.text()).not.toContain('Alice Dupe')
   })
+
+  it('emits select with the member when their row is clicked', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people } })
+    await w.get('[aria-label="View Alice\'s activity"]').trigger('click')
+    expect(w.emitted('select')?.[0]).toEqual([people[0]])
+  })
+
+  it('does not make pending invites clickable for stats', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people, pending } })
+    expect(w.find('[aria-label="View Pat\'s activity"]').exists()).toBe(false)
+  })
 })

--- a/test/SuggestionCard.nuxt.test.ts
+++ b/test/SuggestionCard.nuxt.test.ts
@@ -38,4 +38,21 @@ describe('SuggestionCard', () => {
     await trailerBtn?.trigger('click')
     expect(w.emitted('trailer')).toBeTruthy()
   })
+
+  it('shows a static vote count and no vote button once locked', async () => {
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2, locked: true } })
+    expect(w.text()).toContain('2')
+    expect(w.find('[aria-label="Remove vote"]').exists()).toBe(false)
+    expect(w.find('[aria-label="Vote"]').exists()).toBe(false)
+  })
+
+  it('hides the remove button for the owner once locked', async () => {
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2, locked: true } })
+    expect(w.find('[aria-label="Remove suggestion"]').exists()).toBe(false)
+  })
+
+  it('still lets the owner remove while voting is open', async () => {
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2 } })
+    expect(w.find('[aria-label="Remove suggestion"]').exists()).toBe(true)
+  })
 })

--- a/test/UserStatsModal.nuxt.test.ts
+++ b/test/UserStatsModal.nuxt.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import UserStatsModal from '../app/components/UserStatsModal.vue'
+import type { UserStats } from '../shared/utils/userStats'
+
+const statsRef = ref<UserStats | null>(null)
+const pendingRef = ref(false)
+const errorRef = ref<string | null>(null)
+
+mockNuxtImport('useUserStats', () => () => ({ stats: statsRef, pending: pendingRef, error: errorRef }))
+
+const person = { id: 'u1', email: 'alice@x.com', display_name: 'Alice', avatar_url: null, is_admin: false, blocked: false, created_at: '' }
+
+const fullStats: UserStats = {
+  going: 3,
+  maybe: 1,
+  declined: 2,
+  votesCast: 9,
+  submitted: [
+    { id: 's1', eventId: 'e1', title: 'Heat', won: true },
+    { id: 's2', eventId: 'e2', title: 'Casino', won: false }
+  ],
+  wins: 1,
+  brought: ['Chips', 'Drinks']
+}
+
+// UModal teleports its body to <body>; assert against the document, not the wrapper.
+const bodyText = (): string => document.body.textContent ?? ''
+
+beforeEach(() => {
+  document.body.innerHTML = ''
+  statsRef.value = null
+  pendingRef.value = false
+  errorRef.value = null
+})
+
+describe('UserStatsModal', () => {
+  it('shows RSVP and voting tallies plus suggested movies and brought items', async () => {
+    statsRef.value = fullStats
+    await mountSuspended(UserStatsModal, { props: { person, open: true } })
+    await flushPromises()
+    const text = bodyText()
+    expect(text).toContain('Alice')
+    expect(text).toContain('Heat')
+    expect(text).toContain('Casino')
+    expect(text).toContain('Chips')
+    expect(text).toContain('Drinks')
+    expect(text).toContain('won')
+  })
+
+  it('shows a loading state while stats are pending', async () => {
+    pendingRef.value = true
+    await mountSuspended(UserStatsModal, { props: { person, open: true } })
+    await flushPromises()
+    expect(bodyText()).toContain('Loading')
+  })
+
+  it('surfaces an error message', async () => {
+    errorRef.value = 'boom'
+    await mountSuspended(UserStatsModal, { props: { person, open: true } })
+    await flushPromises()
+    expect(bodyText()).toContain('boom')
+  })
+})

--- a/test/WinnersBanner.nuxt.test.ts
+++ b/test/WinnersBanner.nuxt.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import WinnersBanner from '../app/components/WinnersBanner.vue'
+
+mockNuxtImport('useTmdb', () => () => ({ posterUrl: (p: string | null) => (p ? `https://img/${p}` : null) }))
+
+const winner = (id: string, title: string, votes: number) => ({
+  id,
+  event_id: 'e1',
+  user_id: 'u1',
+  deleted: false,
+  created_at: '2026-01-01T00:00:00Z',
+  tmdb_movie: { id: 1, title, poster_path: `${id}.jpg` },
+  votes: Array.from({ length: votes }, (_, i) => ({ user_id: `v${i}` }))
+})
+
+describe('WinnersBanner', () => {
+  it('labels a two-winner result a Double Feature and shows both titles + vote counts', async () => {
+    const winners = [winner('a', 'Heat', 5), winner('b', 'Casino', 3)]
+    const w = await mountSuspended(WinnersBanner, { props: { winners } })
+    expect(w.text()).toContain('Double Feature')
+    expect(w.text()).toContain('Heat')
+    expect(w.text()).toContain('Casino')
+    expect(w.text()).toContain('5 votes')
+    expect(w.text()).toContain('3 votes')
+  })
+
+  it('labels a single winner as Winner and singularises one vote', async () => {
+    const w = await mountSuspended(WinnersBanner, { props: { winners: [winner('a', 'Heat', 1)] } })
+    expect(w.text()).toContain('Winner')
+    expect(w.text()).not.toContain('Double Feature')
+    expect(w.text()).toContain('1 vote')
+    expect(w.text()).not.toContain('1 votes')
+  })
+
+  it('renders nothing when there are no winners', async () => {
+    const w = await mountSuspended(WinnersBanner, { props: { winners: [] } })
+    expect(w.text()).toBe('')
+  })
+})

--- a/test/errorMessage.test.ts
+++ b/test/errorMessage.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { errorMessage } from '../shared/utils/errorMessage'
+
+describe('errorMessage', () => {
+  it('reads the message off an Error', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom')
+  })
+
+  it('reads the message off a Supabase/PostgREST-style error object', () => {
+    expect(errorMessage({ message: 'row not found', code: 'PGRST116' })).toBe('row not found')
+  })
+
+  it('falls back when there is no usable message', () => {
+    expect(errorMessage(null, 'nope')).toBe('nope')
+    expect(errorMessage('a string', 'nope')).toBe('nope')
+    expect(errorMessage({ message: '' }, 'nope')).toBe('nope')
+    expect(errorMessage({ message: 42 }, 'nope')).toBe('nope')
+  })
+
+  it('uses a default fallback when none is given', () => {
+    expect(errorMessage(undefined)).toBe('Something went wrong')
+  })
+})

--- a/test/eventStats.test.ts
+++ b/test/eventStats.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import type { Suggestion } from '../shared/types/suggestion'
+import { computeEventStats } from '../shared/utils/eventStats'
+
+const sug = (id: string, userId: string, voters: string[], title = id, deleted = false): Suggestion => ({
+  id,
+  event_id: 'e1',
+  user_id: userId,
+  tmdb_movie: { id: 1, title },
+  deleted,
+  created_at: '2026-01-01T00:00:00Z',
+  votes: voters.map(user_id => ({ user_id }))
+})
+
+describe('computeEventStats', () => {
+  it('counts live suggestions, total votes, and distinct submitters/voters', () => {
+    const stats = computeEventStats({
+      suggestions: [
+        sug('s1', 'alice', ['x', 'y']),
+        sug('s2', 'bob', ['x']),
+        sug('s3', 'alice', []) // alice submitted twice → 2 distinct submitters
+      ],
+      rsvps: [],
+      bringItems: []
+    })
+    expect(stats.suggestionCount).toBe(3)
+    expect(stats.voteCount).toBe(3)
+    expect(stats.submitterCount).toBe(2)
+    expect(stats.voterCount).toBe(2) // x and y
+  })
+
+  it('excludes soft-deleted suggestions from every count', () => {
+    const stats = computeEventStats({
+      suggestions: [sug('s1', 'alice', ['x']), sug('gone', 'bob', ['y', 'z'], 'Gone', true)],
+      rsvps: [],
+      bringItems: []
+    })
+    expect(stats.suggestionCount).toBe(1)
+    expect(stats.voteCount).toBe(1)
+    expect(stats.submitterCount).toBe(1)
+  })
+
+  it('splits RSVPs into going / maybe / declined', () => {
+    const stats = computeEventStats({
+      suggestions: [],
+      rsvps: [{ status: 'going' }, { status: 'going' }, { status: 'maybe' }, { status: 'no' }],
+      bringItems: []
+    })
+    expect(stats.going).toBe(2)
+    expect(stats.maybe).toBe(1)
+    expect(stats.declined).toBe(1)
+  })
+
+  it('reports bring-list progress (claimed vs total)', () => {
+    const stats = computeEventStats({
+      suggestions: [],
+      rsvps: [],
+      bringItems: [{ user_id: 'a' }, { user_id: null }, { user_id: 'b' }]
+    })
+    expect(stats.bringTotal).toBe(3)
+    expect(stats.bringClaimed).toBe(2)
+  })
+
+  it('lists the top-2 picks, most votes first', () => {
+    const stats = computeEventStats({
+      suggestions: [sug('s1', 'a', ['x'], 'One'), sug('s2', 'b', ['x', 'y', 'z'], 'Three'), sug('s3', 'c', ['x', 'y'], 'Two')],
+      rsvps: [],
+      bringItems: []
+    })
+    expect(stats.topPicks).toEqual([
+      { title: 'Three', votes: 3 },
+      { title: 'Two', votes: 2 }
+    ])
+  })
+
+  it('returns an empty topPicks list when nothing has votes', () => {
+    const stats = computeEventStats({
+      suggestions: [sug('s1', 'a', []), sug('s2', 'b', [])],
+      rsvps: [],
+      bringItems: []
+    })
+    expect(stats.topPicks).toEqual([])
+  })
+})

--- a/test/useEventAdmin.nuxt.test.ts
+++ b/test/useEventAdmin.nuxt.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+interface UpdateCall { payload: Record<string, unknown>, filters: Record<string, unknown> }
+const calls = { updates: [] as UpdateCall[] }
+
+const filteredChain = (payload: Record<string, unknown>) => {
+  const filters: Record<string, unknown> = {}
+  const chain = {
+    eq: (col: string, val: unknown) => {
+      filters[col] = val
+      return chain
+    },
+    then: (onFulfilled: (r: { error: null }) => unknown) => {
+      calls.updates.push({ payload, filters })
+      return Promise.resolve({ error: null }).then(onFulfilled)
+    }
+  }
+  return chain
+}
+
+const supabase = {
+  from() {
+    return { update: (payload: Record<string, unknown>) => filteredChain(payload) }
+  }
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+mockNuxtImport('useSupabaseUser', () => () => ref({ id: 'me' }))
+
+beforeEach(() => {
+  calls.updates = []
+})
+
+describe('useEventAdmin.setVotingLocked', () => {
+  it('stamps voting_locked_at on the event when locking', async () => {
+    const { setVotingLocked } = useEventAdmin()
+    await setVotingLocked('e1', true)
+    expect(calls.updates).toHaveLength(1)
+    expect(calls.updates[0]!.filters).toEqual({ id: 'e1' })
+    expect(typeof calls.updates[0]!.payload.voting_locked_at).toBe('string')
+    // a real ISO timestamp, not null
+    expect(calls.updates[0]!.payload.voting_locked_at).not.toBeNull()
+  })
+
+  it('clears voting_locked_at when reopening', async () => {
+    const { setVotingLocked } = useEventAdmin()
+    await setVotingLocked('e1', false)
+    expect(calls.updates[0]).toEqual({ payload: { voting_locked_at: null }, filters: { id: 'e1' } })
+  })
+})

--- a/test/useEventInvites.nuxt.test.ts
+++ b/test/useEventInvites.nuxt.test.ts
@@ -7,11 +7,13 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 let list: Array<Record<string, unknown>> = [] // current event's invites (refresh)
 let eventsList: Array<Record<string, unknown>> = [] // other events (seed)
 let poolList: Array<Record<string, unknown>> = [] // invites across other events (seed pool)
+let rosterList: Array<Record<string, unknown>> = [] // allowlist roster (seed fallback)
 const ops = { inserted: [] as unknown[], deleted: [] as unknown[] }
 
 // Thenable + chainable stub mirroring the PostgREST builder. event_invites resolves
 // to the seed `poolList` when filtered with .in() (the pool query) and `list`
-// otherwise (the per-event refresh); events resolves to `eventsList`.
+// otherwise (the per-event refresh); events resolves to `eventsList`; invites (the
+// allowlist roster, used as the seed fallback) resolves to `rosterList`.
 function builder(table: string) {
   let usedIn = false
   const c: Record<string, unknown> = {
@@ -39,7 +41,11 @@ function builder(table: string) {
       }
     }),
     then: (resolve: (v: unknown) => void) => {
-      const data = table === 'events' ? eventsList : table === 'event_invites' ? (usedIn ? poolList : list) : []
+      const data = table === 'events'
+        ? eventsList
+        : table === 'event_invites'
+          ? (usedIn ? poolList : list)
+          : table === 'invites' ? rosterList : []
       resolve({ data })
     }
   }
@@ -57,6 +63,7 @@ beforeEach(() => {
   list = []
   eventsList = []
   poolList = []
+  rosterList = []
   ops.inserted = []
   ops.deleted = []
 })
@@ -101,11 +108,43 @@ describe('useEventInvites', () => {
     expect(ops.inserted.flat().some(i => (i as { email?: string }).email === 'guest@x')).toBe(true)
   })
 
-  it('seedFromLastEvent returns 0 when no other event has a list', async () => {
+  it('seedFromLastEvent returns 0 when no prior event has a list and the roster is empty', async () => {
     eventsList = [{ id: 'prev' }]
     poolList = []
+    rosterList = []
     const { seedFromLastEvent } = useEventInvites(ref('e'))
     await flushPromises()
     expect(await seedFromLastEvent()).toBe(0)
+  })
+
+  it('seedFromLastEvent falls back to the allowlist roster when no prior event has a list', async () => {
+    // First-ever event: no other event has a guest list, but the household roster does.
+    list = []
+    eventsList = []
+    poolList = []
+    rosterList = [
+      { email: 'mom@x', display_name: 'Mom' },
+      { email: 'dad@x', display_name: 'Dad' }
+    ]
+    const { seedFromLastEvent } = useEventInvites(ref('e'))
+    await flushPromises()
+    const added = await seedFromLastEvent()
+    expect(added).toBe(2)
+    const emails = ops.inserted.flat().map(i => (i as { email?: string }).email)
+    expect(emails).toContain('mom@x')
+    expect(emails).toContain('dad@x')
+  })
+
+  it('seedFromLastEvent skips roster entries already invited to this event', async () => {
+    list = [{ id: 'x', event_id: 'e', email: 'mom@x', rsvp: null, sent_at: null, opened_at: null, clicked_at: null, display_name: 'Mom', token: 't' }]
+    eventsList = []
+    rosterList = [{ email: 'mom@x', display_name: 'Mom' }, { email: 'dad@x', display_name: 'Dad' }]
+    const { seedFromLastEvent } = useEventInvites(ref('e'))
+    await flushPromises()
+    const added = await seedFromLastEvent()
+    expect(added).toBe(1)
+    const emails = ops.inserted.flat().map(i => (i as { email?: string }).email)
+    expect(emails).toContain('dad@x')
+    expect(emails).not.toContain('mom@x')
   })
 })

--- a/test/useEventStats.nuxt.test.ts
+++ b/test/useEventStats.nuxt.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+interface Row { [k: string]: unknown }
+const data = {
+  suggestions: [] as Row[],
+  rsvps: [] as Row[],
+  bring: [] as Row[],
+  error: null as { message: string } | null
+}
+
+function builder(table: string) {
+  const c: Record<string, unknown> = {
+    select: () => c,
+    eq: () => c,
+    then: (resolve: (v: unknown) => void) => {
+      if (table === 'suggestions') return resolve({ data: data.suggestions, error: data.error })
+      if (table === 'rsvps') return resolve({ data: data.rsvps, error: null })
+      if (table === 'bring_items') return resolve({ data: data.bring, error: null })
+      return resolve({ data: [], error: null })
+    }
+  }
+  return c
+}
+
+const supabase = { from: (table: string) => builder(table) }
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+beforeEach(() => {
+  data.suggestions = []
+  data.rsvps = []
+  data.bring = []
+  data.error = null
+})
+
+describe('useEventStats', () => {
+  it('aggregates suggestions, votes, rsvps and bring-list for the event', async () => {
+    data.suggestions = [
+      { id: 's1', event_id: 'e1', user_id: 'alice', tmdb_movie: { title: 'Heat' }, deleted: false, created_at: '2026-01-01', votes: [{ user_id: 'x' }, { user_id: 'y' }] },
+      { id: 's2', event_id: 'e1', user_id: 'bob', tmdb_movie: { title: 'Casino' }, deleted: false, created_at: '2026-01-02', votes: [{ user_id: 'x' }] }
+    ]
+    data.rsvps = [{ status: 'going' }, { status: 'no' }]
+    data.bring = [{ user_id: 'a' }, { user_id: null }]
+    const { stats } = useEventStats(ref('e1'))
+    await flushPromises()
+    expect(stats.value).toMatchObject({
+      suggestionCount: 2,
+      voteCount: 3,
+      submitterCount: 2,
+      voterCount: 2,
+      going: 1,
+      declined: 1,
+      bringTotal: 2,
+      bringClaimed: 1
+    })
+    expect(stats.value?.topPicks[0]).toEqual({ title: 'Heat', votes: 2 })
+  })
+
+  it('surfaces an error and leaves stats null', async () => {
+    data.error = { message: 'nope' }
+    const { stats, error } = useEventStats(ref('e1'))
+    await flushPromises()
+    expect(error.value).toBe('nope')
+    expect(stats.value).toBeNull()
+  })
+
+  it('clears stats when the event id becomes null', async () => {
+    data.rsvps = [{ status: 'going' }]
+    const id = ref<string | null>('e1')
+    const { stats } = useEventStats(id)
+    await flushPromises()
+    expect(stats.value).not.toBeNull()
+    id.value = null
+    await flushPromises()
+    expect(stats.value).toBeNull()
+  })
+})

--- a/test/useUserStats.nuxt.test.ts
+++ b/test/useUserStats.nuxt.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+interface Row { [k: string]: unknown }
+const data = {
+  rsvps: [] as Row[],
+  submissions: [] as Row[], // suggestions filtered by user_id
+  votesCount: 0,
+  brought: [] as Row[],
+  lockedEvents: [] as Row[],
+  pool: [] as Row[] // suggestions (with votes) for locked events
+}
+
+// Chainable thenable mirroring the PostgREST builder. The two suggestions reads
+// are told apart by `.in()` (the locked-event pool uses .in('event_id', …); the
+// user's own submissions use .eq('user_id', …)).
+function builder(table: string) {
+  let usedIn = false
+  let isCount = false
+  const c: Record<string, unknown> = {
+    select: (_cols: string, opts?: { head?: boolean }) => {
+      if (opts?.head) isCount = true
+      return c
+    },
+    eq: () => c,
+    in: () => {
+      usedIn = true
+      return c
+    },
+    not: () => c,
+    then: (resolve: (v: unknown) => void) => {
+      if (table === 'rsvps') return resolve({ data: data.rsvps, error: null })
+      if (table === 'votes') return resolve({ count: isCount ? data.votesCount : null, error: null })
+      if (table === 'bring_items') return resolve({ data: data.brought, error: null })
+      if (table === 'events') return resolve({ data: data.lockedEvents, error: null })
+      if (table === 'suggestions') return resolve({ data: usedIn ? data.pool : data.submissions, error: null })
+      return resolve({ data: [], error: null })
+    }
+  }
+  return c
+}
+
+const supabase = { from: (table: string) => builder(table) }
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+beforeEach(() => {
+  data.rsvps = []
+  data.submissions = []
+  data.votesCount = 0
+  data.brought = []
+  data.lockedEvents = []
+  data.pool = []
+})
+
+describe('useUserStats', () => {
+  it('aggregates a member\'s rsvps, submissions, votes and brought items', async () => {
+    data.rsvps = [{ status: 'going' }, { status: 'no' }]
+    data.submissions = [{ id: 's1', event_id: 'e1', tmdb_movie: { title: 'Heat' }, created_at: '2026-01-01' }]
+    data.votesCount = 4
+    data.brought = [{ label: 'Chips' }]
+    const { stats } = useUserStats(ref('u1'))
+    await flushPromises()
+    expect(stats.value).toMatchObject({ going: 1, declined: 1, votesCast: 4, brought: ['Chips'] })
+    expect(stats.value?.submitted).toEqual([{ id: 's1', eventId: 'e1', title: 'Heat', won: false }])
+    expect(stats.value?.wins).toBe(0)
+  })
+
+  it('marks a submission a win when it is a top-2 pick in a locked event', async () => {
+    data.submissions = [{ id: 's1', event_id: 'e1', tmdb_movie: { title: 'Heat' }, created_at: '2026-01-01' }]
+    data.lockedEvents = [{ id: 'e1' }]
+    data.pool = [
+      { id: 's1', event_id: 'e1', deleted: false, created_at: '2026-01-01', tmdb_movie: { title: 'Heat' }, votes: [{ user_id: 'a' }, { user_id: 'b' }] },
+      { id: 's2', event_id: 'e1', deleted: false, created_at: '2026-01-02', tmdb_movie: { title: 'Other' }, votes: [{ user_id: 'a' }] }
+    ]
+    const { stats } = useUserStats(ref('u1'))
+    await flushPromises()
+    expect(stats.value?.submitted[0]?.won).toBe(true)
+    expect(stats.value?.wins).toBe(1)
+  })
+
+  it('does not count a win for an event whose voting is not locked', async () => {
+    data.submissions = [{ id: 's1', event_id: 'e1', tmdb_movie: { title: 'Heat' }, created_at: '2026-01-01' }]
+    data.lockedEvents = [] // e1 is still open
+    const { stats } = useUserStats(ref('u1'))
+    await flushPromises()
+    expect(stats.value?.wins).toBe(0)
+    expect(stats.value?.submitted[0]?.won).toBe(false)
+  })
+
+  it('clears stats when the target user becomes null', async () => {
+    data.rsvps = [{ status: 'going' }]
+    const id = ref<string | null>('u1')
+    const { stats } = useUserStats(id)
+    await flushPromises()
+    expect(stats.value).not.toBeNull()
+    id.value = null
+    await flushPromises()
+    expect(stats.value).toBeNull()
+  })
+})

--- a/test/userStats.test.ts
+++ b/test/userStats.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { computeUserStats } from '../shared/utils/userStats'
+
+const base = {
+  rsvps: [] as { status: string }[],
+  submissions: [] as { id: string, event_id: string, tmdb_movie: { title: string } }[],
+  votesCast: 0,
+  brought: [] as { label: string }[],
+  winningSuggestionIds: new Set<string>()
+}
+
+describe('computeUserStats', () => {
+  it('tallies RSVP statuses into going / maybe / declined', () => {
+    const stats = computeUserStats({
+      ...base,
+      rsvps: [{ status: 'going' }, { status: 'going' }, { status: 'maybe' }, { status: 'no' }]
+    })
+    expect(stats.going).toBe(2)
+    expect(stats.maybe).toBe(1)
+    expect(stats.declined).toBe(1)
+  })
+
+  it('lists submitted movies with their titles', () => {
+    const stats = computeUserStats({
+      ...base,
+      submissions: [
+        { id: 's1', event_id: 'e1', tmdb_movie: { title: 'Heat' } },
+        { id: 's2', event_id: 'e2', tmdb_movie: { title: 'Casino' } }
+      ]
+    })
+    expect(stats.submitted.map(s => s.title)).toEqual(['Heat', 'Casino'])
+    expect(stats.submitted[0]).toMatchObject({ id: 's1', eventId: 'e1', won: false })
+  })
+
+  it('flags a submission as won when its id is in the winning set, and counts wins', () => {
+    const stats = computeUserStats({
+      ...base,
+      submissions: [
+        { id: 's1', event_id: 'e1', tmdb_movie: { title: 'Heat' } },
+        { id: 's2', event_id: 'e2', tmdb_movie: { title: 'Casino' } }
+      ],
+      winningSuggestionIds: new Set(['s1'])
+    })
+    expect(stats.submitted.find(s => s.id === 's1')?.won).toBe(true)
+    expect(stats.submitted.find(s => s.id === 's2')?.won).toBe(false)
+    expect(stats.wins).toBe(1)
+  })
+
+  it('passes through votes cast and the list of brought items', () => {
+    const stats = computeUserStats({
+      ...base,
+      votesCast: 7,
+      brought: [{ label: 'Chips' }, { label: 'Drinks' }]
+    })
+    expect(stats.votesCast).toBe(7)
+    expect(stats.brought).toEqual(['Chips', 'Drinks'])
+  })
+
+  it('returns zeroed stats for a person with no activity', () => {
+    const stats = computeUserStats(base)
+    expect(stats).toEqual({
+      going: 0,
+      maybe: 0,
+      declined: 0,
+      votesCast: 0,
+      submitted: [],
+      wins: 0,
+      brought: []
+    })
+  })
+})

--- a/test/winners.test.ts
+++ b/test/winners.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import type { Suggestion } from '../shared/types/suggestion'
+import { topWinners } from '../shared/utils/winners'
+
+const make = (id: string, votes: number, created_at: string, deleted = false): Suggestion => ({
+  id,
+  event_id: 'e1',
+  user_id: 'u1',
+  tmdb_movie: { id: Number(id.replace(/\D/g, '')) || 0, title: id, release_date: '2000-01-01' },
+  deleted,
+  created_at,
+  votes: Array.from({ length: votes }, (_, i) => ({ user_id: `voter-${i}` }))
+})
+
+describe('topWinners', () => {
+  it('returns the two most-voted suggestions, most votes first', () => {
+    const input = [
+      make('a', 1, '2026-01-01T00:00:00Z'),
+      make('b', 5, '2026-01-01T00:00:00Z'),
+      make('c', 3, '2026-01-01T00:00:00Z')
+    ]
+    expect(topWinners(input).map(s => s.id)).toEqual(['b', 'c'])
+  })
+
+  it('breaks ties by earliest suggested so the result is stable', () => {
+    const input = [
+      make('late', 2, '2026-02-01T00:00:00Z'),
+      make('early', 2, '2026-01-01T00:00:00Z')
+    ]
+    expect(topWinners(input).map(s => s.id)).toEqual(['early', 'late'])
+  })
+
+  it('excludes deleted suggestions', () => {
+    const input = [
+      make('gone', 9, '2026-01-01T00:00:00Z', true),
+      make('keep', 1, '2026-01-01T00:00:00Z')
+    ]
+    expect(topWinners(input).map(s => s.id)).toEqual(['keep'])
+  })
+
+  it('excludes suggestions with zero votes', () => {
+    const input = [make('voted', 1, '2026-01-01T00:00:00Z'), make('unvoted', 0, '2026-01-01T00:00:00Z')]
+    expect(topWinners(input).map(s => s.id)).toEqual(['voted'])
+  })
+
+  it('respects a custom winner count', () => {
+    const input = [
+      make('a', 5, '2026-01-01T00:00:00Z'),
+      make('b', 4, '2026-01-01T00:00:00Z'),
+      make('c', 3, '2026-01-01T00:00:00Z')
+    ]
+    expect(topWinners(input, 1).map(s => s.id)).toEqual(['a'])
+    expect(topWinners(input, 3).map(s => s.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns fewer than requested when there are not enough voted suggestions', () => {
+    expect(topWinners([make('only', 2, '2026-01-01T00:00:00Z')])).toHaveLength(1)
+    expect(topWinners([])).toEqual([])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [make('a', 1, '2026-01-01T00:00:00Z'), make('b', 2, '2026-01-01T00:00:00Z')]
+    const snapshot = input.map(s => s.id)
+    topWinners(input)
+    expect(input.map(s => s.id)).toEqual(snapshot)
+  })
+})


### PR DESCRIPTION
## Scope

Three admin-facing features plus two bug fixes, all on `new-stuff`.

**Lock voting / end voting** (the headline). An admin can end voting for an event: no more votes, un-votes, or suggestions, and the top-2 vote-getters become the "double feature" winners. RLS is the boundary — the lock is enforced in the policies, not just hidden in the UI (Invariant 1).

**Per-person activity drill-down.** Click a member in admin → People to see their RSVPs, the movies they suggested (and which won), votes cast, and what they've brought.

**Per-event stats drill-down.** A 📊 action on each admin event card opens that event's key stats: suggestion/vote totals, distinct submitters/voters, the RSVP split, bring-list progress, and the top picks.

**Fixes:** "Pull from last event" now works on the first event (falls back to the allowlist roster); the misleading 403 on sending invites now returns a clear 500 naming the env var when the service-role read fails.

## Implementation

- **Lock voting** — migration `20260620000000_lock_voting.sql` adds `events.voting_locked_at` and an `is_voting_locked()` SECURITY DEFINER function, then rewrites the `votes` insert/delete and `suggestions` insert policies to reject writes on a locked event (preserving the existing `is_allowed()` / `is_blocked()` conditions). `shared/utils/topWinners` picks the double feature; `WinnersBanner` + a `locked` prop on `SuggestionCard` render the locked state; `useEventAdmin.setVotingLocked()` toggles it; admin best-effort announces the winners to members on lock.
- **Stats drill-downs** — pure aggregators (`computeUserStats`, `computeEventStats`) do the counting and are unit-tested in isolation; thin composables (`useUserStats`, `useEventStats`) do the I/O; `UserStatsModal` / `EventStatsModal` render. "Wins" count only finished (vote-locked) events, mirroring the overview's winners.
- **errorMessage helper** — Supabase/PostgREST errors are plain `{ message }` objects, not `Error` instances, so `e instanceof Error ? …` was dropping the real message. `shared/utils/errorMessage` handles both shapes.

Worth a close look: the three rewritten RLS policies in the migration (confirm no condition was weakened), and the `as unknown as Suggestion[]` casts where the `votes(...)` embed isn't in the generated types (same pattern as `useSuggestions`).

## How to Test

**Automated:** 209 tests passing (+53 this branch), lint + typecheck clean. New/updated coverage: `winners`, `useEventAdmin`, `WinnersBanner`, `SuggestionCard` (locked), `userStats`, `useUserStats`, `UserStatsModal`, `PeopleList` (select), `eventStats`, `useEventStats`, `EventStatsModal`, `errorMessage`, `useEventInvites` (roster fallback).

**Manual:**
1. Admin → Suggestions → **End voting** → overview hides vote/suggest controls, suggestions show static counts, winners banner appears; **Reopen** restores them. Try voting via console after locking — RLS rejects it.
2. Admin → People → click a member → activity stats.
3. Admin → Events → 📊 on a card → event stats ("Winners" if locked, "Leading" otherwise).
4. Invites tab → "Pull from last event" on a fresh event pulls the roster; sending an invite succeeds with the corrected service-role key.

## Invariants & Risk

- **Authorization (Invariant 1):** touches RLS — adds `is_voting_locked()` and rewrites the votes/suggestions write policies. The lock is enforced in Postgres, not just the UI. No policy relaxed; existing allow/block checks preserved.
- **Service-role key (Invariant 2):** the invite-send route reads the service role server-side only; the fix only improves the error surfaced when the key is misconfigured.
- **Vote integrity (Invariant 3):** unchanged — winners are derived from `votes.length`, no counter introduced.
- **Ops:** migration `20260620000000_lock_voting.sql` must be applied to prod (done on this project's DB); `NUXT_SUPABASE_SECRET_KEY` in Vercel must be the service-role key (done).

## Known gap

"Guests they'll bring" was requested for the user-stats drill-down but is **not** included — there's no column for it. Needs an RSVP guest-count feature first (`rsvps.guest_count` + capture in `RsvpControl`), then it slots into the modal. Forum and karma-based voting are on the roadmap.
