### PR TITLE
refactor: extract .ics download mechanics out of EventInfoModal

### DIFF
--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -25,13 +25,7 @@ const googleUrl = computed(() => (calEvent.value ? googleCalendarUrl(calEvent.va
 
 function downloadIcs(): void {
   if (!calEvent.value) return
-  const blob = new Blob([icsContent(calEvent.value)], { type: 'text/calendar;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = `${(props.event?.title || 'event').replace(/[^\w-]+/g, '-')}.ics`
-  a.click()
-  URL.revokeObjectURL(url)
+  downloadTextFile(icsContent(calEvent.value), icsFilename(props.event?.title), 'text/calendar;charset=utf-8')
 }
 </script>
 

--- a/app/utils/download.ts
+++ b/app/utils/download.ts
@@ -1,0 +1,13 @@
+/**
+ * Triggers a browser download of an in-memory text file. Client-only — it pokes
+ * the DOM (Blob + object URL + a synthetic anchor click), so it lives in app/utils
+ * rather than shared/ (which is also imported server-side).
+ */
+export function downloadTextFile(content: string, filename: string, mimeType: string): void {
+  const url = URL.createObjectURL(new Blob([content], { type: mimeType }))
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/shared/utils/calendar.ts
+++ b/shared/utils/calendar.ts
@@ -56,6 +56,11 @@ export function googleCalendarUrl(e: CalendarEvent): string {
   return `https://calendar.google.com/calendar/render?${params.toString()}`
 }
 
+/** A safe `.ics` download filename derived from an event title. */
+export function icsFilename(title: string | null | undefined): string {
+  return `${(title || 'event').replace(/[^\w-]+/g, '-')}.ics`
+}
+
 /** ICS file content (for Apple Calendar / Outlook / .ics download). */
 export function icsContent(e: CalendarEvent): string {
   const esc = (s: string): string => s.replace(/[\\;,]/g, m => `\\${m}`).replace(/\n/g, '\\n')

--- a/test/calendar.test.ts
+++ b/test/calendar.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { applyTime, googleCalendarUrl, icsContent } from '../shared/utils/calendar'
+import { applyTime, googleCalendarUrl, icsContent, icsFilename } from '../shared/utils/calendar'
 
 // A fixed UTC instant keeps the UTC-formatted output deterministic across timezones.
 const start = new Date('2026-07-04T23:00:00Z')
@@ -55,6 +55,19 @@ describe('icsContent', () => {
     const ics = icsContent({ title: 'Movie Night', start })
     expect(ics).toMatch(/UID:20260704T230000Z-movie-night@/)
     expect(ics).toContain('DTSTAMP:20260704T230000Z')
+  })
+})
+
+describe('icsFilename', () => {
+  it('slugifies the title and appends .ics', () => {
+    expect(icsFilename('Movie Night: Heat!')).toBe('Movie-Night-Heat-.ics')
+    expect(icsFilename('already-fine_2026')).toBe('already-fine_2026.ics')
+  })
+
+  it('falls back to "event" when there is no title', () => {
+    expect(icsFilename('')).toBe('event.ics')
+    expect(icsFilename(null)).toBe('event.ics')
+    expect(icsFilename(undefined)).toBe('event.ics')
   })
 })
 

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { downloadTextFile } from '../app/utils/download'
+
+describe('downloadTextFile', () => {
+  let clicked: HTMLAnchorElement | null = null
+
+  beforeEach(() => {
+    clicked = null
+    URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    URL.revokeObjectURL = vi.fn()
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+      clicked = this
+    })
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('clicks an anchor pointing at an object URL with the given filename, then revokes it', () => {
+    downloadTextFile('BEGIN:VCALENDAR', 'movie-night.ics', 'text/calendar;charset=utf-8')
+
+    expect(URL.createObjectURL).toHaveBeenCalledOnce()
+    expect((URL.createObjectURL as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBeInstanceOf(Blob)
+    expect(clicked).not.toBeNull()
+    expect(clicked!.getAttribute('href')).toBe('blob:mock-url')
+    expect(clicked!.download).toBe('movie-night.ics')
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+})

--- a/test/download.test.ts
+++ b/test/download.test.ts
@@ -2,14 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { downloadTextFile } from '../app/utils/download'
 
 describe('downloadTextFile', () => {
-  let clicked: HTMLAnchorElement | null = null
+  // Capture the anchor's properties at click time (reading them off `this`
+  // directly, rather than aliasing `this` to a variable).
+  let clickedHref: string | null = null
+  let clickedDownload: string | null = null
 
   beforeEach(() => {
-    clicked = null
+    clickedHref = null
+    clickedDownload = null
     URL.createObjectURL = vi.fn(() => 'blob:mock-url')
     URL.revokeObjectURL = vi.fn()
     vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
-      clicked = this
+      clickedHref = this.getAttribute('href')
+      clickedDownload = this.download
     })
   })
 
@@ -20,9 +25,9 @@ describe('downloadTextFile', () => {
 
     expect(URL.createObjectURL).toHaveBeenCalledOnce()
     expect((URL.createObjectURL as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBeInstanceOf(Blob)
-    expect(clicked).not.toBeNull()
-    expect(clicked!.getAttribute('href')).toBe('blob:mock-url')
-    expect(clicked!.download).toBe('movie-night.ics')
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledOnce()
+    expect(clickedHref).toBe('blob:mock-url')
+    expect(clickedDownload).toBe('movie-night.ics')
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
   })
 })


### PR DESCRIPTION
## Scope

Pure refactor (behavior-preserving). The "Apple / .ics" button handler in
`EventInfoModal` embedded imperative blob → object-URL → anchor-click plumbing
plus filename slugification directly in a presentational component, so it couldn't
be tested without a real DOM click.

## Implementation

- **`shared/utils/calendar.ts`** — adds `icsFilename(title)`, the pure download
  filename slug (`title || 'event'` → `[^\w-]+` → `-`, then `.ics`), next to the
  existing `icsContent`/`googleCalendarUrl` helpers.
- **`app/utils/download.ts`** (new) — `downloadTextFile(content, filename,
  mimeType)`, the browser download trigger. It pokes the DOM (Blob + object URL +
  synthetic anchor click), so it lives in `app/utils` (client-only) rather than
  `shared/`, which is also imported server-side.

`EventInfoModal.downloadIcs` collapses to a single call. Same filename, same
`text/calendar;charset=utf-8` blob — no behavior change.

## How to Test

**Automated:**
- `test/calendar.test.ts` — added `icsFilename` cases (slugify + `.ics`; falls
  back to `event.ics` for blank/null/undefined titles).
- `test/download.test.ts` (new) — asserts `downloadTextFile` clicks an anchor
  pointing at the object URL with the given filename and revokes the URL after.
- `npm test` → 243 passed; `npm run typecheck` clean.

**Manual:** open an upcoming event's info modal, click "Apple / .ics" — it
downloads `<slugified-title>.ics` exactly as before.

## Invariants & Risk

No product invariants touched (no auth/RLS/TMDB-key/vote/admin surface). The
event description is still rendered via the existing `sanitizeHtml` path
(Invariant 5) — untouched. Low risk: behavior-preserving extraction, now covered
by a DOM-level test.
