### PR TITLE
fix: don't auto-pull last event's guests on every page load

### DIFF
--- a/app/components/EventInviteManager.vue
+++ b/app/components/EventInviteManager.vue
@@ -2,9 +2,9 @@
 import { z } from 'zod'
 import type { EventInvite } from '#shared/types/event-invite'
 
-// Admin guest-list manager + Evite tracker for one event. Auto-rolls the list
-// forward from the previous event, lets admins add/remove, sends tokenized
-// e-vites, and shows live RSVP / open / click tracking.
+// Admin guest-list manager + Evite tracker for one event. Lets admins add/remove
+// guests, pull last event's list in on demand, send tokenized e-vites, and shows
+// live RSVP / open / click tracking.
 const props = defineProps<{ eventId: string }>()
 const toast = useToast()
 const { invites, stats, addInvite, removeInvite, removeInvites, seedFromLastEvent, sendInvites } = useEventInvites(() => props.eventId)
@@ -50,17 +50,6 @@ async function onDeleteSelected(): Promise<void> {
     deleting.value = false
   }
 }
-
-// Auto-roll: the first time we see an empty list for this event, pull last
-// event's invitees ("auto add from last event unless we remove them").
-const seededFor = ref<string | null>(null)
-watch([() => props.eventId, invites], async ([id, list]) => {
-  if (id && seededFor.value !== id && list.length === 0) {
-    seededFor.value = id
-    const n = await seedFromLastEvent().catch(() => 0)
-    if (n) toast.add({ title: `Pulled ${n} from the last movie night`, color: 'neutral' })
-  }
-}, { immediate: true })
 
 async function onAdd(): Promise<void> {
   const email = newEmail.value.trim()

--- a/test/EventInviteManager.nuxt.test.ts
+++ b/test/EventInviteManager.nuxt.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment nuxt
 import { describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import EventInviteManager from '../app/components/EventInviteManager.vue'
 
@@ -10,6 +11,7 @@ const invites = ref([
 ])
 const sent = vi.fn(async () => ({ sent: 0 }))
 const removeMany = vi.fn(async () => {})
+const seedFn = vi.fn(async () => 0)
 
 mockNuxtImport('useEventInvites', () => () => ({
   invites,
@@ -19,7 +21,7 @@ mockNuxtImport('useEventInvites', () => () => ({
   addInvite: async () => {},
   removeInvite: async () => {},
   removeInvites: removeMany,
-  seedFromLastEvent: async () => 0,
+  seedFromLastEvent: seedFn,
   sendInvites: sent
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
@@ -50,5 +52,26 @@ describe('EventInviteManager', () => {
     const del = w.findAll('button').find(b => b.text().includes('Delete'))
     await del!.trigger('click')
     expect(removeMany).toHaveBeenCalledWith(['b'])
+  })
+
+  it('does not auto-pull from the last event on load, even when the list is empty', async () => {
+    seedFn.mockClear()
+    const saved = invites.value
+    invites.value = []
+    try {
+      await mountSuspended(EventInviteManager, { props: { eventId: 'fresh-event' } })
+      await flushPromises()
+      expect(seedFn).not.toHaveBeenCalled()
+    } finally {
+      invites.value = saved
+    }
+  })
+
+  it('pulls from the last event only when the button is clicked', async () => {
+    seedFn.mockClear()
+    const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e' } })
+    const pull = w.findAll('button').find(b => b.text().includes('Pull from last event'))
+    await pull!.trigger('click')
+    expect(seedFn).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Scope

Stop the event invite manager from auto-pulling the previous event's guest list every time the page loads.

## Problem

The `EventInviteManager` had an auto-roll watcher that called `seedFromLastEvent()` whenever the list loaded empty. That meant: clear a guest list, reload, and everyone gets silently re-added — directly fighting the 'auto-add unless we remove them' intent. It also re-ran on every navigation to a fresh event.

## Fix

Remove the auto-roll watcher. Keep the explicit **Pull from last event** button (unchanged) so it's a deliberate action.

## Tests

- New: mounting with an empty list does **not** call `seedFromLastEvent`.
- New: clicking **Pull from last event** still calls it once.
- 221 unit tests green, lint + typecheck clean.

## Invariants & Risk

UI-only behavior change; no auth/RLS/schema impact.