### PR TITLE
fix: read server-side user id from JWT sub — the actual invite-send 500 cause

### DIFF
--- a/server/api/account/delete.post.ts
+++ b/server/api/account/delete.post.ts
@@ -7,12 +7,13 @@ import { serverSupabaseServiceRole, serverSupabaseUser } from '#supabase/server'
  */
 export default defineEventHandler(async (event) => {
   const user = await serverSupabaseUser(event)
-  if (!user) {
+  const userId = claimsUserId(user)
+  if (!userId) {
     throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
   }
 
   const admin = serverSupabaseServiceRole(event)
-  const { error } = await admin.auth.admin.deleteUser(user.id)
+  const { error } = await admin.auth.admin.deleteUser(userId)
   if (error) {
     throw createError({ statusCode: 500, statusMessage: 'Failed to delete account' })
   }

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -12,14 +12,15 @@ import type { Database } from '~/types/database.types'
  */
 export default defineEventHandler(async (event) => {
   const user = await serverSupabaseUser(event)
-  if (!user) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+  const userId = claimsUserId(user)
+  if (!user || !userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
 
   const eventId = getRouterParam(event, 'id')
   if (!eventId) throw createError({ statusCode: 400, statusMessage: 'Missing event id' })
 
   // RLS-scoped client: runs as the signed-in user via their session cookie.
   const db = await serverSupabaseClient<Database>(event)
-  const { data: me, error: meError } = await db.from('profiles').select('is_admin').eq('id', user.id).single()
+  const { data: me, error: meError } = await db.from('profiles').select('is_admin').eq('id', userId).single()
   if (meError) {
     throw createError({ statusCode: 500, statusMessage: 'Could not load your profile', data: { cause: meError.message, code: meError.code } })
   }
@@ -61,7 +62,7 @@ export default defineEventHandler(async (event) => {
       })
       // Allowlist them so they can sign in too (idempotent).
       await db.from('invites').upsert(
-        { email: invite.email, display_name: invite.display_name, invited_by: user.id },
+        { email: invite.email, display_name: invite.display_name, invited_by: userId },
         { onConflict: 'email', ignoreDuplicates: true }
       )
       await db

--- a/server/api/events/announce.post.ts
+++ b/server/api/events/announce.post.ts
@@ -22,11 +22,12 @@ const bodySchema = z.object({
  */
 export default defineEventHandler(async (event) => {
   const user = await serverSupabaseUser(event)
-  if (!user) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+  const userId = claimsUserId(user)
+  if (!user || !userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
 
   // RLS-scoped client: runs as the signed-in user via their session cookie.
   const admin = await serverSupabaseClient<Database>(event)
-  const { data: me } = await admin.from('profiles').select('is_admin').eq('id', user.id).single()
+  const { data: me } = await admin.from('profiles').select('is_admin').eq('id', userId).single()
   if (!me?.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
 
   const parsed = bodySchema.safeParse(await readBody(event))

--- a/server/api/invites/send.post.ts
+++ b/server/api/invites/send.post.ts
@@ -18,7 +18,8 @@ const bodySchema = z.object({
  */
 export default defineEventHandler(async (event) => {
   const user = await serverSupabaseUser(event)
-  if (!user) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+  const userId = claimsUserId(user)
+  if (!user || !userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
 
   const parsed = bodySchema.safeParse(await readBody(event))
   if (!parsed.success) {
@@ -30,7 +31,7 @@ export default defineEventHandler(async (event) => {
   const db = await serverSupabaseClient<Database>(event)
 
   // The inviter must be an allowlisted (admin or on the list), non-blocked member.
-  const { data: me } = await db.from('profiles').select('is_admin, blocked').eq('id', user.id).single()
+  const { data: me } = await db.from('profiles').select('is_admin, blocked').eq('id', userId).single()
   if (!me || me.blocked) throw createError({ statusCode: 403, statusMessage: 'Not allowed to invite' })
   let allowed = me.is_admin
   const inviterEmail = (user.email ?? '').trim().toLowerCase()
@@ -44,7 +45,7 @@ export default defineEventHandler(async (event) => {
   const { error: insertError } = await db.from('invites').insert({
     email,
     display_name: name ?? null,
-    invited_by: user.id
+    invited_by: userId
   })
   if (insertError && insertError.code !== '23505') {
     throw createError({ statusCode: 400, statusMessage: insertError.message || 'Could not add invite' })

--- a/server/utils/userId.ts
+++ b/server/utils/userId.ts
@@ -1,0 +1,14 @@
+import type { JwtPayload } from '@supabase/supabase-js'
+
+/**
+ * The signed-in user's id from Supabase JWT claims.
+ *
+ * `serverSupabaseUser` returns the decoded JWT *claims* (a `JwtPayload`), not a
+ * `User` object — so the user id is `sub`, not `id`. Reading `.id` yields
+ * `undefined`, which then reaches PostgREST as `id=eq.undefined` and blows up with
+ * `22P02 invalid input syntax for type uuid: "undefined"`. Centralizing the read
+ * here keeps every server route from re-introducing that bug.
+ */
+export function claimsUserId(user: JwtPayload | null): string | null {
+  return typeof user?.sub === 'string' && user.sub ? user.sub : null
+}

--- a/test/userId.test.ts
+++ b/test/userId.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import type { JwtPayload } from '@supabase/supabase-js'
+import { claimsUserId } from '../server/utils/userId'
+
+describe('claimsUserId', () => {
+  it('reads the id from the JWT `sub` claim (not `id`)', () => {
+    const claims = { sub: '54d2d3f7-ad73-49c5-ad60-afecb2883747', email: 'a@x.com' } as unknown as JwtPayload
+    expect(claimsUserId(claims)).toBe('54d2d3f7-ad73-49c5-ad60-afecb2883747')
+  })
+
+  it('returns null for a null user', () => {
+    expect(claimsUserId(null)).toBeNull()
+  })
+
+  it('returns null when there is no sub (so we never query id=eq.undefined)', () => {
+    // The regression: serverSupabaseUser returns claims, and reading `.id` gave
+    // undefined → PostgREST 22P02. A claims object with an `id` but no `sub` must
+    // still resolve to null, not the bogus id.
+    const claims = { id: 'should-be-ignored', email: 'a@x.com' } as unknown as JwtPayload
+    expect(claimsUserId(claims)).toBeNull()
+  })
+
+  it('returns null for a blank sub', () => {
+    expect(claimsUserId({ sub: '' } as unknown as JwtPayload)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Scope

**This is the real fix for the invite-send 500.** Every previous theory (service-role key) was wrong — the diagnostic I added in #64 finally proved it:

```json
{ "statusMessage": "Could not load your profile",
  "data": { "cause": "invalid input syntax for type uuid: \"undefined\"", "code": "22P02" } }
```

## Root cause

`serverSupabaseUser(event)` returns the decoded **JWT claims** (`JwtPayload`), **not** a Supabase `User` object — the user id is `sub`, not `id`. `JwtPayload` has an index signature, so `user.id` type-checks as `any` but is `undefined` at runtime. That `undefined` reached PostgREST as `id=eq.undefined`, and Postgres rejected it with `22P02`.

The old service-role code hit this **exact same error** on the same query and assumed it meant a bad `NUXT_SUPABASE_SECRET_KEY` — which is why we chased the key for two rounds. The key was a red herring; the query was malformed regardless of the key.

## Fix

Add `claimsUserId(claims)` (in `server/utils/`) that reads `sub` correctly, and use it in the four routes that read the user id:

- `events/[id]/invites/send.post.ts` — the one that was 500ing (admin check + `invited_by`)
- `invites/send.post.ts` — invite a friend (same two spots)
- `events/announce.post.ts` — admin event blast (admin check)
- `account/delete.post.ts` — `auth.admin.deleteUser(undefined)` was silently broken too

## Tests

`test/userId.test.ts` covers `claimsUserId`, including the regression: claims that carry an `id` but no `sub` must resolve to `null`, never the bogus id. Full suite green (217 passing), lint + typecheck clean.

## Invariants & Risk

No RLS/schema/key changes. Pure correctness fix for how the server reads the authenticated user's id. Pairs with #65 (which moved these routes onto the caller's RLS) — together, sending now works and no longer depends on the service-role key at all.
