### PR TITLE
refactor: AdminSuggestion extends Suggestion

### DIFF
--- a/shared/types/suggestion.ts
+++ b/shared/types/suggestion.ts
@@ -15,14 +15,12 @@ export interface Suggestion {
   votes: { user_id: string }[]
 }
 
-/** A suggestion as read for the admin view — adds author + voter display names. */
-export interface AdminSuggestion {
-  id: string
-  event_id: string
-  user_id: string
-  tmdb_movie: TmdbMovie
-  deleted: boolean
-  created_at: string
+/**
+ * A suggestion as read for the admin view — a richer Suggestion that adds the
+ * author and overrides `votes` with each voter's display name. The override is a
+ * narrowing (admin votes are a subtype of base votes), which `extends` permits.
+ */
+export interface AdminSuggestion extends Suggestion {
   author: { display_name: string | null, email: string | null } | null
   votes: { user_id: string, voter: { display_name: string | null } | null }[]
 }


### PR DESCRIPTION
## Scope

`AdminSuggestion` re-declared all six scalar fields of `Suggestion` (`id`, `event_id`, `user_id`, `tmdb_movie`, `deleted`, `created_at`). It's genuinely a *richer* `Suggestion` — the same row read with author + voter joins — so it now `extends Suggestion`.

## Implementation

```ts
export interface AdminSuggestion extends Suggestion {
  author: { display_name: string | null, email: string | null } | null
  votes: { user_id: string, voter: { display_name: string | null } | null }[]
}
```

- Inherits the six scalar fields (one source of truth — a schema change updates only `Suggestion`).
- `author` is a pure addition.
- `votes` is **overridden with a narrower type** — admin votes (`{ user_id, voter }[]`) are a subtype of base votes (`{ user_id }[]`), which `extends` permits. (TypeScript already treated `AdminSuggestion` as assignable to `Suggestion` structurally; this just removes the duplicated source.)

## How to Test

Type-only change. `npm run typecheck` clean (the override compiles and all consumers — `useSuggestions`, `useAdminSuggestions`, `useUserStats`, `computeEventStats`, `topWinners`, `SuggestionCard` — type-check unchanged). `npm run lint` clean. 27 suggestion-consuming tests pass.

## Invariants & Risk

None touched. Vote integrity unchanged — `votes` is still the normalized rows, count is `votes.length`. Type-only refactor, zero runtime change.