### PR TITLE
fix: surface invite-send failures (Resend errors) instead of fake 'everyone invited'

### DIFF
--- a/app/components/EventInviteManager.vue
+++ b/app/components/EventInviteManager.vue
@@ -89,12 +89,17 @@ async function onSeed(): Promise<void> {
 async function onSend(): Promise<void> {
   sending.value = true
   try {
-    const { sent } = await sendInvites()
-    toast.add({
-      title: sent ? `Sent ${sent} invite${sent === 1 ? '' : 's'}` : 'Everyone has already been invited',
-      icon: 'i-lucide-send',
-      color: 'success'
-    })
+    const { sent, failed, error } = await sendInvites()
+    if (sent && failed) {
+      toast.add({ title: `Sent ${sent}, ${failed} failed`, description: error ?? undefined, icon: 'i-lucide-send', color: 'warning' })
+    } else if (sent) {
+      toast.add({ title: `Sent ${sent} invite${sent === 1 ? '' : 's'}`, icon: 'i-lucide-send', color: 'success' })
+    } else if (failed) {
+      // The send reached Resend but was rejected — show the reason, don't pretend success.
+      toast.add({ title: `Couldn't send ${failed} invite${failed === 1 ? '' : 's'}`, description: error ?? undefined, color: 'error' })
+    } else {
+      toast.add({ title: 'Everyone has already been invited', color: 'neutral' })
+    }
   } catch (error) {
     toast.add({ title: 'Could not send invites', description: error instanceof Error ? error.message : undefined, color: 'error' })
   } finally {

--- a/app/composables/useEventInvites.ts
+++ b/app/composables/useEventInvites.ts
@@ -125,13 +125,18 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
     return toAdd.length
   }
 
-  /** Send (or re-send) the tokenized e-vites for this event via the server route. */
-  async function sendInvites(): Promise<{ sent: number }> {
+  /** Send (or re-send) the tokenized e-vites for this event via the server route.
+   *  Returns how many sent/failed and the first failure reason (e.g. a Resend
+   *  rejection) so the UI can show why instead of a misleading success. */
+  async function sendInvites(): Promise<{ sent: number, failed: number, error: string | null }> {
     const id = toValue(eventId)
-    if (!id) return { sent: 0 }
-    const result = await $fetch<{ ok: boolean, sent: number }>(`/api/events/${id}/invites/send`, { method: 'POST' })
+    if (!id) return { sent: 0, failed: 0, error: null }
+    const result = await $fetch<{ ok: boolean, sent: number, failed: number, error: string | null }>(
+      `/api/events/${id}/invites/send`,
+      { method: 'POST' }
+    )
     await refresh()
-    return { sent: result.sent }
+    return { sent: result.sent, failed: result.failed, error: result.error }
   }
 
   // Live updates as RSVPs / opens land (event_invites is in the realtime publication).

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -29,13 +29,16 @@ export default defineEventHandler(async (event) => {
   const { data: ev } = await db.from('events').select('title, event_date, location').eq('id', eventId).single()
   if (!ev) throw createError({ statusCode: 404, statusMessage: 'Event not found' })
 
-  const { data: invites } = await db
+  const { data: invites, error: queueError } = await db
     .from('event_invites')
     .select('id, email, display_name, token')
     .eq('event_id', eventId)
     .is('sent_at', null)
+  if (queueError) {
+    throw createError({ statusCode: 500, statusMessage: 'Could not load the guest list', data: { cause: queueError.message, code: queueError.code } })
+  }
   const queue = invites ?? []
-  if (!queue.length) return { ok: true, sent: 0 }
+  if (!queue.length) return { ok: true, sent: 0, failed: 0, error: null }
 
   const config = useRuntimeConfig(event)
   if (!config.resendApiKey) throw createError({ statusCode: 500, statusMessage: 'Email is not configured' })
@@ -44,6 +47,7 @@ export default defineEventHandler(async (event) => {
   const inviterName = meta?.full_name ?? meta?.name ?? user.email ?? null
 
   let sent = 0
+  const failures: { email: string, error: string }[] = []
   for (const invite of queue) {
     const mail = buildEventInviteEmail({
       eventTitle: ev.title,
@@ -70,9 +74,15 @@ export default defineEventHandler(async (event) => {
         .update({ sent_at: new Date().toISOString(), resend_id: resendId })
         .eq('id', invite.id)
       sent++
-    } catch {
-      // Skip this recipient; leave sent_at null so a later send retries it.
+    } catch (e) {
+      // Leave sent_at null so a later send retries — but record WHY (don't swallow:
+      // a swallowed Resend rejection looked like "everyone already invited").
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      failures.push({ email: invite.email, error: message })
+      console.error('[events/invites/send] failed for', invite.email, '-', message)
     }
   }
-  return { ok: true, sent }
+  // `error` carries the first failure (usually identical across recipients, e.g. an
+  // unverified Resend sender domain) so the UI can show the real reason.
+  return { ok: true, sent, failed: failures.length, error: failures[0]?.error ?? null }
 })

--- a/test/EventInviteManager.nuxt.test.ts
+++ b/test/EventInviteManager.nuxt.test.ts
@@ -1,17 +1,21 @@
 // @vitest-environment nuxt
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
 import { flushPromises } from '@vue/test-utils'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import EventInviteManager from '../app/components/EventInviteManager.vue'
 
+interface SendResult { sent: number, failed: number, error: string | null }
+interface Toast { title?: string, description?: string, color?: string }
+
 const invites = ref([
   { id: 'a', event_id: 'e', email: 'pat@x.com', display_name: 'Pat', token: '1', rsvp: 'going', rsvp_at: null, invited_by: null, resend_id: null, sent_at: 't', delivered_at: null, opened_at: null, clicked_at: null, bounced_at: null, created_at: '' },
   { id: 'b', event_id: 'e', email: 'sam@x.com', display_name: 'Sam', token: '2', rsvp: null, rsvp_at: null, invited_by: null, resend_id: null, sent_at: null, delivered_at: null, opened_at: null, clicked_at: null, bounced_at: null, created_at: '' }
 ])
-const sent = vi.fn(async () => ({ sent: 0 }))
+const sendFn = vi.fn<() => Promise<SendResult>>(async () => ({ sent: 0, failed: 0, error: null }))
 const removeMany = vi.fn(async () => {})
 const seedFn = vi.fn(async () => 0)
+const toasts: Toast[] = []
 
 mockNuxtImport('useEventInvites', () => () => ({
   invites,
@@ -22,9 +26,21 @@ mockNuxtImport('useEventInvites', () => () => ({
   removeInvite: async () => {},
   removeInvites: removeMany,
   seedFromLastEvent: seedFn,
-  sendInvites: sent
+  sendInvites: sendFn
 }))
-mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+mockNuxtImport('useToast', () => () => ({ add: (t: Toast) => toasts.push(t) }))
+
+const clickSend = async (w: { findAll: (s: string) => Array<{ text: () => string, trigger: (e: string) => Promise<void> }> }): Promise<void> => {
+  const send = w.findAll('button').find(b => b.text().includes('Send'))
+  await send!.trigger('click')
+  await flushPromises()
+}
+
+beforeEach(() => {
+  toasts.length = 0
+  sendFn.mockReset()
+  sendFn.mockResolvedValue({ sent: 0, failed: 0, error: null })
+})
 
 describe('EventInviteManager', () => {
   it('shows the tracker stats and the guest list', async () => {
@@ -73,5 +89,40 @@ describe('EventInviteManager', () => {
     const pull = w.findAll('button').find(b => b.text().includes('Pull from last event'))
     await pull!.trigger('click')
     expect(seedFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces the failure reason when a send is rejected (not a fake success)', async () => {
+    sendFn.mockResolvedValue({ sent: 0, failed: 1, error: 'The benteenscreenonthegreen.com domain is not verified' })
+    const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e' } })
+    await clickSend(w)
+    const toast = toasts.at(-1)
+    expect(toast?.color).toBe('error')
+    expect(toast?.title).toContain('Couldn\'t send')
+    expect(toast?.description).toBe('The benteenscreenonthegreen.com domain is not verified')
+  })
+
+  it('reports a fully successful send', async () => {
+    sendFn.mockResolvedValue({ sent: 2, failed: 0, error: null })
+    const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e' } })
+    await clickSend(w)
+    const toast = toasts.at(-1)
+    expect(toast?.color).toBe('success')
+    expect(toast?.title).toBe('Sent 2 invites')
+  })
+
+  it('reports a partial send (some sent, some failed)', async () => {
+    sendFn.mockResolvedValue({ sent: 1, failed: 1, error: 'rejected' })
+    const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e' } })
+    await clickSend(w)
+    const toast = toasts.at(-1)
+    expect(toast?.color).toBe('warning')
+    expect(toast?.title).toBe('Sent 1, 1 failed')
+  })
+
+  it('only says "everyone already invited" when nothing was queued', async () => {
+    sendFn.mockResolvedValue({ sent: 0, failed: 0, error: null })
+    const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e' } })
+    await clickSend(w)
+    expect(toasts.at(-1)?.title).toBe('Everyone has already been invited')
   })
 })


### PR DESCRIPTION
## Scope

Make the invite-send actually tell you when it fails, instead of reporting "Everyone has already been invited."

## What was happening

You added a guest (`event_invites` row, `sent_at: null`), hit Send, and got `{ "sent": 0 }` → UI said "Everyone has already been invited" — yet nothing reached Resend and the row still showed "not sent."

The send loop **swallowed the error**:

```ts
try { await sendEmail(...); ...; sent++ }
catch { /* leave sent_at null */ }   // <- Resend's rejection vanished here
```

So `sent: 0` meant two indistinguishable things — "nothing to send" and "every send was rejected." Resend rejecting at the API layer (e.g. wrong key / `from`) also doesn't create a dashboard entry, which is why you saw no email there.

## Fix

The route now:
- checks the queue query error (was ignored),
- collects per-recipient failures and `console.error`s each,
- returns `{ sent, failed, error }` where `error` is the first failure reason.

The UI distinguishes:
- ✅ `Sent N` (success)
- ⚠️ `Sent N, M failed` (partial)
- ❌ `Couldn't send N` **+ the actual reason in the toast** (all failed)
- "Everyone has already been invited" **only** when nothing was actually queued (`failed: 0`)

## Why this matters for your case

Your domain is verified, so the real reason is something else (e.g. the API key not matching the account that owns the verified domain, or the `from` address). **After this deploys, hit Send again — the red toast will show Resend's exact message**, and the server logs will have a `[events/invites/send] failed for …` line. That's the missing piece.

## Tests

`EventInviteManager` now covers all four outcomes (success / partial / all-failed-shows-reason / nothing-queued). 223 unit tests green, lint + typecheck clean.

## Invariants & Risk

No RLS/schema/key changes. Server-side diagnostics + UX only.
