### PR TITLE
fix: invite names + bulk delete, admin role management, invite-send diagnostic

### DIFF
--- a/app/components/EventInviteManager.vue
+++ b/app/components/EventInviteManager.vue
@@ -7,13 +7,49 @@ import type { EventInvite } from '#shared/types/event-invite'
 // e-vites, and shows live RSVP / open / click tracking.
 const props = defineProps<{ eventId: string }>()
 const toast = useToast()
-const { invites, stats, addInvite, removeInvite, seedFromLastEvent, sendInvites } = useEventInvites(() => props.eventId)
+const { invites, stats, addInvite, removeInvite, removeInvites, seedFromLastEvent, sendInvites } = useEventInvites(() => props.eventId)
 
 const newEmail = ref('')
 const newName = ref('')
 const sending = ref(false)
 const seeding = ref(false)
+const deleting = ref(false)
 const emailSchema = z.string().email()
+
+// Multi-select for bulk delete. Kept in sync as the list changes (realtime / refresh).
+const selected = ref<Set<string>>(new Set())
+const selectedCount = computed(() => selected.value.size)
+const allSelected = computed(() => invites.value.length > 0 && invites.value.every(i => selected.value.has(i.id)))
+
+watch(invites, (list) => {
+  const live = new Set(list.map(i => i.id))
+  const next = new Set([...selected.value].filter(id => live.has(id)))
+  if (next.size !== selected.value.size) selected.value = next
+})
+
+function toggleOne(id: string): void {
+  const next = new Set(selected.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  selected.value = next
+}
+function toggleAll(): void {
+  selected.value = allSelected.value ? new Set() : new Set(invites.value.map(i => i.id))
+}
+async function onDeleteSelected(): Promise<void> {
+  const ids = [...selected.value]
+  if (!ids.length) return
+  deleting.value = true
+  try {
+    await removeInvites(ids)
+    selected.value = new Set()
+    toast.add({ title: `Removed ${ids.length} guest${ids.length === 1 ? '' : 's'}`, color: 'neutral' })
+  } catch {
+    toast.add({ title: 'Could not remove the selected guests', color: 'error' })
+  } finally {
+    deleting.value = false
+  }
+}
 
 // Auto-roll: the first time we see an empty list for this event, pull last
 // event's invitees ("auto add from last event unless we remove them").
@@ -166,9 +202,38 @@ function statusBadge(invite: EventInvite): { label: string, color: 'success' | '
       />
     </div>
 
+    <!-- Bulk select toolbar -->
+    <div v-if="invites.length" class="flex items-center gap-3 px-1">
+      <UCheckbox
+        :model-value="allSelected"
+        aria-label="Select all guests"
+        @update:model-value="toggleAll"
+      />
+      <span class="text-sm text-muted">
+        {{ selectedCount ? `${selectedCount} selected` : 'Select all' }}
+      </span>
+      <UButton
+        v-if="selectedCount"
+        :label="`Delete ${selectedCount}`"
+        icon="i-lucide-trash-2"
+        color="error"
+        variant="soft"
+        size="xs"
+        class="ml-auto"
+        :loading="deleting"
+        @click="onDeleteSelected"
+      />
+    </div>
+
     <!-- Guest list -->
     <ul v-if="invites.length" class="divide-y divide-default rounded-lg ring ring-default overflow-hidden">
       <li v-for="invite in invites" :key="invite.id" class="flex items-center gap-3 p-3">
+        <UCheckbox
+          :model-value="selected.has(invite.id)"
+          :aria-label="`Select ${invite.display_name || invite.email}`"
+          class="shrink-0"
+          @update:model-value="toggleOne(invite.id)"
+        />
         <div class="min-w-0 flex-1">
           <p class="font-medium truncate">
             {{ invite.display_name || invite.email }}

--- a/app/components/PeopleList.vue
+++ b/app/components/PeopleList.vue
@@ -11,7 +11,11 @@ const emit = defineEmits<{
   unblock: [person: Profile]
   revoke: [invite: Invite]
   select: [person: Profile]
+  setAdmin: [person: Profile, value: boolean]
 }>()
+
+// To hide the admin toggle on your own row (you can't change your own admin).
+const { myId } = useAuth()
 
 type Row
   = | { kind: 'member', key: string, name: string, email: string, profile: Profile }
@@ -99,8 +103,18 @@ function initials(name: string, email: string): string {
           </p>
         </component>
 
-        <!-- Member actions: ban/unban (admins can't be banned from the UI). -->
+        <!-- Member actions: admin toggle + ban/unban (admins can't be banned from the UI). -->
         <template v-if="row.kind === 'member'">
+          <UButton
+            v-if="row.profile.id !== myId"
+            :label="row.profile.is_admin ? 'Remove admin' : 'Make admin'"
+            :icon="row.profile.is_admin ? 'i-lucide-shield-off' : 'i-lucide-shield'"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            class="shrink-0"
+            @click="emit('setAdmin', row.profile, !row.profile.is_admin)"
+          />
           <UButton
             v-if="row.profile.blocked"
             label="Unban"

--- a/app/composables/useAdminPeople.ts
+++ b/app/composables/useAdminPeople.ts
@@ -47,6 +47,14 @@ export function useAdminPeople() {
     await refresh()
   }
 
+  /** Grant or revoke admin. Enforced in the RPC (admin-only; can't change your own —
+   *  is_admin stays out-of-band, Invariant 4). */
+  async function setAdmin(id: string, value: boolean): Promise<void> {
+    const { error } = await supabase.rpc('admin_set_admin', { target_id: id, value })
+    if (error) throw error
+    await refresh()
+  }
+
   /** Withdraw a pending invite. RLS allows admins to delete any invite. */
   async function revokeInvite(email: string): Promise<void> {
     const { error } = await supabase.from('invites').delete().eq('email', email)
@@ -54,5 +62,5 @@ export function useAdminPeople() {
     await refresh()
   }
 
-  return { people, pendingInvites, pending, loadError, setBlocked, revokeInvite }
+  return { people, pendingInvites, pending, loadError, setBlocked, setAdmin, revokeInvite }
 }

--- a/app/composables/useEventInvites.ts
+++ b/app/composables/useEventInvites.ts
@@ -60,6 +60,27 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
     await refresh()
   }
 
+  /** Remove several invites at once (multi-select delete). No-op for an empty list. */
+  async function removeInvites(inviteIds: readonly string[]): Promise<void> {
+    if (!inviteIds.length) return
+    const { error } = await supabase.from('event_invites').delete().in('id', [...inviteIds])
+    if (error) throw error
+    await refresh()
+  }
+
+  /** Overlay the best-known display name (a signed-in person's profile name) onto
+   *  seed candidates, falling back to whatever name the source row carried. Keeps
+   *  "pull from last event" from importing bare emails when we actually know names. */
+  async function withProfileNames(
+    candidates: Array<{ email: string, display_name: string | null }>
+  ): Promise<Array<{ email: string, display_name: string | null }>> {
+    const emails = candidates.map(c => c.email).filter(Boolean)
+    if (!emails.length) return candidates
+    const { data: profiles } = await supabase.from('profiles').select('email, display_name').in('email', emails)
+    const nameByEmail = new Map((profiles ?? []).filter(p => p.email).map(p => [p.email, p.display_name]))
+    return candidates.map(c => ({ email: c.email, display_name: nameByEmail.get(c.email) ?? c.display_name }))
+  }
+
   /** Build this event's guest list from the most recent OTHER event that has one
    *  (newest-first, skipping empty events). Falls back to the household roster
    *  (everyone on the allowlist) when no prior event has a guest list yet — so the
@@ -95,9 +116,8 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
     }
 
     const existing = new Set(invites.value.map(i => i.email))
-    const toAdd = candidates
-      .filter(c => !existing.has(c.email))
-      .map(c => ({ event_id: id, email: c.email, display_name: c.display_name }))
+    const named = await withProfileNames(candidates.filter(c => !existing.has(c.email)))
+    const toAdd = named.map(c => ({ event_id: id, email: c.email, display_name: c.display_name }))
     if (!toAdd.length) return 0
     const { error } = await supabase.from('event_invites').insert(toAdd)
     if (error) throw error
@@ -135,5 +155,5 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
     if (channel) supabase.removeChannel(channel)
   })
 
-  return { invites, pending, stats, refresh, addInvite, removeInvite, seedFromLastEvent, sendInvites }
+  return { invites, pending, stats, refresh, addInvite, removeInvite, removeInvites, seedFromLastEvent, sendInvites }
 }

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -10,7 +10,7 @@ useSeoMeta({ title: 'Admin · BSOTG' })
 const toast = useToast()
 const { events } = useEvents()
 const { createEvent, updateEvent, deleteEvent, setVotingLocked } = useEventAdmin()
-const { people, pendingInvites, loadError, setBlocked, revokeInvite } = useAdminPeople()
+const { people, pendingInvites, loadError, setBlocked, setAdmin, revokeInvite } = useAdminPeople()
 
 const modalOpen = ref(false)
 const inviteOpen = ref(false)
@@ -223,6 +223,18 @@ function onSelectPerson(person: Profile): void {
   statsPerson.value = person
   statsOpen.value = true
 }
+async function onSetAdmin(person: Profile, value: boolean): Promise<void> {
+  try {
+    await setAdmin(person.id, value)
+    toast.add({
+      title: `${person.display_name ?? 'User'} ${value ? 'is now an admin' : 'is no longer an admin'}`,
+      icon: 'i-lucide-shield',
+      color: value ? 'success' : 'neutral'
+    })
+  } catch (error) {
+    toast.add({ title: 'Could not change admin status', description: error instanceof Error ? error.message : undefined, color: 'error' })
+  }
+}
 function onSelectEvent(event: MovieEvent): void {
   statsEvent.value = event
   eventStatsOpen.value = true
@@ -397,6 +409,7 @@ function onSelectEvent(event: MovieEvent): void {
             @unblock="onUnblock"
             @revoke="onRevoke"
             @select="onSelectPerson"
+            @set-admin="onSetAdmin"
           />
         </div>
       </template>

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -62,6 +62,7 @@ export interface Database {
     }
     Views: { [_ in never]: never }
     Functions: {
+      admin_set_admin: { Args: { target_id: string, value: boolean }, Returns: undefined }
       admin_set_blocked: { Args: { target_id: string, value: boolean }, Returns: undefined }
       is_allowed: { Args: Record<string, never>, Returns: boolean }
     }

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -20,8 +20,16 @@ export default defineEventHandler(async (event) => {
   const { data: me, error: meError } = await db.from('profiles').select('is_admin').eq('id', user.id).single()
   // If the service-role read fails outright, NUXT_SUPABASE_SECRET_KEY is wrong
   // (it should be the service-role / sb_secret_ key) — surface that, not "Admins only".
+  // Bubble the underlying cause so the actual fault is diagnosable: an "Invalid API
+  // key" means a bad/mismatched key; a PGRST116 "0 rows" means the key isn't really
+  // service-role (RLS applied) or no profile row exists for this user.
   if (meError || !me) {
-    throw createError({ statusCode: 500, statusMessage: 'Could not verify admin — check NUXT_SUPABASE_SECRET_KEY (must be the service-role key)' })
+    console.error('[invites/send] admin verify failed', { code: meError?.code, message: meError?.message, userId: user.id })
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Could not verify admin — check NUXT_SUPABASE_SECRET_KEY (must be the service-role key)',
+      data: { cause: meError?.message ?? 'no profile row returned', code: meError?.code ?? null }
+    })
   }
   if (!me.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
 

--- a/supabase/migrations/20260621000000_admin_role_rpc.sql
+++ b/supabase/migrations/20260621000000_admin_role_rpc.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- Manage the admin role from the People section. is_admin stays out-of-band
+-- (Invariant 4): the RLS update policy on profiles still forbids a user from
+-- changing is_admin directly. This admin-only SECURITY DEFINER RPC is the single
+-- controlled path, mirroring admin_set_blocked. You cannot change your OWN admin
+-- status — prevents locking yourself out or odd self-promotion edge cases.
+-- ============================================================================
+
+create function public.admin_set_admin(target_id uuid, value boolean)
+  returns void language plpgsql security definer set search_path = '' as $$
+begin
+  if not public.is_admin() then
+    raise exception 'only admins may change admin status';
+  end if;
+  if target_id = auth.uid() then
+    raise exception 'you cannot change your own admin status';
+  end if;
+  update public.profiles set is_admin = value where id = target_id;
+end;
+$$;
+revoke all on function public.admin_set_admin(uuid, boolean) from public;
+grant execute on function public.admin_set_admin(uuid, boolean) to authenticated;

--- a/test/EventInviteManager.nuxt.test.ts
+++ b/test/EventInviteManager.nuxt.test.ts
@@ -5,17 +5,20 @@ import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import EventInviteManager from '../app/components/EventInviteManager.vue'
 
 const invites = ref([
-  { id: 'a', event_id: 'e', email: 'pat@x.com', display_name: 'Pat', token: '1', rsvp: 'going', rsvp_at: null, invited_by: null, resend_id: null, sent_at: 't', delivered_at: null, opened_at: null, clicked_at: null, bounced_at: null, created_at: '' }
+  { id: 'a', event_id: 'e', email: 'pat@x.com', display_name: 'Pat', token: '1', rsvp: 'going', rsvp_at: null, invited_by: null, resend_id: null, sent_at: 't', delivered_at: null, opened_at: null, clicked_at: null, bounced_at: null, created_at: '' },
+  { id: 'b', event_id: 'e', email: 'sam@x.com', display_name: 'Sam', token: '2', rsvp: null, rsvp_at: null, invited_by: null, resend_id: null, sent_at: null, delivered_at: null, opened_at: null, clicked_at: null, bounced_at: null, created_at: '' }
 ])
 const sent = vi.fn(async () => ({ sent: 0 }))
+const removeMany = vi.fn(async () => {})
 
 mockNuxtImport('useEventInvites', () => () => ({
   invites,
   pending: ref(false),
-  stats: computed(() => ({ invited: 1, sent: 1, opened: 0, clicked: 0, going: 1, maybe: 0, no: 0, noReply: 0 })),
+  stats: computed(() => ({ invited: 2, sent: 1, opened: 0, clicked: 0, going: 1, maybe: 0, no: 0, noReply: 1 })),
   refresh: async () => {},
   addInvite: async () => {},
   removeInvite: async () => {},
+  removeInvites: removeMany,
   seedFromLastEvent: async () => 0,
   sendInvites: sent
 }))
@@ -28,5 +31,24 @@ describe('EventInviteManager', () => {
     expect(w.text()).toContain('going')
     expect(w.text()).toContain('Pat')
     expect(w.text()).toContain('Going')
+  })
+
+  it('selects all guests and bulk-deletes them', async () => {
+    const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e' } })
+    await w.get('[aria-label="Select all guests"]').trigger('click')
+    // The delete button surfaces with the selected count.
+    const del = w.findAll('button').find(b => b.text().includes('Delete'))
+    expect(del).toBeTruthy()
+    await del!.trigger('click')
+    expect(removeMany).toHaveBeenCalledWith(['a', 'b'])
+  })
+
+  it('selects a single guest by their row checkbox', async () => {
+    removeMany.mockClear()
+    const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e' } })
+    await w.get('[aria-label="Select Sam"]').trigger('click')
+    const del = w.findAll('button').find(b => b.text().includes('Delete'))
+    await del!.trigger('click')
+    expect(removeMany).toHaveBeenCalledWith(['b'])
   })
 })

--- a/test/PeopleList.nuxt.test.ts
+++ b/test/PeopleList.nuxt.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment nuxt
 import { describe, expect, it } from 'vitest'
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import PeopleList from '../app/components/PeopleList.vue'
+
+// "me" is Carol (u3, an admin) — her own row hides the admin toggle.
+mockNuxtImport('useAuth', () => () => ({ myId: ref('u3') }))
 
 const people = [
   { id: 'u1', email: 'alice@x.com', display_name: 'Alice', avatar_url: null, is_admin: false, blocked: false, created_at: '' },
@@ -84,5 +88,20 @@ describe('PeopleList', () => {
   it('does not make pending invites clickable for stats', async () => {
     const w = await mountSuspended(PeopleList, { props: { people, pending } })
     expect(w.find('[aria-label="View Pat\'s activity"]').exists()).toBe(false)
+  })
+
+  it('emits setAdmin to promote a non-admin member', async () => {
+    const w = await mountSuspended(PeopleList, { props: { people } })
+    const makeAdmin = w.findAll('button').find(b => b.text().trim() === 'Make admin')
+    await makeAdmin?.trigger('click')
+    expect(w.emitted('setAdmin')?.[0]).toEqual([people[0], true])
+  })
+
+  it('hides the admin toggle on your own row', async () => {
+    // Carol (u3) is "me" and an admin — no Make/Remove admin button on her row.
+    const w = await mountSuspended(PeopleList, { props: { people } })
+    const labels = w.findAll('button').map(b => b.text().trim())
+    // Two other members get a toggle; Carol (self) does not → exactly two toggles.
+    expect(labels.filter(l => l === 'Make admin' || l === 'Remove admin')).toHaveLength(2)
   })
 })

--- a/test/useAdminPeople.nuxt.test.ts
+++ b/test/useAdminPeople.nuxt.test.ts
@@ -68,6 +68,18 @@ describe('useAdminPeople', () => {
     expect(calls.rpc[0]).toEqual({ fn: 'admin_set_blocked', args: { target_id: 'u1', value: true } })
   })
 
+  it('setAdmin grants admin via the admin RPC', async () => {
+    const { setAdmin } = useAdminPeople()
+    await setAdmin('u1', true)
+    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_admin', args: { target_id: 'u1', value: true } })
+  })
+
+  it('setAdmin revokes admin via the admin RPC', async () => {
+    const { setAdmin } = useAdminPeople()
+    await setAdmin('u2', false)
+    expect(calls.rpc[0]).toEqual({ fn: 'admin_set_admin', args: { target_id: 'u2', value: false } })
+  })
+
   it('revokeInvite deletes the invite by email', async () => {
     const { revokeInvite } = useAdminPeople()
     await revokeInvite('pending@x.com')

--- a/test/useEventInvites.nuxt.test.ts
+++ b/test/useEventInvites.nuxt.test.ts
@@ -8,6 +8,7 @@ let list: Array<Record<string, unknown>> = [] // current event's invites (refres
 let eventsList: Array<Record<string, unknown>> = [] // other events (seed)
 let poolList: Array<Record<string, unknown>> = [] // invites across other events (seed pool)
 let rosterList: Array<Record<string, unknown>> = [] // allowlist roster (seed fallback)
+let profilesList: Array<Record<string, unknown>> = [] // profiles (seed name enrichment)
 const ops = { inserted: [] as unknown[], deleted: [] as unknown[] }
 
 // Thenable + chainable stub mirroring the PostgREST builder. event_invites resolves
@@ -38,6 +39,10 @@ function builder(table: string) {
       eq: (_col: string, val: unknown) => {
         ops.deleted.push(val)
         return Promise.resolve({ error: null })
+      },
+      in: (_col: string, vals: unknown[]) => {
+        ops.deleted.push(...vals)
+        return Promise.resolve({ error: null })
       }
     }),
     then: (resolve: (v: unknown) => void) => {
@@ -45,7 +50,9 @@ function builder(table: string) {
         ? eventsList
         : table === 'event_invites'
           ? (usedIn ? poolList : list)
-          : table === 'invites' ? rosterList : []
+          : table === 'invites'
+            ? rosterList
+            : table === 'profiles' ? profilesList : []
       resolve({ data })
     }
   }
@@ -64,6 +71,7 @@ beforeEach(() => {
   eventsList = []
   poolList = []
   rosterList = []
+  profilesList = []
   ops.inserted = []
   ops.deleted = []
 })
@@ -94,6 +102,20 @@ describe('useEventInvites', () => {
     await flushPromises()
     await removeInvite('a')
     expect(ops.deleted).toContain('a')
+  })
+
+  it('removeInvites deletes several ids at once', async () => {
+    const { removeInvites } = useEventInvites(ref('e'))
+    await flushPromises()
+    await removeInvites(['a', 'b', 'c'])
+    expect(ops.deleted).toEqual(expect.arrayContaining(['a', 'b', 'c']))
+  })
+
+  it('removeInvites is a no-op for an empty selection', async () => {
+    const { removeInvites } = useEventInvites(ref('e'))
+    await flushPromises()
+    await removeInvites([])
+    expect(ops.deleted).toHaveLength(0)
   })
 
   it('seedFromLastEvent pulls from the most recent other event that has a list', async () => {
@@ -146,5 +168,29 @@ describe('useEventInvites', () => {
     const emails = ops.inserted.flat().map(i => (i as { email?: string }).email)
     expect(emails).toContain('dad@x')
     expect(emails).not.toContain('mom@x')
+  })
+
+  it('seedFromLastEvent enriches seeded guests with profile display names', async () => {
+    // The source list only has emails (no names); profiles knows them by email.
+    eventsList = []
+    rosterList = [{ email: 'mom@x', display_name: null }, { email: 'dad@x', display_name: null }]
+    profilesList = [{ email: 'mom@x', display_name: 'Mom Bennett' }, { email: 'dad@x', display_name: 'Dad Bennett' }]
+    const { seedFromLastEvent } = useEventInvites(ref('e'))
+    await flushPromises()
+    await seedFromLastEvent()
+    const inserted = ops.inserted.flat() as Array<{ email?: string, display_name?: string | null }>
+    expect(inserted.find(i => i.email === 'mom@x')?.display_name).toBe('Mom Bennett')
+    expect(inserted.find(i => i.email === 'dad@x')?.display_name).toBe('Dad Bennett')
+  })
+
+  it('seedFromLastEvent keeps the source name when no profile name exists', async () => {
+    eventsList = []
+    rosterList = [{ email: 'guest@x', display_name: 'Guest' }]
+    profilesList = [] // no profile for this email
+    const { seedFromLastEvent } = useEventInvites(ref('e'))
+    await flushPromises()
+    await seedFromLastEvent()
+    const inserted = ops.inserted.flat() as Array<{ email?: string, display_name?: string | null }>
+    expect(inserted.find(i => i.email === 'guest@x')?.display_name).toBe('Guest')
   })
 })


### PR DESCRIPTION
## Scope

Invite-system fixes you asked for, plus admin-role management — and a diagnostic for the invite-send 500 that's still failing in prod.

1. **Make/remove admin from the People section** — a per-member action to grant or revoke admin.
2. **"Pull from last event" imports names, not just emails** — overlays each guest's profile display name.
3. **Multi-select + select-all delete** in the event invite manager.
4. **Invite-send 500 diagnostic** — surface the real underlying cause so we can finally pin down why sending fails (see note below).

## Implementation

- **Admin role (Invariant 4 preserved).** New admin-only SECURITY DEFINER RPC `admin_set_admin(target_id, value)` — mirrors `admin_set_blocked`. `is_admin` stays out-of-band: direct client writes are still blocked by the profiles RLS update policy; this RPC is the single controlled path, gated by `is_admin()`, and **refuses to change your own** admin status (no self-lockout). `useAdminPeople.setAdmin` calls it; `PeopleList` shows a make/remove-admin button on every row except your own.
- **Names on seed.** `seedFromLastEvent` now looks up profiles by email and prefers a signed-in person's display name, falling back to whatever the source row had.
- **Bulk delete.** `useEventInvites.removeInvites(ids)` does a single `delete().in('id', ids)`; `EventInviteManager` gets per-row checkboxes, a select-all toggle, and a "Delete N" action.
- **Diagnostic.** The invite-send route now logs the PostgREST `code`/`message` server-side and includes the cause in the 500 body.

## ⚠️ The invite-send 500 is still environmental — this PR helps diagnose, doesn't fix

Prod returned my exact 500 ("check `NUXT_SUPABASE_SECRET_KEY`"), which means the module **found a key** but the service-role query **still failed**. With a real service-role key, RLS is bypassed and that query can't return zero rows for an existing admin. So the value currently in `NUXT_SUPABASE_SECRET_KEY` is **not a working service-role key for this project**. Most likely:
- the deployment didn't pick up the updated key (Vercel env changes only apply to a **new** deploy — redeploy after saving), **or**
- the value is the anon/publishable key, or a key from a different project.

Once this PR deploys, the 500 response body will include the actual cause (e.g. "Invalid API key" vs. a `PGRST116` 0-rows), which tells us exactly which.

## How to Test

**Automated:** 219 passing (+10). New/updated: `useAdminPeople` (setAdmin RPC), `PeopleList` (admin toggle + self-hidden), `useEventInvites` (name enrichment, bulk delete), `EventInviteManager` (select-all/per-row delete).

**Manual:**
1. Admin → People → "Make admin"/"Remove admin" on another member; confirm your own row has no toggle. (Migration `20260621000000_admin_role_rpc.sql` must be applied.)
2. Admin → event → Invites → "Pull from last event" → seeded guests show names.
3. Check rows, use select-all, "Delete N".
4. Try sending an invite → if it still 500s, the response now names the real cause.

## Invariants & Risk

- **Invariant 4 (admin role out-of-band):** upheld. No client code writes `is_admin`; the RPC is admin-gated and self-change is refused. Migration `20260621000000_admin_role_rpc.sql` must be applied to prod.
- **Invariant 1 (RLS boundary):** bulk delete and seed use the anon client under existing `event_invites` admin RLS policies. No policy changes.
- **Invariant 2 (server-only keys):** the diagnostic only changes the error surface of the existing service-role route.
