### PR TITLE
ci: add release-please workflow, tagging from 1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  # Needed so `gh pr checks --watch --required` can query the statusCheckRollup
+  # on the release PR. Without these, GraphQL responds with
+  # "Resource not accessible by integration".
+  checks: read
+  statuses: read
+  actions: read
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run release-please
+        id: release
+        uses: googleapis/release-please-action@v5
+        with:
+          release-type: node
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for release PR checks and merge
+        # Personal repos can't enable GitHub's "Allow auto-merge" setting, so
+        # `gh pr merge --auto` errors with `enablePullRequestAutoMerge`. Poll
+        # the PR's required checks ourselves and squash-merge once they pass.
+        #
+        # Parsing the PR number happens in the shell, NOT in env: — when
+        # release-please runs without opening a PR, steps.release.outputs.pr
+        # is empty and fromJSON('') is a template-validation error that
+        # fails the whole workflow even with if: gating.
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUM=$(echo "$PR_JSON" | jq -r '.number')
+          if [ -z "$PR_NUM" ] || [ "$PR_NUM" = "null" ]; then
+            echo "::error::No PR number in release-please output"
+            exit 1
+          fi
+          echo "Release PR opened: #$PR_NUM"
+          # Give the pull_request event time to register the CI workflow.
+          echo "Waiting 45s for CI to spin up…"
+          sleep 45
+
+          # gh pr checks --watch --required exits non-zero either when a
+          # required check fails OR when no required checks are configured.
+          # We need to tell them apart: "no required checks" is fine on a
+          # personal repo with no branch protection; a real failure is not.
+          set +e
+          CHECKS_OUTPUT=$(gh pr checks "$PR_NUM" --watch --required 2>&1)
+          CHECKS_EXIT=$?
+          set -e
+          echo "$CHECKS_OUTPUT"
+
+          if [ "$CHECKS_EXIT" -ne 0 ]; then
+            if echo "$CHECKS_OUTPUT" | grep -qiE "no required checks reported"; then
+              echo "No required checks configured for this branch — proceeding to merge."
+            else
+              echo "::error::Required checks failed on PR #$PR_NUM — not merging"
+              exit 1
+            fi
+          fi
+
+          echo "Squash-merging…"
+          gh pr merge "$PR_NUM" --squash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benteen-screen",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "Benteen Screen On The Green — movie-night voting. It Really Whips the Movie's Ass.",
   "author": "Patrick Bennett",
   "private": true,


### PR DESCRIPTION
## Scope

Adds an automated **Release** workflow (release-please) so versioning, the
CHANGELOG, GitHub releases, and git tags are all driven by conventional commits
on `main` — and configures it so **the first tag is `v1.0.0`**.

## Implementation

- **`.github/workflows/release.yml`** — release-please in simple `node` mode. On
  every push to `main` it keeps a release PR up to date (version bump +
  `CHANGELOG.md`); the second step polls that PR's required checks and
  squash-merges it (personal repos can't use GitHub's native auto-merge), cutting
  a GitHub release + tag. Treats "no required checks" as OK.
- **`package.json` `2.0.0` → `1.0.0`** — the repo has no prior tags or releases,
  so `2.0.0` was just an unreleased placeholder. Resetting to `1.0.0` makes the
  source of truth match the intended first tag.

## ⚠️ Before this works — two one-time setup steps on your end

1. **Enable Actions to open PRs.** Settings → Actions → General → *Workflow
   permissions* → check **"Allow GitHub Actions to create and approve pull
   requests."** Without it, release-please can't open the release PR.
2. **Pin the first release to exactly `v1.0.0`.** release-please bumps from the
   current version based on commits, so left alone the first cut could land as
   `1.1.0`. To force `1.0.0`, include this footer in the **squash-merge commit
   body when you merge this PR** (release-please reads it from the commit on
   `main`):

   ```
   Release-As: 1.0.0
   ```

   It's one-time and self-expiring — after `v1.0.0` is tagged, normal
   conventional-commit bumping takes over (`feat:` → minor, `fix:` → patch,
   `feat!:`/`BREAKING CHANGE` → major).

## Notes

- **CI won't re-run on the release PR.** PRs opened with the default
  `GITHUB_TOKEN` don't trigger other workflows (`ci.yml`), so the check-poll hits
  the "no required checks" path and merges. That's fine here — every commit was
  already CI'd on its own feature PR before reaching `main`. If you ever want CI
  to *gate* releases, swap `GITHUB_TOKEN` for a PAT in `release.yml`.
- The **first changelog will be large** — it covers all conventional commits in
  history, since there's no prior release to diff against.

## Invariants & Risk

CI/release tooling only — no app code, no product invariants touched. The
workflow has just `contents: write` + `pull-requests: write` (+ read scopes for
the check poll). Low risk.
