### PR TITLE
refactor: extract useOnDemandStats skeleton + StatTiles component

### DIFF
--- a/app/components/EventStatsModal.vue
+++ b/app/components/EventStatsModal.vue
@@ -39,17 +39,7 @@ const rsvp = computed(() => [
 
       <div v-else-if="stats" class="space-y-5">
         <!-- Headline counts -->
-        <div class="grid grid-cols-4 gap-2 text-center">
-          <div v-for="t in tiles" :key="t.label" class="rounded-lg ring ring-default p-2">
-            <UIcon :name="t.icon" class="text-muted" />
-            <p class="text-xl font-bold leading-tight">
-              {{ t.value }}
-            </p>
-            <p class="text-[11px] text-muted leading-tight">
-              {{ t.label }}
-            </p>
-          </div>
-        </div>
+        <StatTiles :tiles="tiles" />
 
         <!-- RSVP split -->
         <section>

--- a/app/components/StatTiles.vue
+++ b/app/components/StatTiles.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+/** A row of headline stat tiles (icon + value + label) — the 4-up summary grid
+ *  shared by the event and user stats modals. */
+defineProps<{ tiles: ReadonlyArray<{ label: string, value: string | number, icon: string }> }>()
+</script>
+
+<template>
+  <div class="grid grid-cols-4 gap-2 text-center">
+    <div v-for="t in tiles" :key="t.label" class="rounded-lg ring ring-default p-2">
+      <UIcon :name="t.icon" class="text-muted" />
+      <p class="text-xl font-bold leading-tight">
+        {{ t.value }}
+      </p>
+      <p class="text-[11px] text-muted leading-tight">
+        {{ t.label }}
+      </p>
+    </div>
+  </div>
+</template>

--- a/app/components/UserStatsModal.vue
+++ b/app/components/UserStatsModal.vue
@@ -33,17 +33,7 @@ const summary = computed(() => [
 
       <div v-else-if="stats" class="space-y-5">
         <!-- RSVP + voting summary -->
-        <div class="grid grid-cols-4 gap-2 text-center">
-          <div v-for="s in summary" :key="s.label" class="rounded-lg ring ring-default p-2">
-            <UIcon :name="s.icon" class="text-muted" />
-            <p class="text-xl font-bold leading-tight">
-              {{ s.value }}
-            </p>
-            <p class="text-[11px] text-muted leading-tight">
-              {{ s.label }}
-            </p>
-          </div>
-        </div>
+        <StatTiles :tiles="summary" />
 
         <!-- Movies suggested -->
         <section>

--- a/app/composables/useEventStats.ts
+++ b/app/composables/useEventStats.ts
@@ -10,49 +10,25 @@ import type { EventStats } from '#shared/utils/eventStats'
  */
 export function useEventStats(eventId: MaybeRefOrGetter<string | null>) {
   const supabase = useSupabaseClient<Database>()
-  const stats = ref<EventStats | null>(null)
-  const pending = ref(false)
-  const error = ref<string | null>(null)
 
-  async function load(id: string): Promise<void> {
-    pending.value = true
-    error.value = null
-    try {
-      const [suggestions, rsvps, bring] = await Promise.all([
-        supabase
-          .from('suggestions')
-          .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
-          .eq('event_id', id),
-        supabase.from('rsvps').select('status').eq('event_id', id),
-        supabase.from('bring_items').select('user_id').eq('event_id', id)
-      ])
-      const firstError = suggestions.error ?? rsvps.error ?? bring.error
-      if (firstError) throw firstError
-      // Drop a stale response if the selected event changed mid-flight.
-      if (toValue(eventId) !== id) return
+  return useOnDemandStats<EventStats>(eventId, async (id) => {
+    const [suggestions, rsvps, bring] = await Promise.all([
+      supabase
+        .from('suggestions')
+        .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
+        .eq('event_id', id),
+      supabase.from('rsvps').select('status').eq('event_id', id),
+      supabase.from('bring_items').select('user_id').eq('event_id', id)
+    ])
+    const firstError = suggestions.error ?? rsvps.error ?? bring.error
+    if (firstError) throw firstError
 
-      stats.value = computeEventStats({
-        // The votes embed isn't declared in the generated types, so cast as
-        // useSuggestions does (the inferred shape doesn't match).
-        suggestions: (suggestions.data ?? []) as unknown as Suggestion[],
-        rsvps: rsvps.data ?? [],
-        bringItems: bring.data ?? []
-      })
-    } catch (e) {
-      error.value = errorMessage(e, 'Failed to load stats')
-      stats.value = null
-    } finally {
-      pending.value = false
-    }
-  }
-
-  watch(() => toValue(eventId), (id) => {
-    if (!id) {
-      stats.value = null
-      return
-    }
-    void load(id)
-  }, { immediate: true })
-
-  return { stats, pending, error }
+    return computeEventStats({
+      // The votes embed isn't declared in the generated types, so cast as
+      // useSuggestions does (the inferred shape doesn't match).
+      suggestions: (suggestions.data ?? []) as unknown as Suggestion[],
+      rsvps: rsvps.data ?? [],
+      bringItems: bring.data ?? []
+    })
+  })
 }

--- a/app/composables/useOnDemandStats.ts
+++ b/app/composables/useOnDemandStats.ts
@@ -1,0 +1,43 @@
+import type { MaybeRefOrGetter, Ref } from 'vue'
+
+/**
+ * Shared lifecycle for an on-demand stats snapshot keyed by an id (an event or a
+ * user). Owns the `stats`/`pending`/`error` refs, runs `loader` when the id is
+ * set, clears on null, and drops a stale response if the id changed mid-flight.
+ * Each caller supplies only its fetch-and-compute `loader`.
+ */
+export function useOnDemandStats<T>(
+  id: MaybeRefOrGetter<string | null>,
+  loader: (id: string) => Promise<T>,
+  fallbackMessage = 'Failed to load stats'
+): { stats: Ref<T | null>, pending: Ref<boolean>, error: Ref<string | null> } {
+  const stats = shallowRef<T | null>(null)
+  const pending = ref(false)
+  const error = ref<string | null>(null)
+
+  async function load(currentId: string): Promise<void> {
+    pending.value = true
+    error.value = null
+    try {
+      const result = await loader(currentId)
+      // Drop a stale response if the selection changed mid-flight.
+      if (toValue(id) !== currentId) return
+      stats.value = result
+    } catch (e) {
+      error.value = errorMessage(e, fallbackMessage)
+      stats.value = null
+    } finally {
+      pending.value = false
+    }
+  }
+
+  watch(() => toValue(id), (currentId) => {
+    if (!currentId) {
+      stats.value = null
+      return
+    }
+    void load(currentId)
+  }, { immediate: true })
+
+  return { stats, pending, error }
+}

--- a/app/composables/useUserStats.ts
+++ b/app/composables/useUserStats.ts
@@ -14,45 +14,6 @@ import type { UserStats } from '#shared/utils/userStats'
  */
 export function useUserStats(userId: MaybeRefOrGetter<string | null>) {
   const supabase = useSupabaseClient<Database>()
-  const stats = ref<UserStats | null>(null)
-  const pending = ref(false)
-  const error = ref<string | null>(null)
-
-  async function load(id: string): Promise<void> {
-    pending.value = true
-    error.value = null
-    try {
-      const [rsvps, submissions, votes, brought] = await Promise.all([
-        supabase.from('rsvps').select('status').eq('user_id', id),
-        supabase
-          .from('suggestions')
-          .select('id, event_id, tmdb_movie, created_at')
-          .eq('user_id', id)
-          .eq('deleted', false),
-        supabase.from('votes').select('suggestion_id', { count: 'exact', head: true }).eq('user_id', id),
-        supabase.from('bring_items').select('label').eq('user_id', id)
-      ])
-      const firstError = rsvps.error ?? submissions.error ?? votes.error ?? brought.error
-      if (firstError) throw firstError
-
-      const winningSuggestionIds = await computeWins(id, submissions.data ?? [])
-      // Drop a stale response if the selected user changed mid-flight.
-      if (toValue(userId) !== id) return
-
-      stats.value = computeUserStats({
-        rsvps: rsvps.data ?? [],
-        submissions: submissions.data ?? [],
-        votesCast: votes.count ?? 0,
-        brought: brought.data ?? [],
-        winningSuggestionIds
-      })
-    } catch (e) {
-      error.value = errorMessage(e, 'Failed to load stats')
-      stats.value = null
-    } finally {
-      pending.value = false
-    }
-  }
 
   /** For the events this person suggested in, find which of their suggestions won
    *  (top-2 voted) once that event's voting is locked. */
@@ -90,13 +51,28 @@ export function useUserStats(userId: MaybeRefOrGetter<string | null>) {
     return winners
   }
 
-  watch(() => toValue(userId), (id) => {
-    if (!id) {
-      stats.value = null
-      return
-    }
-    void load(id)
-  }, { immediate: true })
+  return useOnDemandStats<UserStats>(userId, async (id) => {
+    const [rsvps, submissions, votes, brought] = await Promise.all([
+      supabase.from('rsvps').select('status').eq('user_id', id),
+      supabase
+        .from('suggestions')
+        .select('id, event_id, tmdb_movie, created_at')
+        .eq('user_id', id)
+        .eq('deleted', false),
+      supabase.from('votes').select('suggestion_id', { count: 'exact', head: true }).eq('user_id', id),
+      supabase.from('bring_items').select('label').eq('user_id', id)
+    ])
+    const firstError = rsvps.error ?? submissions.error ?? votes.error ?? brought.error
+    if (firstError) throw firstError
 
-  return { stats, pending, error }
+    const winningSuggestionIds = await computeWins(id, submissions.data ?? [])
+
+    return computeUserStats({
+      rsvps: rsvps.data ?? [],
+      submissions: submissions.data ?? [],
+      votesCast: votes.count ?? 0,
+      brought: brought.data ?? [],
+      winningSuggestionIds
+    })
+  })
 }

--- a/test/StatTiles.nuxt.test.ts
+++ b/test/StatTiles.nuxt.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import StatTiles from '../app/components/StatTiles.vue'
+
+describe('StatTiles', () => {
+  it('renders one tile per entry with its value and label', async () => {
+    const tiles = [
+      { label: 'Movies', value: 3, icon: 'i-lucide-film' },
+      { label: 'Votes', value: 7, icon: 'i-lucide-heart' }
+    ]
+    const w = await mountSuspended(StatTiles, { props: { tiles } })
+    expect(w.text()).toContain('Movies')
+    expect(w.text()).toContain('3')
+    expect(w.text()).toContain('Votes')
+    expect(w.text()).toContain('7')
+  })
+})

--- a/test/useOnDemandStats.nuxt.test.ts
+++ b/test/useOnDemandStats.nuxt.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+describe('useOnDemandStats', () => {
+  it('loads on id set, exposing the loader result', async () => {
+    const { stats, pending, error } = useOnDemandStats(ref('a'), async id => `stats:${id}`)
+    await flushPromises()
+    expect(stats.value).toBe('stats:a')
+    expect(pending.value).toBe(false)
+    expect(error.value).toBeNull()
+  })
+
+  it('clears stats when the id becomes null', async () => {
+    const id = ref<string | null>('a')
+    const { stats } = useOnDemandStats(id, async i => `stats:${i}`)
+    await flushPromises()
+    expect(stats.value).toBe('stats:a')
+    id.value = null
+    await nextTick()
+    expect(stats.value).toBeNull()
+  })
+
+  it('surfaces a loader error and leaves stats null', async () => {
+    const { stats, error } = useOnDemandStats(ref('a'), async () => { throw new Error('boom') }, 'Failed!')
+    await flushPromises()
+    expect(error.value).toBe('boom')
+    expect(stats.value).toBeNull()
+  })
+
+  it('drops a stale response when the id changed mid-flight', async () => {
+    const resolvers: Record<string, (v: string) => void> = {}
+    const loader = (id: string) => new Promise<string>((resolve) => { resolvers[id] = resolve })
+
+    const id = ref('a')
+    const { stats } = useOnDemandStats(id, loader) // immediate watch fires load('a')
+    id.value = 'b'
+    await nextTick() // watcher fires load('b')
+
+    resolvers.a!('stale-a') // resolve the no-longer-current request
+    await flushPromises()
+    expect(stats.value).toBeNull() // stale result discarded
+
+    resolvers.b!('fresh-b')
+    await flushPromises()
+    expect(stats.value).toBe('fresh-b')
+  })
+})

--- a/test/useOnDemandStats.nuxt.test.ts
+++ b/test/useOnDemandStats.nuxt.test.ts
@@ -23,7 +23,10 @@ describe('useOnDemandStats', () => {
   })
 
   it('surfaces a loader error and leaves stats null', async () => {
-    const { stats, error } = useOnDemandStats(ref('a'), async () => { throw new Error('boom') }, 'Failed!')
+    const failing = async (): Promise<string> => {
+      throw new Error('boom')
+    }
+    const { stats, error } = useOnDemandStats(ref('a'), failing, 'Failed!')
     await flushPromises()
     expect(error.value).toBe('boom')
     expect(stats.value).toBeNull()
@@ -31,7 +34,9 @@ describe('useOnDemandStats', () => {
 
   it('drops a stale response when the id changed mid-flight', async () => {
     const resolvers: Record<string, (v: string) => void> = {}
-    const loader = (id: string) => new Promise<string>((resolve) => { resolvers[id] = resolve })
+    const loader = (id: string) => new Promise<string>((resolve) => {
+      resolvers[id] = resolve
+    })
 
     const id = ref('a')
     const { stats } = useOnDemandStats(id, loader) // immediate watch fires load('a')


### PR DESCRIPTION
## Scope

Pure refactor (behavior-preserving). `useEventStats` and `useUserStats` shared an
identical lifecycle skeleton, and the two stats modals duplicated the same
4-up tile grid. This extracts both.

## Implementation

- **`app/composables/useOnDemandStats.ts`** (new) — owns the on-demand snapshot
  lifecycle keyed by an id: the `stats`/`pending`/`error` refs, the
  try/catch/finally with the shared `errorMessage` fallback, the stale-guard
  (drops a response if the id changed mid-flight), and the `immediate` watch that
  clears on null. Each caller supplies only its `loader(id) => Promise<T>`.
- **`app/components/StatTiles.vue`** (new) — the shared icon/value/label tile grid.

`useEventStats`/`useUserStats` collapse to their query-and-compute loader (`-50`
lines of duplicated skeleton); `EventStatsModal`/`UserStatsModal` render
`<StatTiles :tiles="…" />`.

One mechanical note: the stale-guard now runs once the loader fully resolves
rather than mid-loader. It's equivalent — a stale result is discarded either way
(the compute is sync and cheap). The pre-existing shared-`pending` flicker when
the id changes mid-flight is unchanged (not introduced here).

## Screenshots

No visual change — the tile grid markup (classes, layout) is identical; verified
by the existing modal tests plus the new `StatTiles` test.

## How to Test

**Automated:**
- `test/useOnDemandStats.nuxt.test.ts` (new) — loads on id set; clears on null;
  surfaces a loader error; and **drops a stale response when the id changes
  mid-flight** (deferred-promise timing).
- `test/StatTiles.nuxt.test.ts` (new) — renders one tile per entry with value+label.
- Existing `useEventStats`/`useUserStats`/`EventStatsModal`/`UserStatsModal` tests
  pass unchanged (behavior preserved).
- `npm test` → 245 passed; `npm run typecheck` clean.

**Manual:** open an event's stats and a person's activity from the admin
dashboard — the tiles, RSVP split, top picks, and loading/error states look and
behave exactly as before.

## Invariants & Risk

No product invariants touched (no auth/RLS/TMDB-key/vote/admin/HTML surface).
Both composables still read under the caller's RLS-scoped Supabase client. Low
risk — behavior-preserving extraction with the stale-guard now directly tested.
