### PR TITLE
feat: restore per-event participation caps (5 suggestions, 3 votes) + cap UI

### DIFF
--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Suggestion } from '#shared/types/suggestion'
 
-const props = defineProps<{ suggestion: Suggestion, rank: number, maxVotes: number, locked?: boolean }>()
+const props = defineProps<{ suggestion: Suggestion, rank: number, maxVotes: number, locked?: boolean, voteCapReached?: boolean }>()
 const emit = defineEmits<{ vote: [], unvote: [], remove: [], trailer: [] }>()
 
 const { myId } = useAuth()
@@ -12,6 +12,8 @@ const voteCount = computed(() => props.suggestion.votes?.length ?? 0)
 const hasVoted = computed(() =>
   Boolean(myId.value) && (props.suggestion.votes ?? []).some(v => v.user_id === myId.value)
 )
+// At the vote cap you can't add a new vote, but you can still remove one to switch.
+const voteDisabled = computed(() => Boolean(props.voteCapReached) && !hasVoted.value)
 const isOwner = computed(() =>
   Boolean(myId.value) && props.suggestion.user_id === myId.value
 )
@@ -66,6 +68,8 @@ const highlight = computed(() => props.rank === 1 && voteCount.value > 0)
             :label="String(voteCount)"
             size="sm"
             class="shrink-0"
+            :disabled="voteDisabled"
+            :title="voteDisabled ? 'Vote limit reached — remove a vote to switch your pick' : undefined"
             :aria-label="hasVoted ? 'Remove vote' : 'Vote'"
             @click="hasVoted ? emit('unvote') : emit('vote')"
           />

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -10,7 +10,7 @@ const { run } = useToastAction()
 const { posterUrl } = useTmdb()
 const { events } = useEvents()
 // Admins can flip between events; everyone else just sees the active one.
-const { isAdmin } = useAuth()
+const { isAdmin, myId } = useAuth()
 
 const eventIndex = ref(0)
 const initialized = ref(false)
@@ -38,6 +38,12 @@ const cardBackdrop = computed(() => currentEvent.value?.poster_url || leadPoster
 // Voting ended → show the double-feature winners and hide vote/suggest controls.
 const votingLocked = computed(() => Boolean(currentEvent.value?.voting_locked_at))
 const winners = computed(() => topWinners(suggestions.value))
+
+// Per-event participation caps (mirrors the DB triggers — see shared/utils/limits).
+const mySuggestionCount = computed(() => countMySuggestions(suggestions.value, myId.value))
+const myVoteCount = computed(() => countMyVotes(suggestions.value, myId.value))
+const atSuggestionCap = computed(() => mySuggestionCount.value >= SUGGESTION_LIMIT)
+const atVoteCap = computed(() => myVoteCount.value >= VOTE_LIMIT)
 
 const eventOptions = computed(() =>
   events.value.map((event, index) => ({
@@ -76,11 +82,19 @@ async function onSuggest(movie: TmdbMovie): Promise<void> {
     toast.add({ title: 'Already suggested', description: `${movie.title} is already on the list.`, color: 'warning' })
     return
   }
+  if (atSuggestionCap.value) {
+    toast.add({ title: `You've used all ${SUGGESTION_LIMIT} suggestions`, description: 'Remove one from the list to free up a slot.', color: 'warning' })
+    return
+  }
   if (await run(() => suggest(movie), 'Could not add suggestion')) {
     toast.add({ title: 'Suggestion added', icon: 'i-lucide-check', color: 'success' })
   }
 }
 async function onVote(suggestion: Suggestion): Promise<void> {
+  if (atVoteCap.value) {
+    toast.add({ title: `You've used all ${VOTE_LIMIT} votes`, description: 'Remove a vote to switch your pick.', color: 'warning' })
+    return
+  }
   await run(() => vote(suggestion), 'Vote failed')
 }
 async function onUnvote(suggestion: Suggestion): Promise<void> {
@@ -178,32 +192,45 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
 
           <!-- Suggest + finder (hidden once voting is locked) -->
           <template v-if="!votingLocked">
-            <!-- Suggest (desktop inline) -->
-            <div class="hidden lg:block">
-              <h2 class="text-sm font-semibold text-muted mb-2">
-                Suggest a movie
-              </h2>
-              <SuggestSection :suggested-movie-ids="suggestedMovieIds" @suggest="onSuggest" />
-            </div>
+            <p class="text-xs text-muted text-center">
+              {{ mySuggestionCount }} of {{ SUGGESTION_LIMIT }} suggestions used
+            </p>
+            <template v-if="!atSuggestionCap">
+              <!-- Suggest (desktop inline) -->
+              <div class="hidden lg:block">
+                <h2 class="text-sm font-semibold text-muted mb-2">
+                  Suggest a movie
+                </h2>
+                <SuggestSection :suggested-movie-ids="suggestedMovieIds" @suggest="onSuggest" />
+              </div>
 
-            <!-- Suggest (mobile) -->
-            <UButton
-              class="lg:hidden justify-center"
-              block
-              label="Suggest a movie"
-              icon="i-lucide-plus"
-              @click="suggestOpen = true"
-            />
+              <!-- Suggest (mobile) -->
+              <UButton
+                class="lg:hidden justify-center"
+                block
+                label="Suggest a movie"
+                icon="i-lucide-plus"
+                @click="suggestOpen = true"
+              />
 
-            <!-- Movie finder (all sizes) -->
-            <UButton
-              class="justify-center"
-              block
+              <!-- Movie finder (all sizes) -->
+              <UButton
+                class="justify-center"
+                block
+                color="neutral"
+                variant="outline"
+                label="Help me find a movie"
+                icon="i-lucide-clapperboard"
+                @click="finderOpen = true"
+              />
+            </template>
+            <UAlert
+              v-else
+              icon="i-lucide-circle-check"
               color="neutral"
-              variant="outline"
-              label="Help me find a movie"
-              icon="i-lucide-clapperboard"
-              @click="finderOpen = true"
+              variant="subtle"
+              :title="`You've used all ${SUGGESTION_LIMIT} suggestions`"
+              description="Remove one from the list to free up a slot."
             />
           </template>
           <p v-else class="text-sm text-muted text-center inline-flex items-center justify-center gap-1.5">
@@ -219,7 +246,12 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
             <h2 class="text-xl font-semibold">
               {{ votingLocked ? 'Final results' : 'Rankings' }}
             </h2>
-            <UBadge :label="`${suggestions.length}`" color="neutral" variant="subtle" />
+            <UBadge
+              v-if="!votingLocked"
+              :label="`${myVoteCount}/${VOTE_LIMIT} votes used`"
+              :color="atVoteCap ? 'warning' : 'neutral'"
+              variant="subtle"
+            />
           </div>
 
           <div v-if="suggestions.length" class="space-y-3">
@@ -230,6 +262,7 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
               :rank="index + 1"
               :max-votes="maxVotes"
               :locked="votingLocked"
+              :vote-cap-reached="atVoteCap"
               @vote="onVote(suggestion)"
               @unvote="onUnvote(suggestion)"
               @remove="onRemove(suggestion)"

--- a/shared/utils/limits.ts
+++ b/shared/utils/limits.ts
@@ -1,0 +1,21 @@
+import type { Suggestion } from '#shared/types/suggestion'
+
+/**
+ * Per-event participation caps, mirrored from the server-side triggers in
+ * supabase/migrations (Product Invariant 3 — keep these two in sync). The DB is
+ * the real enforcer; these drive the UI (disable controls + warn at the cap).
+ */
+export const SUGGESTION_LIMIT = 5
+export const VOTE_LIMIT = 3
+
+/** How many of this event's (non-deleted) suggestions are mine. */
+export function countMySuggestions(suggestions: ReadonlyArray<Suggestion>, myId: string | null): number {
+  if (!myId) return 0
+  return suggestions.filter(s => s.user_id === myId && !s.deleted).length
+}
+
+/** How many of this event's suggestions I've voted for (= my votes this event). */
+export function countMyVotes(suggestions: ReadonlyArray<Suggestion>, myId: string | null): number {
+  if (!myId) return 0
+  return suggestions.filter(s => (s.votes ?? []).some(v => v.user_id === myId)).length
+}

--- a/supabase/migrations/20260623000000_restore_participation_limits.sql
+++ b/supabase/migrations/20260623000000_restore_participation_limits.sql
@@ -46,7 +46,7 @@ begin
   if auth.uid() is not null and (
     select count(*) from public.votes v
     join public.suggestions s on s.id = v.suggestion_id
-    where v.user_id = auth.uid() and s.event_id = ev
+    where v.user_id = auth.uid() and s.event_id = ev and s.deleted = false
   ) >= public.vote_limit() then
     raise exception 'Vote limit (%) reached for this event', public.vote_limit()
       using errcode = 'check_violation';

--- a/supabase/migrations/20260623000000_restore_participation_limits.sql
+++ b/supabase/migrations/20260623000000_restore_participation_limits.sql
@@ -1,0 +1,60 @@
+-- ============================================================================
+-- Restore the per-event participation limits: 5 suggestions and 3 votes per user
+-- per event, enforced server-side (Product Invariant 3 — RLS/triggers are the
+-- real boundary; the UI in shared/utils/limits.ts only mirrors these numbers).
+--
+-- They were dropped in 20260616010000_user_id_and_drop_limits.sql because the
+-- imported Firestore history had users far over the cap. The triggers fire only
+-- on INSERT, so they enforce going forward without touching existing rows (a
+-- user already over the cap simply can't add more). Service-role / SQL inserts
+-- (auth.uid() is null) stay exempt so imports and admin scripts aren't blocked.
+--
+-- Counting is by auth.uid() rather than NEW.user_id so this is independent of the
+-- set_user_id trigger firing order (NEW.user_id is stamped by another BEFORE
+-- INSERT trigger; auth.uid() is the authoritative actor either way).
+-- ============================================================================
+
+create or replace function public.suggestion_limit() returns int language sql immutable as $$ select 5 $$;
+create or replace function public.vote_limit() returns int language sql immutable as $$ select 3 $$;
+
+-- Per-event suggestion cap.
+create or replace function public.enforce_suggestion_limit() returns trigger
+  language plpgsql security definer set search_path = public as $$
+begin
+  if auth.uid() is not null and (
+    select count(*) from public.suggestions
+    where event_id = new.event_id and user_id = auth.uid() and deleted = false
+  ) >= public.suggestion_limit() then
+    raise exception 'Suggestion limit (%) reached for this event', public.suggestion_limit()
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+drop trigger if exists enforce_suggestion_limit_trigger on public.suggestions;
+create trigger enforce_suggestion_limit_trigger
+  before insert on public.suggestions
+  for each row execute function public.enforce_suggestion_limit();
+
+-- Per-event vote cap. Votes carry no event_id, so resolve it through the suggestion.
+create or replace function public.enforce_vote_limit() returns trigger
+  language plpgsql security definer set search_path = public as $$
+declare
+  ev uuid;
+begin
+  select event_id into ev from public.suggestions where id = new.suggestion_id;
+  if auth.uid() is not null and (
+    select count(*) from public.votes v
+    join public.suggestions s on s.id = v.suggestion_id
+    where v.user_id = auth.uid() and s.event_id = ev
+  ) >= public.vote_limit() then
+    raise exception 'Vote limit (%) reached for this event', public.vote_limit()
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+drop trigger if exists enforce_vote_limit_trigger on public.votes;
+create trigger enforce_vote_limit_trigger
+  before insert on public.votes
+  for each row execute function public.enforce_vote_limit();

--- a/test/SuggestionCard.nuxt.test.ts
+++ b/test/SuggestionCard.nuxt.test.ts
@@ -55,4 +55,15 @@ describe('SuggestionCard', () => {
     const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2 } })
     expect(w.find('[aria-label="Remove suggestion"]').exists()).toBe(true)
   })
+
+  it('disables the vote button at the vote cap when I have not voted', async () => {
+    const notMine = { ...suggestion, votes: [{ user_id: 'bob' }] }
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion: notMine, rank: 1, maxVotes: 2, voteCapReached: true } })
+    expect(w.get('[aria-label="Vote"]').attributes('disabled')).toBeDefined()
+  })
+
+  it('still lets me remove a vote at the cap (to switch my pick)', async () => {
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2, voteCapReached: true } })
+    expect(w.get('[aria-label="Remove vote"]').attributes('disabled')).toBeUndefined()
+  })
 })

--- a/test/limits.test.ts
+++ b/test/limits.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { SUGGESTION_LIMIT, VOTE_LIMIT, countMySuggestions, countMyVotes } from '../shared/utils/limits'
+import type { Suggestion } from '../shared/types/suggestion'
+
+function mk(partial: Partial<Suggestion>): Suggestion {
+  return {
+    id: Math.random().toString(36).slice(2),
+    event_id: 'e1',
+    user_id: 'bob',
+    tmdb_movie: { id: 1, title: 'X' },
+    deleted: false,
+    created_at: '2026-01-01T00:00:00Z',
+    votes: [],
+    ...partial
+  }
+}
+
+describe('participation limits', () => {
+  it('mirror the DB caps: 5 suggestions, 3 votes', () => {
+    expect(SUGGESTION_LIMIT).toBe(5)
+    expect(VOTE_LIMIT).toBe(3)
+  })
+
+  it('countMySuggestions counts my non-deleted suggestions only', () => {
+    const list = [mk({ user_id: 'me' }), mk({ user_id: 'me', deleted: true }), mk({ user_id: 'bob' })]
+    expect(countMySuggestions(list, 'me')).toBe(1)
+    expect(countMySuggestions(list, 'bob')).toBe(1)
+    expect(countMySuggestions(list, null)).toBe(0)
+  })
+
+  it('countMyVotes counts the suggestions I voted for', () => {
+    const list = [
+      mk({ votes: [{ user_id: 'me' }] }),
+      mk({ votes: [{ user_id: 'bob' }] }),
+      mk({ votes: [{ user_id: 'me' }, { user_id: 'x' }] })
+    ]
+    expect(countMyVotes(list, 'me')).toBe(2)
+    expect(countMyVotes(list, null)).toBe(0)
+  })
+})

--- a/test/overview.nuxt.test.ts
+++ b/test/overview.nuxt.test.ts
@@ -16,15 +16,17 @@ const event = {
   created_at: ''
 }
 
-// Shared admin flag — flipped per test before mounting (mockNuxtImport allows
+// Shared state — flipped per test before mounting (mockNuxtImport allows
 // referencing module-scope values, same pattern as useAdminPeople.nuxt.test.ts).
 const isAdmin = ref(false)
+const myId = ref<string | null>(null)
+const suggestionList = ref<Array<Record<string, unknown>>>([])
 
-mockNuxtImport('useAuth', () => () => ({ isAdmin }))
+mockNuxtImport('useAuth', () => () => ({ isAdmin, myId }))
 mockNuxtImport('useEvents', () => () => ({ events: ref([event]) }))
 mockNuxtImport('useTmdb', () => () => ({ posterUrl: () => null }))
 mockNuxtImport('useSuggestions', () => () => ({
-  suggestions: ref([]),
+  suggestions: suggestionList,
   alreadySuggested: () => false,
   suggest: async () => {},
   vote: async () => {},
@@ -51,7 +53,13 @@ const stubs = {
 
 beforeEach(() => {
   isAdmin.value = false
+  myId.value = null
+  suggestionList.value = []
 })
+
+function mineSuggestion(i: number): Record<string, unknown> {
+  return { id: `s${i}`, event_id: 'e1', user_id: 'me', tmdb_movie: { id: i, title: `M${i}` }, deleted: false, created_at: '2026-01-01', votes: [] }
+}
 
 describe('overview page', () => {
   it('renders the active event in the poster header', async () => {
@@ -75,5 +83,13 @@ describe('overview page', () => {
     const w = await mountSuspended(OverviewPage, { global: { stubs } })
     expect(w.text().toLowerCase()).not.toContain('pizza dough')
     expect(w.text()).toContain('See the bring list')
+  })
+
+  it('shows the suggestion-cap notice once I have 5 suggestions', async () => {
+    myId.value = 'me'
+    suggestionList.value = [1, 2, 3, 4, 5].map(mineSuggestion)
+    const w = await mountSuspended(OverviewPage, { global: { stubs } })
+    expect(w.text()).toContain('5 of 5 suggestions used')
+    expect(w.text()).toContain('used all 5 suggestions')
   })
 })

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -130,4 +130,31 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('invites').delete().eq('email', `rls_byadmin_${stamp}@example.com`)
     await admin!.from('app_settings').update({ max_invites: null }).eq('id', true)
   })
+
+  it('caps suggestions at 5 per user per event (server-side trigger)', async () => {
+    for (let i = 0; i < 5; i++) {
+      const { error } = await memberClient.from('suggestions').insert({ event_id: eventId, tmdb_movie: { id: i, title: `S${i}` } })
+      expect(error, `suggestion ${i} should be allowed`).toBeNull()
+    }
+    const sixth = await memberClient.from('suggestions').insert({ event_id: eventId, tmdb_movie: { id: 99, title: 'over' } })
+    expect(sixth.error, 'the 6th suggestion should be rejected by the cap').toBeTruthy()
+    await admin!.from('suggestions').delete().eq('event_id', eventId)
+  })
+
+  it('caps votes at 3 per user per event (server-side trigger)', async () => {
+    // Seed 4 suggestions via the service role (exempt from the suggestion cap) to vote on.
+    const { data: seeded } = await admin!
+      .from('suggestions')
+      .insert([0, 1, 2, 3].map(i => ({ event_id: eventId, user_id: memberId, tmdb_movie: { id: 100 + i, title: `V${i}` } })))
+      .select('id')
+    const ids = (seeded ?? []).map(s => s.id)
+    for (let i = 0; i < 3; i++) {
+      const { error } = await memberClient.from('votes').insert({ suggestion_id: ids[i] })
+      expect(error, `vote ${i} should be allowed`).toBeNull()
+    }
+    const fourth = await memberClient.from('votes').insert({ suggestion_id: ids[3] })
+    expect(fourth.error, 'the 4th vote should be rejected by the cap').toBeTruthy()
+    await admin!.from('votes').delete().eq('user_id', memberId)
+    await admin!.from('suggestions').delete().eq('event_id', eventId)
+  })
 })


### PR DESCRIPTION
## Scope

Ryan exceeded the suggestion/vote caps because **there are none right now**. They
were deliberately dropped in `20260616010000_user_id_and_drop_limits.sql` (the
imported Firestore history had users far over the cap) and the UI mirror
(`limits.ts`) was deleted — so CLAUDE.md Invariant 3 was stale. This restores
them at **5 suggestions / 3 votes per user per event**, enforced server-side,
with a UI notification.

## Implementation

**Server-side (the real boundary — Invariant 1/3):** new migration restores
`suggestion_limit() = 5`, `vote_limit() = 3`, and the `enforce_*_limit` triggers.
Two deliberate choices vs. the original:
- Count by **`auth.uid()`** instead of `NEW.user_id`, so it's independent of the
  `set_user_id` trigger's firing order (which now stamps `user_id` from a separate
  BEFORE-INSERT trigger).
- Service-role / seed inserts (`auth.uid()` null) stay exempt, so imports/admin
  scripts aren't blocked.

Triggers fire on **INSERT only**, so they enforce **going forward** — existing
over-cap rows are untouched (a user already over the cap simply can't add more).

**UI (mirror + notification):**
- `shared/utils/limits.ts` — the cap constants + `countMySuggestions`/`countMyVotes`.
- `overview` — shows `N of 5 suggestions used` and `N/3 votes used`, replaces the
  suggest controls with a cap notice at 5, and on each `SuggestionCard` disables
  the Vote button at 3 (you can still **unvote** to switch). Trying to exceed
  either also toasts a warning.

## ⚠️ Two things to know

1. **This deploys a DB migration to prod** (via the db-migrate workflow on merge).
2. **Ryan's existing excess is not auto-removed** — the triggers only stop *new*
   inserts. If you want his over-cap suggestions/votes trimmed to the cap, say so
   and I'll write a one-off cleanup (I won't delete data unprompted).

## How to Test

- `test/limits.test.ts` — cap constants + counting helpers.
- `test/SuggestionCard.nuxt.test.ts` — vote button disabled at the cap (but unvote still allowed).
- `test/overview.nuxt.test.ts` — the "5 of 5 / used all 5 suggestions" notice appears at the cap.
- `test/rls.integration.test.ts` — **the 6th suggestion and 4th vote are rejected by the triggers** (runs in CI against Supabase-local).
- `npm test` → 280 passed; lint 0 errors; typecheck clean.

Manual: as a member, add 5 suggestions (6th blocked + toast); cast 3 votes (4th blocked, button disabled); unvote one to free a slot.

## Invariants & Risk

Directly restores **Invariant 3** (per-event caps enforced by triggers + mirrored
in the UI). RLS unchanged; vote integrity unchanged (still normalized rows). The
caps are server-enforced — the UI is only a convenience. Medium risk (a prod
migration touching inserts) but the proven original pattern + integration tests
cover it.
