### PR TITLE
refactor: extract useMyId for the shared 'my-id' state key

### DIFF
--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -10,7 +10,7 @@ import type { Profile } from '#shared/types/user'
 export function useAuth() {
   const supabase = useSupabaseClient<Database>()
   const user = useSupabaseUser()
-  const myId = useState<string | null>('my-id', () => null)
+  const myId = useMyId()
   const profile = useState<Profile | null>('profile', () => null)
   // Cached allowlist verdict (set by middleware/invited.global.ts); cleared on
   // sign-out so the next user is re-checked within the same SPA session.

--- a/app/composables/useBringList.ts
+++ b/app/composables/useBringList.ts
@@ -7,7 +7,7 @@ const SELECT = 'id, event_id, label, note, user_id, created_by, bringer:profiles
 /** Potluck "bring list" for an event: items + add/claim/unclaim/remove (realtime). */
 export function useBringList(eventId: MaybeRefOrGetter<string | null | undefined>) {
   const supabase = useSupabaseClient<Database>()
-  const myId = useState<string | null>('my-id', () => null)
+  const myId = useMyId()
 
   const { data: items, error, refresh } = useRealtimeQuery<BringItem[]>({
     key: eventId,

--- a/app/composables/useMyId.ts
+++ b/app/composables/useMyId.ts
@@ -1,0 +1,11 @@
+import type { Ref } from 'vue'
+
+/**
+ * The signed-in user's id as app-wide shared state. `auth-profile.client.ts` is
+ * the writer (it resolves the authoritative id via `getUser()`); everything else
+ * reads it. Centralizing the `'my-id'` key here means a typo can't silently fork
+ * the state into a separate, always-null ref.
+ */
+export function useMyId(): Ref<string | null> {
+  return useState<string | null>('my-id', () => null)
+}

--- a/app/composables/useRsvp.ts
+++ b/app/composables/useRsvp.ts
@@ -5,7 +5,7 @@ import type { RsvpStatus } from '#shared/types/rsvp'
 /** RSVP state for an event: my status, live counts, and set/toggle. */
 export function useRsvp(eventId: MaybeRefOrGetter<string | null | undefined>) {
   const supabase = useSupabaseClient<Database>()
-  const myId = useState<string | null>('my-id', () => null)
+  const myId = useMyId()
 
   const { data: rsvps, error, refresh } = useRealtimeQuery<{ user_id: string, status: string }[]>({
     key: eventId,

--- a/app/composables/useSuggestions.ts
+++ b/app/composables/useSuggestions.ts
@@ -10,7 +10,7 @@ import type { TmdbMovie } from '#shared/types/movie'
  */
 export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefined>) {
   const supabase = useSupabaseClient<Database>()
-  const myId = useState<string | null>('my-id', () => null)
+  const myId = useMyId()
 
   const { data: suggestions, error, refresh } = useRealtimeQuery<Suggestion[]>({
     key: eventId,

--- a/app/plugins/auth-profile.client.ts
+++ b/app/plugins/auth-profile.client.ts
@@ -10,7 +10,7 @@ import type { Profile } from '#shared/types/user'
 export default defineNuxtPlugin(() => {
   const supabase = useSupabaseClient<Database>()
   const user = useSupabaseUser()
-  const myId = useState<string | null>('my-id', () => null)
+  const myId = useMyId()
   const profile = useState<Profile | null>('profile', () => null)
 
   watch(user, async () => {

--- a/test/useMyId.nuxt.test.ts
+++ b/test/useMyId.nuxt.test.ts
@@ -1,0 +1,11 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+
+describe('useMyId', () => {
+  it('exposes the shared my-id state — the same ref for every caller', () => {
+    const id = useMyId()
+    id.value = 'user-123'
+    // A second call resolves to the same keyed state, not a fresh null ref.
+    expect(useMyId().value).toBe('user-123')
+  })
+})


### PR DESCRIPTION
## Scope

The `'my-id'` `useState` key was hand-written in **5 places** (`useAuth`, `useRsvp`, `useSuggestions`, `useBringList`, and the `auth-profile` plugin that writes it). A typo in the key in any one of them would silently create a *separate*, always-null ref. This centralizes it.

## Implementation

```ts
export function useMyId(): Ref<string | null> {
  return useState<string | null>('my-id', () => null)
}
```

All 5 sites now call `useMyId()`. The plugin remains the writer; everyone else reads. One key, one source.

## How to Test

`test/useMyId.nuxt.test.ts` asserts two calls resolve to the same shared ref. All myId-consuming composable tests (`useAuth`/`useRsvp`/`useSuggestions`/`useBringList`) pass unchanged. `npm test` → 272 passed; lint 0 errors; typecheck clean.

## Invariants & Risk

None touched — pure dedup of a state key. Behavior identical.