### PR TITLE
refactor: share server-route auth + email-config guards

### DIFF
--- a/server/api/account/delete.post.ts
+++ b/server/api/account/delete.post.ts
@@ -1,4 +1,4 @@
-import { serverSupabaseServiceRole, serverSupabaseUser } from '#supabase/server'
+import { serverSupabaseServiceRole } from '#supabase/server'
 
 /**
  * Deletes the signed-in user's account. Supabase doesn't allow client-side user
@@ -6,11 +6,7 @@ import { serverSupabaseServiceRole, serverSupabaseUser } from '#supabase/server'
  * auth user cascades to profile → suggestions → votes (FK on delete cascade).
  */
 export default defineEventHandler(async (event) => {
-  const user = await serverSupabaseUser(event)
-  const userId = claimsUserId(user)
-  if (!userId) {
-    throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
-  }
+  const { userId } = await requireUser(event)
 
   const admin = serverSupabaseServiceRole(event)
   const { error } = await admin.auth.admin.deleteUser(userId)

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -1,4 +1,4 @@
-import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server'
+import { serverSupabaseClient } from '#supabase/server'
 import type { Database } from '~/types/database.types'
 
 /**
@@ -11,20 +11,14 @@ import type { Database } from '~/types/database.types'
  * stamp sent_at + the Resend message id.
  */
 export default defineEventHandler(async (event) => {
-  const user = await serverSupabaseUser(event)
-  const userId = claimsUserId(user)
-  if (!user || !userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+  const { user, userId } = await requireUser(event)
 
   const eventId = getRouterParam(event, 'id')
   if (!eventId) throw createError({ statusCode: 400, statusMessage: 'Missing event id' })
 
   // RLS-scoped client: runs as the signed-in user via their session cookie.
   const db = await serverSupabaseClient<Database>(event)
-  const { data: me, error: meError } = await db.from('profiles').select('is_admin').eq('id', userId).single()
-  if (meError) {
-    throw createError({ statusCode: 500, statusMessage: 'Could not load your profile', data: { cause: meError.message, code: meError.code } })
-  }
-  if (!me?.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+  await requireAdmin(db, userId)
 
   const { data: ev } = await db
     .from('events')
@@ -45,11 +39,9 @@ export default defineEventHandler(async (event) => {
   const queue = invites ?? []
   if (!queue.length) return { ok: true, sent: 0, failed: 0, error: null }
 
-  const config = useRuntimeConfig(event)
-  if (!config.resendApiKey) throw createError({ statusCode: 500, statusMessage: 'Email is not configured' })
-  const origin = config.siteUrl || getRequestURL(event).origin
-  const meta = user.user_metadata as Record<string, string | undefined> | undefined
-  const inviterName = meta?.full_name ?? meta?.name ?? user.email ?? null
+  const { resendApiKey, resendFrom } = requireEmailConfig(event)
+  const origin = resolveOrigin(event)
+  const inviterName = inviterNameFromClaims(user)
 
   let sent = 0
   const failures: { email: string, error: string }[] = []
@@ -68,7 +60,7 @@ export default defineEventHandler(async (event) => {
       options: inviteOptions
     })
     try {
-      const { id: resendId } = await sendEmail(config.resendApiKey, config.resendFrom, {
+      const { id: resendId } = await sendEmail(resendApiKey, resendFrom, {
         to: invite.email,
         subject: mail.subject,
         html: mail.html,

--- a/server/api/events/announce.post.ts
+++ b/server/api/events/announce.post.ts
@@ -1,4 +1,4 @@
-import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server'
+import { serverSupabaseClient } from '#supabase/server'
 import { z } from 'zod'
 import type { Database } from '~/types/database.types'
 
@@ -21,14 +21,11 @@ const bodySchema = z.object({
  *  - going:   people who RSVP'd "going" to this event
  */
 export default defineEventHandler(async (event) => {
-  const user = await serverSupabaseUser(event)
-  const userId = claimsUserId(user)
-  if (!user || !userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+  const { user, userId } = await requireUser(event)
 
   // RLS-scoped client: runs as the signed-in user via their session cookie.
   const admin = await serverSupabaseClient<Database>(event)
-  const { data: me } = await admin.from('profiles').select('is_admin').eq('id', userId).single()
-  if (!me?.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+  await requireAdmin(admin, userId)
 
   const parsed = bodySchema.safeParse(await readBody(event))
   if (!parsed.success) throw createError({ statusCode: 400, statusMessage: 'Invalid announcement' })
@@ -56,20 +53,19 @@ export default defineEventHandler(async (event) => {
 
   if (!emails.length) return { ok: true, count: 0 }
 
-  const config = useRuntimeConfig(event)
-  if (!config.resendApiKey) throw createError({ statusCode: 500, statusMessage: 'Email is not configured' })
+  const { resendApiKey, resendFrom } = requireEmailConfig(event)
 
   const mail = buildAnnounceEmail({
     eventTitle: ev.title,
     eventDate: ev.event_date ? formatEmailDate(ev.event_date) : null,
     message,
     subject,
-    link: `${config.siteUrl || getRequestURL(event).origin}/overview`
+    link: `${resolveOrigin(event)}/overview`
   })
 
   try {
-    await sendEmail(config.resendApiKey, config.resendFrom, {
-      to: config.resendFrom, // a `to` is required; real recipients are BCC'd
+    await sendEmail(resendApiKey, resendFrom, {
+      to: resendFrom, // a `to` is required; real recipients are BCC'd
       bcc: emails,
       subject: mail.subject,
       html: mail.html,

--- a/server/api/invites/send.post.ts
+++ b/server/api/invites/send.post.ts
@@ -1,4 +1,4 @@
-import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server'
+import { serverSupabaseClient } from '#supabase/server'
 import { z } from 'zod'
 import type { Database } from '~/types/database.types'
 
@@ -17,9 +17,7 @@ const bodySchema = z.object({
  * (Invariant 2).
  */
 export default defineEventHandler(async (event) => {
-  const user = await serverSupabaseUser(event)
-  const userId = claimsUserId(user)
-  if (!user || !userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+  const { user, userId } = await requireUser(event)
 
   const parsed = bodySchema.safeParse(await readBody(event))
   if (!parsed.success) {
@@ -66,11 +64,10 @@ export default defineEventHandler(async (event) => {
     return { ok: true, emailed: false }
   }
 
-  const meta = user.user_metadata as Record<string, string | undefined> | undefined
-  const inviterName = meta?.full_name ?? meta?.name ?? user.email ?? null
+  const inviterName = inviterNameFromClaims(user)
   const mail = buildInviteEmail({
     inviterName,
-    link: `${config.siteUrl || getRequestURL(event).origin}/login`,
+    link: `${resolveOrigin(event)}/login`,
     eventTitle: nextEvent?.title ?? null,
     eventDate: nextEvent?.event_date ? formatEmailDate(nextEvent.event_date) : null
   })

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -1,0 +1,35 @@
+import { serverSupabaseUser } from '#supabase/server'
+import type { H3Event } from 'h3'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '~/types/database.types'
+import { claimsUserId } from './userId'
+
+// Shared server-route guards. `serverSupabaseUser` returns decoded JWT *claims*
+// (see userId.ts), so the user id is `sub` — read it via `claimsUserId`.
+
+type AuthUser = NonNullable<Awaited<ReturnType<typeof serverSupabaseUser>>>
+
+/**
+ * Resolves the signed-in user, throwing a 401 when there is no valid session.
+ * Returns both the claims and the non-null user id so callers skip the
+ * `!user || !userId` dance.
+ */
+export async function requireUser(event: H3Event): Promise<{ user: AuthUser, userId: string }> {
+  const user = await serverSupabaseUser(event)
+  const userId = claimsUserId(user)
+  if (!user || !userId) throw createError({ statusCode: 401, statusMessage: 'Not authenticated' })
+  return { user, userId }
+}
+
+/**
+ * Asserts the user is an admin, using their own RLS-scoped client. Surfaces the
+ * profile lookup error as a 500 (rather than silently treating it as "not
+ * admin"), then throws 403 if they aren't an admin.
+ */
+export async function requireAdmin(db: SupabaseClient<Database>, userId: string): Promise<void> {
+  const { data: me, error } = await db.from('profiles').select('is_admin').eq('id', userId).single()
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: 'Could not load your profile', data: { cause: error.message, code: error.code } })
+  }
+  if (!me?.is_admin) throw createError({ statusCode: 403, statusMessage: 'Admins only' })
+}

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -1,8 +1,27 @@
 import { Resend } from 'resend'
+import type { H3Event } from 'h3'
 
 // The email *builders* (subject/html/text) live in shared/utils/email.ts so the
 // admin UI can render a live preview with the exact same output. This server-only
-// module keeps the Resend send wrapper (the API key must never reach the client).
+// module keeps the Resend send wrapper + the config/origin helpers its routes
+// share (the API key must never reach the client).
+
+/** The origin for links in emails: the configured canonical URL, else the request's. */
+export function resolveOrigin(event: H3Event): string {
+  const { siteUrl } = useRuntimeConfig(event)
+  return siteUrl || getRequestURL(event).origin
+}
+
+/**
+ * Resolves the Resend config, throwing a 500 when no API key is set. Routes that
+ * intentionally soft-degrade on a missing key (e.g. invite-a-friend still
+ * allowlists the email) should read the config directly instead.
+ */
+export function requireEmailConfig(event: H3Event): { resendApiKey: string, resendFrom: string } {
+  const { resendApiKey, resendFrom } = useRuntimeConfig(event)
+  if (!resendApiKey) throw createError({ statusCode: 500, statusMessage: 'Email is not configured' })
+  return { resendApiKey, resendFrom }
+}
 
 export interface SendParams {
   to: string | string[]

--- a/server/utils/userId.ts
+++ b/server/utils/userId.ts
@@ -12,3 +12,15 @@ import type { JwtPayload } from '@supabase/supabase-js'
 export function claimsUserId(user: JwtPayload | null): string | null {
   return typeof user?.sub === 'string' && user.sub ? user.sub : null
 }
+
+/** The subset of JWT claims we read to label an inviter in an e-vite. */
+interface InviterClaims {
+  user_metadata?: { full_name?: string | null, name?: string | null } | null
+  email?: string | null
+}
+
+/** A human name for the inviter, derived from the same claims: full name → name → email → null. */
+export function inviterNameFromClaims(user: InviterClaims): string | null {
+  const meta = user.user_metadata
+  return meta?.full_name ?? meta?.name ?? user.email ?? null
+}

--- a/test/server-email.nuxt.test.ts
+++ b/test/server-email.nuxt.test.ts
@@ -1,0 +1,15 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import type { H3Event } from 'h3'
+import { requireEmailConfig } from '../server/utils/email'
+
+// server/utils/email.ts has no `#supabase/server` dependency, so it loads in the
+// Nuxt env. The test runtime has no Resend key configured, which is exactly the
+// guard's failure case — assert it throws the shared 500 rather than returning.
+const fakeEvent = {} as H3Event
+
+describe('requireEmailConfig', () => {
+  it('throws a 500 when no Resend API key is configured', () => {
+    expect(() => requireEmailConfig(fakeEvent)).toThrowError(expect.objectContaining({ statusCode: 500 }))
+  })
+})

--- a/test/userId.test.ts
+++ b/test/userId.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { JwtPayload } from '@supabase/supabase-js'
-import { claimsUserId } from '../server/utils/userId'
+import { claimsUserId, inviterNameFromClaims } from '../server/utils/userId'
 
 describe('claimsUserId', () => {
   it('reads the id from the JWT `sub` claim (not `id`)', () => {
@@ -22,5 +22,23 @@ describe('claimsUserId', () => {
 
   it('returns null for a blank sub', () => {
     expect(claimsUserId({ sub: '' } as unknown as JwtPayload)).toBeNull()
+  })
+})
+
+describe('inviterNameFromClaims', () => {
+  it('prefers the full name', () => {
+    expect(inviterNameFromClaims({ user_metadata: { full_name: 'Ada Lovelace', name: 'ada' }, email: 'a@b.c' }))
+      .toBe('Ada Lovelace')
+  })
+
+  it('falls back to name, then email', () => {
+    expect(inviterNameFromClaims({ user_metadata: { name: 'ada' }, email: 'a@b.c' })).toBe('ada')
+    expect(inviterNameFromClaims({ user_metadata: {}, email: 'a@b.c' })).toBe('a@b.c')
+    expect(inviterNameFromClaims({ user_metadata: null, email: 'a@b.c' })).toBe('a@b.c')
+  })
+
+  it('returns null when no name or email is present', () => {
+    expect(inviterNameFromClaims({ user_metadata: null, email: null })).toBeNull()
+    expect(inviterNameFromClaims({})).toBeNull()
   })
 })


### PR DESCRIPTION
## Scope

Pure refactor of the four email/admin server routes (`account/delete`,
`events/announce`, `events/[id]/invites/send`, `invites/send`). Each
re-implemented the same preamble — resolve user + 401, load profile + 403 if not
admin, resolve `siteUrl || origin`, guard the Resend key, derive the inviter
name from JWT claims. This DRYs them into shared `server/utils` helpers and, in
the process, **fixes one real inconsistency**.

## Implementation

- **`server/utils/auth.ts`** (new)
  - `requireUser(event)` → `{ user, userId }`; throws 401. Removes the
    `!user || !userId` dance from every route.
  - `requireAdmin(db, userId)` — loads `is_admin` under the caller's own
    RLS-scoped client and throws 403 if not admin. **Surfaces a profile-lookup
    error as a 500** rather than silently treating it as "not admin."
- **`server/utils/userId.ts`** — adds `inviterNameFromClaims` next to
  `claimsUserId` (both derive a value from the same JWT claims).
- **`server/utils/email.ts`** — adds `resolveOrigin` and `requireEmailConfig`.

The one behavior change is in `events/announce`, which previously did
`const { data: me } = …` (dropping the query `error`), so any profile read that
didn't return an admin row looked like "not an admin" → 403. It now matches
`events/[id]/invites/send`, which already surfaced this as a 500.

Note (h/t review) this is slightly broader than "a query failure": `.single()`
also errors (`PGRST116`) on **zero rows**, so a session whose `profiles` row is
missing now gets `500 Could not load your profile` instead of `403 Admins only`.
That's intended and arguably more correct — a logged-in user with no profile is a
server-state anomaly, not "you're not an admin." It's also a genuine edge case
that can't be hit normally: the `profiles: read` RLS policy is
`using (id = auth.uid() or is_allowed())`, so a caller can **always** read their
own row (RLS never hides it from the owner), and `handle_new_user` guarantees the
row exists on sign-up. So zero-rows here means a real anomaly, where 500 is the
right signal.

`invites/send` deliberately keeps its own
allowlist rule (non-admins can invite) and its soft email-degrade (a missing
Resend key still allowlists), so it uses `requireUser`/`resolveOrigin`/
`inviterNameFromClaims` but not `requireAdmin`/`requireEmailConfig`.

Net −39 / +119 with the duplicated guards gone from four routes.

## How to Test

**Automated:**
- `test/userId.test.ts` — added `inviterNameFromClaims` cases (full_name → name →
  email → null, incl. null metadata).
- `test/server-email.nuxt.test.ts` — asserts `requireEmailConfig` throws the
  shared 500 when unconfigured.
- `npm test` → 244 passed; `npm run typecheck` clean.

Note on coverage: `requireUser`/`requireAdmin` import the Nitro-only
`#supabase/server` virtual module, which can't be resolved in the Vitest env
(same reason the repo has no server-route unit tests). Their authorization
behavior is covered by `test/rls.integration.test.ts` (Supabase-local), and the
extraction is otherwise behavior-preserving. The pure/guard logic that *can* be
unit-tested in isolation (`inviterNameFromClaims`, `requireEmailConfig`) is.

**Manual:** as an admin, send an event blast and the e-vites; as a regular
allowlisted member, invite a friend — all behave as before. As a non-admin,
hitting the admin routes still 403s.

## Invariants & Risk

Touches authorization (Invariant 1) and the Resend key path (Invariant 2):
- RLS is unchanged — `requireAdmin` runs the same `is_admin` check under the
  caller's RLS-scoped client; it's a UX/clean-error convenience, not the gate.
- The Resend key is still read only server-side via `useRuntimeConfig(event)`.
- Admin role is still read-only here (no writes to `is_admin`).

Low risk: behavior-preserving extraction; the only intentional change (announce
500-on-lookup-error) hardens an error path and aligns two sibling routes.

