### PR TITLE
refactor: extract EventPicker for the admin event selector

### DIFF
--- a/app/components/EventPicker.vue
+++ b/app/components/EventPicker.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+/** The admin event selector: a USelectMenu bound to an event id, used to scope
+ *  each admin tab to one event. */
+const model = defineModel<string>()
+defineProps<{ items: { label: string, value: string }[] }>()
+</script>
+
+<template>
+  <USelectMenu
+    v-model="model"
+    :items="items"
+    value-key="value"
+    :search-input="false"
+    placeholder="Select an event"
+    class="w-full sm:max-w-sm mb-4"
+  />
+</template>

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -384,14 +384,7 @@ function onSelectEvent(event: MovieEvent): void {
 
       <!-- SUGGESTIONS -->
       <template #suggestions>
-        <USelectMenu
-          v-model="selectedEventId"
-          :items="eventOptions"
-          value-key="value"
-          :search-input="false"
-          placeholder="Select an event"
-          class="w-full sm:max-w-sm mb-4"
-        />
+        <EventPicker v-model="selectedEventId" :items="eventOptions" />
 
         <!-- End / reopen voting -->
         <div v-if="selectedEvent" class="mb-4 space-y-3">
@@ -485,14 +478,7 @@ function onSelectEvent(event: MovieEvent): void {
         <p class="text-sm text-muted mb-4">
           Add what the group needs for this event — people claim items on the event page.
         </p>
-        <USelectMenu
-          v-model="selectedEventId"
-          :items="eventOptions"
-          value-key="value"
-          :search-input="false"
-          placeholder="Select an event"
-          class="w-full sm:max-w-sm mb-4"
-        />
+        <EventPicker v-model="selectedEventId" :items="eventOptions" />
 
         <div v-if="selectedEventId" class="max-w-xl">
           <BringList
@@ -514,14 +500,7 @@ function onSelectEvent(event: MovieEvent): void {
           Curate the guest list for an event and send Evite-style invitations with
           one-click RSVP. A new event's list auto-fills from the last movie night.
         </p>
-        <USelectMenu
-          v-model="selectedEventId"
-          :items="eventOptions"
-          value-key="value"
-          :search-input="false"
-          placeholder="Select an event"
-          class="w-full sm:max-w-sm mb-4"
-        />
+        <EventPicker v-model="selectedEventId" :items="eventOptions" />
         <EventInviteManager v-if="selectedEventId" :key="selectedEventId" :event-id="selectedEventId" :event="selectedEvent" />
         <UCard v-else variant="subtle" class="text-center text-muted">
           Select an event to manage its guest list.
@@ -532,14 +511,7 @@ function onSelectEvent(event: MovieEvent): void {
         <p class="text-sm text-muted mb-4">
           Email an announcement or reminder about an event. Recipients are BCC'd.
         </p>
-        <USelectMenu
-          v-model="selectedEventId"
-          :items="eventOptions"
-          value-key="value"
-          :search-input="false"
-          placeholder="Select an event"
-          class="w-full sm:max-w-sm mb-4"
-        />
+        <EventPicker v-model="selectedEventId" :items="eventOptions" />
         <EventAnnounceComposer v-if="selectedEventId" :event-id="selectedEventId" class="max-w-xl" />
         <UCard v-else variant="subtle" class="text-center text-muted">
           Select an event to send a blast.


### PR DESCRIPTION
## Scope

The admin event selector — an identical `USelectMenu` bound to `selectedEventId`/`eventOptions` — was repeated **verbatim 4×** across the admin tabs. Extracted into `<EventPicker v-model :items />`.

## Implementation

`app/components/EventPicker.vue` wraps the `USelectMenu` with the fixed attrs (`value-key`, no search, placeholder, `w-full sm:max-w-sm mb-4`) and exposes `v-model` + `items`. The 4 admin blocks collapse to one line each. overview's selector is index-based with different styling — left as-is.

## How to Test

Type-only/markup refactor. `npm run typecheck` clean, lint 0 errors, admin composable tests pass. Manually: each admin tab's event dropdown selects/scopes as before.

## Invariants & Risk

None touched. Behavior-preserving.