### PR TITLE
ci: make Claude PR review reasonable on tokens

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,15 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    # Review once per PR — when it opens or leaves draft. Deliberately NOT on
+    # `synchronize`, so pushing more commits to a PR doesn't re-run a full (paid)
+    # review each time. Re-review on demand by commenting `@claude` (see claude.yml).
+    types: [opened, ready_for_review]
+    # Don't spend a review on docs-/config-only PRs (only skips when EVERY changed
+    # file matches; a mixed code+docs PR still runs).
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -49,4 +57,5 @@ jobs:
             Leave inline comments on specific lines for concrete issues; mark nits as
             non-blocking. If the PR looks solid, say so briefly — don't invent problems.
           claude_args: |
+            --model claude-sonnet-4-6
             --allowedTools "Read,Grep,Glob,Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
## Scope

The auto PR-review workflow (`claude-code-review.yml`) was burning tokens. It was
configured in the most expensive way possible — this trims it to something
reasonable without removing the capability.

## Implementation

Three changes, all in `.github/workflows/claude-code-review.yml`:

1. **Trigger once per PR, not per push.** Was `[opened, synchronize, reopened,
   ready_for_review]` — `synchronize` meant a full (paid) review ran on **every
   push** to an open PR. Now `[opened, ready_for_review]`: review when a PR opens
   or leaves draft. Re-review on demand by commenting `@claude` (handled by the
   existing `claude.yml`).
2. **Pin the model to `claude-sonnet-4-6`.** No model was pinned, so it defaulted
   to the most capable / most expensive (Opus-class) tier. Sonnet is ~5× cheaper
   per token and more than capable for code review.
3. **`paths-ignore` docs-only PRs** (`**.md`, `docs/**`). Only skips when *every*
   changed file matches, so mixed code+docs PRs still get reviewed.

`claude.yml` (the `@claude`-mention workflow) is intentionally left as-is — it's
already opt-in and only fires when explicitly mentioned.

## Expected impact

For an active PR that gets N pushes, review runs drop from ~N to 1, and each run
is on a ~5×-cheaper model — so the dominant term falls by roughly an order of
magnitude, more for busy PRs.

## How to Test

CI/config only — no app code touched, no tests apply. Verify by:
- Opening a PR → exactly one review runs (on Sonnet).
- Pushing more commits to that PR → **no** new review fires.
- Commenting `@claude …` on a PR → still works (via `claude.yml`).

> Note: this PR touches the workflow file, so the *introducing* review may still
> run under the old rules one last time. All subsequent PRs use the new config
> once this merges.

## Invariants & Risk

No product invariants touched (CI/tooling only). Low risk — purely reduces when
and how expensively the review runs; the review prompt and permissions are
unchanged.
