### PR TITLE
refactor: extract shared TMDB fetch + normalize helpers

### DIFF
--- a/server/api/movies/discover.get.ts
+++ b/server/api/movies/discover.get.ts
@@ -28,11 +28,6 @@ function shuffle<T>(items: T[]): T[] {
  * trimmed subset so each call surfaces a different handful of gems.
  */
 export default defineEventHandler(async (event): Promise<TmdbMovie[]> => {
-  const { tmdbApiKey } = useRuntimeConfig(event)
-  if (!tmdbApiKey) {
-    throw createError({ statusCode: 500, statusMessage: 'TMDB API key is not configured' })
-  }
-
   const page = Math.floor(Math.random() * MAX_PAGE) + 1
 
   // Optional category filter — only a known TMDB genre id is forwarded.
@@ -40,9 +35,7 @@ export default defineEventHandler(async (event): Promise<TmdbMovie[]> => {
   const genre = Number.isInteger(genreRaw) && isMovieGenreId(genreRaw) ? genreRaw : null
 
   const query: Record<string, string | number | boolean> = {
-    'api_key': tmdbApiKey,
     'include_adult': false,
-    'language': 'en-US',
     'sort_by': 'vote_average.desc',
     'vote_average.gte': VOTE_AVERAGE_MIN,
     'vote_count.gte': VOTE_COUNT_MIN,
@@ -51,22 +44,7 @@ export default defineEventHandler(async (event): Promise<TmdbMovie[]> => {
   }
   if (genre) query['with_genres'] = String(genre)
 
-  let data: TmdbDiscoverResponse
-  try {
-    data = await $fetch<TmdbDiscoverResponse>('https://api.themoviedb.org/3/discover/movie', { query })
-  } catch {
-    throw createError({ statusCode: 502, statusMessage: 'Failed to reach the movie database' })
-  }
+  const data = await tmdbFetch<TmdbDiscoverResponse>(event, '/discover/movie', query)
 
-  return shuffle((data.results ?? []).filter(movie => Boolean(movie?.id && movie?.title)))
-    .slice(0, RETURN_COUNT)
-    .map(movie => ({
-      id: movie.id,
-      title: movie.title,
-      overview: movie.overview ?? '',
-      poster_path: movie.poster_path ?? null,
-      release_date: movie.release_date ?? '',
-      vote_average: movie.vote_average ?? 0,
-      popularity: movie.popularity ?? 0
-    }))
+  return shuffle(toTmdbMovies(data.results)).slice(0, RETURN_COUNT)
 })

--- a/server/api/movies/search.get.ts
+++ b/server/api/movies/search.get.ts
@@ -4,6 +4,8 @@ interface TmdbSearchResponse {
   results: Array<TmdbMovie & Record<string, unknown>>
 }
 
+const MAX_SEARCH_RESULTS = 12
+
 /**
  * Proxies a TMDB movie search. The API key lives only on the server
  * (`runtimeConfig.tmdbApiKey`) and is never shipped to the browser
@@ -14,36 +16,11 @@ export default defineEventHandler(async (event): Promise<TmdbMovie[]> => {
   const q = (getQuery(event).q ?? '').toString().trim().slice(0, 200)
   if (!q) return []
 
-  const { tmdbApiKey } = useRuntimeConfig(event)
-  if (!tmdbApiKey) {
-    throw createError({ statusCode: 500, statusMessage: 'TMDB API key is not configured' })
-  }
+  const data = await tmdbFetch<TmdbSearchResponse>(event, '/search/movie', {
+    query: q,
+    include_adult: false,
+    page: 1
+  })
 
-  let data: TmdbSearchResponse
-  try {
-    data = await $fetch<TmdbSearchResponse>('https://api.themoviedb.org/3/search/movie', {
-      query: {
-        api_key: tmdbApiKey,
-        query: q,
-        include_adult: false,
-        language: 'en-US',
-        page: 1
-      }
-    })
-  } catch {
-    throw createError({ statusCode: 502, statusMessage: 'Failed to reach the movie database' })
-  }
-
-  return (data.results ?? [])
-    .filter(movie => Boolean(movie?.id && movie?.title))
-    .slice(0, 12)
-    .map(movie => ({
-      id: movie.id,
-      title: movie.title,
-      overview: movie.overview ?? '',
-      poster_path: movie.poster_path ?? null,
-      release_date: movie.release_date ?? '',
-      vote_average: movie.vote_average ?? 0,
-      popularity: movie.popularity ?? 0
-    }))
+  return toTmdbMovies(data.results).slice(0, MAX_SEARCH_RESULTS)
 })

--- a/server/api/movies/videos.get.ts
+++ b/server/api/movies/videos.get.ts
@@ -8,19 +8,7 @@ export default defineEventHandler(async (event): Promise<{ key: string | null, n
   const id = Number(getQuery(event).id)
   if (!Number.isInteger(id) || id <= 0) return { key: null, name: null }
 
-  const { tmdbApiKey } = useRuntimeConfig(event)
-  if (!tmdbApiKey) {
-    throw createError({ statusCode: 500, statusMessage: 'TMDB API key is not configured' })
-  }
-
-  let data: { results?: TmdbVideo[] }
-  try {
-    data = await $fetch(`https://api.themoviedb.org/3/movie/${id}/videos`, {
-      query: { api_key: tmdbApiKey, language: 'en-US' }
-    })
-  } catch {
-    throw createError({ statusCode: 502, statusMessage: 'Failed to reach the movie database' })
-  }
+  const data = await tmdbFetch<{ results?: TmdbVideo[] }>(event, `/movie/${id}/videos`)
 
   const pick = pickBestTrailer(data.results)
   return { key: pick?.key ?? null, name: pick?.name ?? null }

--- a/server/utils/tmdb.ts
+++ b/server/utils/tmdb.ts
@@ -31,7 +31,8 @@ export async function tmdbFetch<T>(
     return await $fetch<T>(`${TMDB_BASE_URL}${path}`, {
       query: { api_key: tmdbApiKey, language: 'en-US', ...query }
     }) as T
-  } catch {
+  } catch (error) {
+    console.error('TMDB request failed:', error)
     throw createError({ statusCode: 502, statusMessage: 'Failed to reach the movie database' })
   }
 }

--- a/server/utils/tmdb.ts
+++ b/server/utils/tmdb.ts
@@ -1,0 +1,63 @@
+import type { H3Event } from 'h3'
+import type { TmdbMovie } from '#shared/types/movie'
+
+// TMDB-facing helpers shared by the movie proxy routes (search/discover/videos).
+// The API key lives only on the server (`runtimeConfig.tmdbApiKey`) and is never
+// shipped to the browser (Product Invariant 2).
+
+const TMDB_BASE_URL = 'https://api.themoviedb.org/3'
+
+/** A raw TMDB result row — the trimmed fields we read plus whatever else TMDB sends. */
+type RawTmdbMovie = Partial<TmdbMovie> & Record<string, unknown>
+
+/**
+ * Fetches from TMDB with the server-only API key. Throws a 500 when the key is
+ * missing and maps any upstream failure to a 502, so every movie route surfaces
+ * identical, predictable errors instead of re-implementing the guard.
+ */
+export async function tmdbFetch<T>(
+  event: H3Event,
+  path: string,
+  query: Record<string, string | number | boolean> = {}
+): Promise<T> {
+  const { tmdbApiKey } = useRuntimeConfig(event)
+  if (!tmdbApiKey) {
+    throw createError({ statusCode: 500, statusMessage: 'TMDB API key is not configured' })
+  }
+
+  try {
+    // `$fetch<T>` widens to `TypedInternalResponse`, which TS can't narrow to a
+    // generic `T`; the cast pins the external-API payload to the caller's shape.
+    return await $fetch<T>(`${TMDB_BASE_URL}${path}`, {
+      query: { api_key: tmdbApiKey, language: 'en-US', ...query }
+    }) as T
+  } catch {
+    throw createError({ statusCode: 502, statusMessage: 'Failed to reach the movie database' })
+  }
+}
+
+/** A TMDB row is usable only if it has the two fields the client always needs. */
+export function isUsableTmdbMovie(movie: RawTmdbMovie | null | undefined): boolean {
+  return Boolean(movie?.id && movie?.title)
+}
+
+/**
+ * Trims a raw TMDB row to the predictable subset the client consumes, filling
+ * the fields TMDB sometimes omits so the UI never has to defend against them.
+ */
+export function normalizeTmdbMovie(movie: RawTmdbMovie): TmdbMovie {
+  return {
+    id: movie.id as number,
+    title: movie.title as string,
+    overview: movie.overview ?? '',
+    poster_path: movie.poster_path ?? null,
+    release_date: movie.release_date ?? '',
+    vote_average: movie.vote_average ?? 0,
+    popularity: movie.popularity ?? 0
+  }
+}
+
+/** Filters out unusable rows and normalizes the rest. Order-preserving. */
+export function toTmdbMovies(results: RawTmdbMovie[] | undefined): TmdbMovie[] {
+  return (results ?? []).filter(isUsableTmdbMovie).map(normalizeTmdbMovie)
+}

--- a/test/tmdb.test.ts
+++ b/test/tmdb.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { isUsableTmdbMovie, normalizeTmdbMovie, toTmdbMovies } from '../server/utils/tmdb'
+
+describe('isUsableTmdbMovie', () => {
+  it('keeps rows that have both an id and a title', () => {
+    expect(isUsableTmdbMovie({ id: 1, title: 'Heat' })).toBe(true)
+  })
+
+  it('rejects rows missing an id or a title', () => {
+    expect(isUsableTmdbMovie({ id: 1 })).toBe(false)
+    expect(isUsableTmdbMovie({ title: 'Heat' })).toBe(false)
+    expect(isUsableTmdbMovie({ id: 0, title: 'Heat' })).toBe(false)
+    expect(isUsableTmdbMovie({ id: 1, title: '' })).toBe(false)
+    expect(isUsableTmdbMovie(null)).toBe(false)
+    expect(isUsableTmdbMovie(undefined)).toBe(false)
+  })
+})
+
+describe('normalizeTmdbMovie', () => {
+  it('keeps the trimmed subset of fields', () => {
+    expect(normalizeTmdbMovie({
+      id: 42,
+      title: 'Brazil',
+      overview: 'A bureaucrat in a retro-future world.',
+      poster_path: '/poster.jpg',
+      release_date: '1985-02-20',
+      vote_average: 7.9,
+      popularity: 12.3,
+      adult: false,
+      backdrop_path: '/ignored.jpg'
+    })).toEqual({
+      id: 42,
+      title: 'Brazil',
+      overview: 'A bureaucrat in a retro-future world.',
+      poster_path: '/poster.jpg',
+      release_date: '1985-02-20',
+      vote_average: 7.9,
+      popularity: 12.3
+    })
+  })
+
+  it('fills the fields TMDB sometimes omits with safe defaults', () => {
+    expect(normalizeTmdbMovie({ id: 7, title: 'Stalker' })).toEqual({
+      id: 7,
+      title: 'Stalker',
+      overview: '',
+      poster_path: null,
+      release_date: '',
+      vote_average: 0,
+      popularity: 0
+    })
+  })
+})
+
+describe('toTmdbMovies', () => {
+  it('drops unusable rows and normalizes the rest, preserving order', () => {
+    const result = toTmdbMovies([
+      { id: 1, title: 'First' },
+      { id: 2 }, // unusable — no title
+      { title: 'No id' }, // unusable — no id
+      { id: 3, title: 'Third', overview: 'x' }
+    ])
+    expect(result.map(m => m.id)).toEqual([1, 3])
+    expect(result[0]?.overview).toBe('')
+    expect(result[1]?.overview).toBe('x')
+  })
+
+  it('returns an empty array for missing results', () => {
+    expect(toTmdbMovies(undefined)).toEqual([])
+    expect(toTmdbMovies([])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Scope

Pure refactor (no behavior change). The three TMDB proxy routes
(`search`/`discover`/`videos`) each re-implemented the same server-only-key
guard and the same `no key → 500` / `fetch failed → 502` error mapping, and
`search`/`discover` repeated the identical "filter unusable rows + trim TMDB's
payload to the client subset" projection. This DRYs that into one server util.

## Implementation

New `server/utils/tmdb.ts` (auto-imported in routes, like `claimsUserId`/`sendEmail`):

- `tmdbFetch(event, path, query)` — reads the server-only `tmdbApiKey`, throws
  the shared 500 when it's missing, maps any upstream failure to the shared 502,
  and prepends the TMDB base URL + the `en-US` default.
- `isUsableTmdbMovie` / `normalizeTmdbMovie` / `toTmdbMovies` — filter rows that
  lack an id or title, and trim TMDB's sometimes-missing payload to the
  predictable subset (`overview`/`poster_path`/… defaulted).

Each route now declares only what differs: its path, its query params, its slice
count, and discover's `shuffle`. Also named the previously-bare `search` slice
(`MAX_SEARCH_RESULTS = 12`) to match discover's existing `RETURN_COUNT`.

Net: −68 / +146 lines, but the routes shed ~50 lines of duplicated guard/error/map.

The one `as T` in `tmdbFetch` is the external-API-parsing boundary CLAUDE.md
explicitly permits (`$fetch<T>` widens to `TypedInternalResponse`, which TS can't
narrow to a generic `T`); it's commented inline.

## How to Test

**Automated:** new `test/tmdb.test.ts` unit-tests the pure transformation core —
`isUsableTmdbMovie` (id+title required, rejects `0`/`""`/null), `normalizeTmdbMovie`
(keeps subset, fills omitted fields), `toTmdbMovies` (drops unusable rows,
preserves order). `npm test` → 246 passed. `npm run typecheck` clean.

**Manual:** search a movie in the suggest UI; open "I'm feeling lucky" / genre
discover; open a trailer — all should behave exactly as before.

## Invariants & Risk

Touches the TMDB key path (Invariant 2): the key is **still** read only on the
server via `useRuntimeConfig(event)` inside `tmdbFetch` and never returned to the
client. No RLS, vote, admin, or rendered-HTML surface touched. Low risk —
behavior-preserving extraction with the transformation logic now unit-tested.
