### PR TITLE
fix: repair package-lock.json after @nuxt/ui 4.9.0 bump (unbreak main CI)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1948,6 +1948,28 @@
         }
       }
     },
+    "node_modules/@nuxt/cli/node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@nuxt/cli/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nuxt/devalue": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.2.tgz",
@@ -2490,6 +2512,23 @@
       },
       "engines": {
         "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/crossws": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.6.tgz",
+      "integrity": "sha512-/Wxe9Z007EbJ496j88nToZEvyPZ8PY/wjZJ18Agh/GCA9cYHyLbxtrpdFlFzAw3TV20F0SUYGl0g6PzChbwUrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nuxt/test-utils/node_modules/estree-walker": {
@@ -8825,6 +8864,23 @@
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/devframe/node_modules/crossws": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.6.tgz",
+      "integrity": "sha512-/Wxe9Z007EbJ496j88nToZEvyPZ8PY/wjZJ18Agh/GCA9cYHyLbxtrpdFlFzAw3TV20F0SUYGl0g6PzChbwUrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
           "optional": true
         }
       }


### PR DESCRIPTION
## Scope

`main` CI is red: #71 merged `@nuxt/ui@^4.9.0` into `package.json` but with a lockfile still resolved for 4.8.2's dependency tree, so `npm ci` fails everywhere with `Missing: cac@6.7.14 / commander@13.1.0 / crossws@0.4.6 from lock file`. That blocks CI on every branch. This regenerates the lockfile in sync with `package.json`.

## Validation (Node 22)

- `npm ci` now in sync
- `npm run lint` → 0 errors
- `npm run typecheck` → clean
- `npm test` → 264 passed
- `npm run build` → succeeds

So `@nuxt/ui` 4.9.0 itself is fine — the only problem was the stale lock.

## Risk

Lockfile-only change (regenerated, not hand-edited). Hotfix to unblock `main`.