### PR TITLE
chore: make ESLint the single formatter; add npm run format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,10 @@ yarn-error.log*
 .DS_Store
 .fleet
 .idea
-.vscode
+# Ignore personal VS Code files but share the project formatter config.
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 *.tgz
 .eslintcache
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  // ESLint is this repo's formatter; Prettier is intentionally not used (it
+  // conflicts with the @stylistic rules). Marked as unwanted so VS Code doesn't
+  // suggest it and re-introduce the conflict.
+  "recommendations": ["dbaeumer.vscode-eslint"],
+  "unwantedRecommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  // This project formats with ESLint (@nuxt/eslint's @stylistic rules:
+  // single quotes, no semicolons, no trailing commas), NOT Prettier. Running
+  // both makes them fight and produces lint-failing files. So: Prettier off,
+  // ESLint applies all auto-fixes (including formatting) on save.
+  "prettier.enable": false,
+  "editor.formatOnSave": false,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.useFlatConfig": true,
+  "eslint.validate": ["javascript", "typescript", "vue"]
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "lint": "eslint .",
+    "format": "eslint . --fix",
     "typecheck": "nuxt typecheck",
     "test": "vitest run",
     "test:watch": "vitest"


### PR DESCRIPTION
## Scope

Makes **ESLint the single source of truth for formatting** so the editor and the
linter stop fighting, and adds a one-command formatter.

Background: the repo uses `@nuxt/eslint`'s `@stylistic` rules (single quotes, no
semicolons, no trailing commas). A separately-configured **Prettier** (double
quotes, semicolons) was reformatting files on save into a lint-failing state —
it had even committed a mangled `useAdminPeople.ts` on another branch.

## Implementation

- **`npm run format`** → `eslint . --fix` — formats all TS/JS/Vue per the linter.
- **`.vscode/settings.json`** — `prettier.enable: false`, `formatOnSave: false`,
  and `source.fixAll.eslint` on save, so ESLint applies its fixes (including
  formatting) and Prettier never runs. `eslint.validate` covers js/ts/vue.
- **`.vscode/extensions.json`** — recommends the ESLint extension, marks the
  Prettier extension as unwanted (so VS Code stops suggesting it).
- **`.gitignore`** — shares those two `.vscode` files while keeping personal
  VS Code settings ignored.

No source files are reformatted in this PR — running `npm run format` once will
normalise the existing ~445 attribute-wrap **warnings** (they don't fail CI), but
that's a large sweep best done after the in-flight PRs land to avoid conflicts.

## How to Test

Tooling/config only — no app code, no tests apply.
- `npm run format` reformats per ESLint (needs Node ≥22 — see below).
- In VS Code, saving a TS/Vue file applies ESLint fixes and Prettier no longer
  touches it.

## Note: local Node

CI runs Node 22 (`.nvmrc`), but `nvm`'s **default alias was 20**, so local shells
used Node 20 — which can't run this ESLint stack (`Object.groupBy` needs 21+).
Set the default to 22 (`nvm alias default 22`); `engines` already requires
`>=22.0.0`.

## Invariants & Risk

Editor/tooling config only — no product invariants touched. Low risk.
