### PR TITLE
feat: per-event poster display controls (ratio, focal point, zoom)

### DIFF
--- a/app/components/EventFormModal.vue
+++ b/app/components/EventFormModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { MovieEvent } from '#shared/types/event'
+import type { PosterDisplay } from '#shared/utils/posterDisplay'
 
 interface SavePayload {
   id?: string
@@ -10,6 +11,7 @@ interface SavePayload {
   location: string | null
   locationUrl: string | null
   posterUrl: string | null
+  posterDisplay: PosterDisplay
 }
 
 const open = defineModel<boolean>('open', { default: false })
@@ -26,6 +28,7 @@ const startTime = ref('')
 const location = ref('')
 const locationUrl = ref('')
 const posterUrl = ref<string | null>(null)
+const posterDisplay = ref<PosterDisplay>({ ...DEFAULT_POSTER_DISPLAY })
 const uploading = ref(false)
 const fileInput = ref<HTMLInputElement | null>(null)
 
@@ -44,6 +47,7 @@ watch(open, (isOpen) => {
     location.value = props.event.location ?? ''
     locationUrl.value = props.event.location_url ?? ''
     posterUrl.value = props.event.poster_url ?? null
+    posterDisplay.value = normalizePosterDisplay(props.event.poster_display)
   } else {
     title.value = ''
     description.value = ''
@@ -52,6 +56,7 @@ watch(open, (isOpen) => {
     location.value = ''
     locationUrl.value = ''
     posterUrl.value = null
+    posterDisplay.value = { ...DEFAULT_POSTER_DISPLAY }
   }
 })
 
@@ -83,7 +88,8 @@ function submit(): void {
     startTime: startTime.value.trim() || null,
     location: location.value.trim() || null,
     locationUrl: locationUrl.value.trim() || null,
-    posterUrl: posterUrl.value
+    posterUrl: posterUrl.value,
+    posterDisplay: posterDisplay.value
   })
   open.value = false
 }
@@ -142,6 +148,7 @@ function submit(): void {
             </div>
             <input ref="fileInput" type="file" accept="image/*" class="hidden" @change="onFileChange">
           </div>
+          <PosterAdjuster v-if="posterUrl" v-model="posterDisplay" :poster-url="posterUrl" class="mt-3" />
         </UFormField>
 
         <UFormField label="Description">

--- a/app/components/EventHero.vue
+++ b/app/components/EventHero.vue
@@ -8,21 +8,27 @@ const props = defineProps<{ event: MovieEvent, backdrop: string | null }>()
 defineEmits<{ open: [] }>()
 
 const upcoming = computed(() => isUpcoming(props.event.event_date))
+// How this event's poster fills the header (ratio / focal point / zoom).
+const display = computed(() => normalizePosterDisplay(props.event.poster_display))
 </script>
 
 <template>
   <button
     type="button"
-    class="group relative block w-full cursor-pointer overflow-hidden rounded-xl text-left ring ring-default min-h-44 sm:min-h-56 transition hover:ring-primary/40"
+    class="group relative block w-full cursor-pointer overflow-hidden rounded-xl text-left ring ring-default bg-black transition hover:ring-primary/40"
+    :class="posterRatioClass(display.ratio)"
     :aria-label="`${event.title} — view event details`"
     @click="$emit('open')"
   >
-    <!-- Poster background (falls back to a neutral surface when none is set) -->
+    <!-- Poster (object-cover with the event's focal point + zoom; falls back to a
+         neutral surface when none is set). Hover-scale lives on the wrapper so it
+         composes with the per-event zoom on the image. -->
     <div
       v-if="backdrop"
-      class="absolute inset-0 bg-cover bg-center transition-transform duration-500 group-hover:scale-105"
-      :style="{ backgroundImage: `url(${backdrop})` }"
-    />
+      class="absolute inset-0 transition-transform duration-500 group-hover:scale-105"
+    >
+      <img :src="backdrop" alt="" class="size-full object-cover" :style="posterFillStyle(display)">
+    </div>
     <div v-else class="absolute inset-0 bg-elevated" />
 
     <!-- Legibility gradient so the title is readable over any poster -->

--- a/app/components/PosterAdjuster.vue
+++ b/app/components/PosterAdjuster.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { POSTER_RATIO_LABELS } from '#shared/utils/posterDisplay'
+import type { PosterDisplay, PosterRatio } from '#shared/utils/posterDisplay'
+
+defineProps<{ posterUrl: string }>()
+const model = defineModel<PosterDisplay>({ required: true })
+
+const previewRef = ref<HTMLElement | null>(null)
+const dragging = ref(false)
+let startX = 0
+let startY = 0
+let startPosX = 50
+let startPosY = 50
+
+function clampPct(n: number): number {
+  return Math.min(100, Math.max(0, Math.round(n)))
+}
+
+function onPointerDown(e: PointerEvent): void {
+  dragging.value = true
+  startX = e.clientX
+  startY = e.clientY
+  startPosX = model.value.posX
+  startPosY = model.value.posY
+  ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+}
+
+function onPointerMove(e: PointerEvent): void {
+  if (!dragging.value || !previewRef.value) return
+  const rect = previewRef.value.getBoundingClientRect()
+  // Drag the image like a map: moving it right reveals the left side, so the
+  // focal point moves the opposite way.
+  const dx = ((e.clientX - startX) / rect.width) * 100
+  const dy = ((e.clientY - startY) / rect.height) * 100
+  model.value = { ...model.value, posX: clampPct(startPosX - dx), posY: clampPct(startPosY - dy) }
+}
+
+function onPointerUp(e: PointerEvent): void {
+  dragging.value = false
+  ;(e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId)
+}
+
+function setRatio(ratio: PosterRatio): void {
+  model.value = { ...model.value, ratio }
+}
+
+function onZoomInput(e: Event): void {
+  model.value = { ...model.value, zoom: Number((e.target as HTMLInputElement).value) }
+}
+
+function reset(): void {
+  model.value = { ...DEFAULT_POSTER_DISPLAY }
+}
+</script>
+
+<template>
+  <div class="space-y-3">
+    <!-- Ratio presets -->
+    <div class="flex flex-wrap gap-1.5">
+      <UButton
+        v-for="r in POSTER_RATIOS"
+        :key="r"
+        :label="POSTER_RATIO_LABELS[r]"
+        size="xs"
+        :color="model.ratio === r ? 'primary' : 'neutral'"
+        :variant="model.ratio === r ? 'solid' : 'outline'"
+        @click="setRatio(r)"
+      />
+    </div>
+
+    <!-- Live preview (drag to reposition) — same render path as the real header -->
+    <div
+      ref="previewRef"
+      class="relative w-full overflow-hidden rounded-lg bg-black ring ring-default cursor-move touch-none select-none"
+      :class="posterRatioClass(model.ratio)"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerUp"
+    >
+      <img :src="posterUrl" alt="" class="size-full object-cover pointer-events-none" :style="posterFillStyle(model)">
+      <div class="absolute inset-0 ring-1 ring-inset ring-white/15 pointer-events-none" />
+      <span class="absolute bottom-1 left-1/2 -translate-x-1/2 rounded bg-black/50 px-1.5 py-0.5 text-[10px] text-white/80 pointer-events-none">
+        Drag to reposition
+      </span>
+    </div>
+
+    <!-- Zoom -->
+    <div class="flex items-center gap-3">
+      <UIcon name="i-lucide-zoom-in" class="size-4 text-muted shrink-0" />
+      <input
+        type="range"
+        :min="ZOOM_MIN"
+        :max="ZOOM_MAX"
+        step="0.05"
+        :value="model.zoom"
+        aria-label="Poster zoom"
+        class="w-full accent-primary"
+        @input="onZoomInput"
+      >
+      <span class="text-xs text-muted tabular-nums w-10 text-right shrink-0">{{ Math.round(model.zoom * 100) }}%</span>
+    </div>
+
+    <UButton label="Reset" icon="i-lucide-rotate-ccw" size="xs" color="neutral" variant="ghost" @click="reset" />
+  </div>
+</template>

--- a/app/composables/useEventAdmin.ts
+++ b/app/composables/useEventAdmin.ts
@@ -1,4 +1,5 @@
 import type { Database } from '~/types/database.types'
+import type { PosterDisplay } from '#shared/utils/posterDisplay'
 
 export interface EventInput {
   title: string
@@ -8,6 +9,7 @@ export interface EventInput {
   location?: string | null
   locationUrl?: string | null
   posterUrl?: string | null
+  posterDisplay?: PosterDisplay
 }
 
 /** Map the form's `EventInput` onto the event-table column shape. */
@@ -19,7 +21,9 @@ function toRow(input: EventInput) {
     start_time: input.startTime?.trim() || null,
     location: input.location?.trim() || null,
     location_url: input.locationUrl?.trim() || null,
-    poster_url: input.posterUrl?.trim() || null
+    poster_url: input.posterUrl?.trim() || null,
+    // Typed PosterDisplay → jsonb column (a plain object; cast at the boundary).
+    poster_display: (input.posterDisplay ?? null) as Record<string, unknown> | null
   }
 }
 

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -3,6 +3,7 @@ import type { MovieEvent } from '#shared/types/event'
 import type { BringItem } from '#shared/types/bring'
 import type { Profile } from '#shared/types/user'
 import type { Invite } from '#shared/types/invite'
+import type { PosterDisplay } from '#shared/utils/posterDisplay'
 
 definePageMeta({ middleware: 'admin' })
 useSeoMeta({ title: 'Admin · BSOTG' })
@@ -88,6 +89,7 @@ async function onSave(payload: {
   location: string | null
   locationUrl: string | null
   posterUrl: string | null
+  posterDisplay: PosterDisplay
 }): Promise<void> {
   const ok = await run(async () => {
     if (payload.id) await updateEvent(payload.id, payload)

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -30,9 +30,9 @@ export interface Database {
         Relationships: []
       }
       events: {
-        Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, voting_locked_at: string | null, invite_options: Record<string, unknown> | null, created_by: string | null, created_at: string }
-        Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, invite_options?: Record<string, unknown> | null, created_by?: string | null, created_at?: string }
-        Update: { id?: string, title?: string, description?: string, event_date?: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, invite_options?: Record<string, unknown> | null, created_by?: string | null, created_at?: string }
+        Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, voting_locked_at: string | null, invite_options: Record<string, unknown> | null, poster_display: Record<string, unknown> | null, created_by: string | null, created_at: string }
+        Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, invite_options?: Record<string, unknown> | null, poster_display?: Record<string, unknown> | null, created_by?: string | null, created_at?: string }
+        Update: { id?: string, title?: string, description?: string, event_date?: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, invite_options?: Record<string, unknown> | null, poster_display?: Record<string, unknown> | null, created_by?: string | null, created_at?: string }
         Relationships: []
       }
       rsvps: {

--- a/shared/types/event.ts
+++ b/shared/types/event.ts
@@ -12,6 +12,8 @@ export interface MovieEvent {
   voting_locked_at: string | null
   /** Per-event e-vite customization (jsonb). Read via normalizeInviteOptions. */
   invite_options: Record<string, unknown> | null
+  /** Per-event poster header display (jsonb). Read via normalizePosterDisplay. */
+  poster_display: Record<string, unknown> | null
   created_at: string
 }
 

--- a/shared/utils/posterDisplay.ts
+++ b/shared/utils/posterDisplay.ts
@@ -1,0 +1,68 @@
+/**
+ * Per-event control over how the poster fills the overview header: a header
+ * aspect ratio, a focal point (which part of the poster shows), and a zoom.
+ * Stored as the `events.poster_display` jsonb; both EventHero and the admin
+ * PosterAdjuster render from the SAME helpers so the editor is WYSIWYG.
+ */
+
+export const POSTER_RATIOS = ['banner', 'wide', 'cinema', 'tall'] as const
+export type PosterRatio = typeof POSTER_RATIOS[number]
+
+export interface PosterDisplay {
+  /** Header shape. */
+  ratio: PosterRatio
+  /** Focal point, 0–100 (% across / down the poster). */
+  posX: number
+  posY: number
+  /** Scale multiplier; 1 = cover baseline, <1 shows more (letterboxed), >1 zooms in. */
+  zoom: number
+}
+
+export const ZOOM_MIN = 0.5
+export const ZOOM_MAX = 3
+
+export const DEFAULT_POSTER_DISPLAY: PosterDisplay = { ratio: 'banner', posX: 50, posY: 50, zoom: 1 }
+
+export const POSTER_RATIO_LABELS: Record<PosterRatio, string> = {
+  banner: 'Banner',
+  wide: 'Wide',
+  cinema: 'Cinematic',
+  tall: 'Tall'
+}
+
+const RATIO_CLASS: Record<PosterRatio, string> = {
+  banner: 'aspect-[3/1]',
+  wide: 'aspect-[16/9]',
+  cinema: 'aspect-[21/9]',
+  tall: 'aspect-[4/3]'
+}
+
+function clamp(n: number, min: number, max: number, fallback: number): number {
+  return typeof n === 'number' && Number.isFinite(n) ? Math.min(max, Math.max(min, n)) : fallback
+}
+
+/** Validate/clamp the stored jsonb (untrusted) into a safe PosterDisplay. */
+export function normalizePosterDisplay(raw: unknown): PosterDisplay {
+  const d = (raw && typeof raw === 'object') ? raw as Record<string, unknown> : {}
+  const ratio = POSTER_RATIOS.includes(d.ratio as PosterRatio) ? d.ratio as PosterRatio : DEFAULT_POSTER_DISPLAY.ratio
+  return {
+    ratio,
+    posX: clamp(d.posX as number, 0, 100, DEFAULT_POSTER_DISPLAY.posX),
+    posY: clamp(d.posY as number, 0, 100, DEFAULT_POSTER_DISPLAY.posY),
+    zoom: clamp(d.zoom as number, ZOOM_MIN, ZOOM_MAX, DEFAULT_POSTER_DISPLAY.zoom)
+  }
+}
+
+/** Tailwind aspect-ratio class for the header container. */
+export function posterRatioClass(ratio: PosterRatio): string {
+  return RATIO_CLASS[ratio]
+}
+
+/** Inline style for the poster <img> (object-cover): focal point + zoom. */
+export function posterFillStyle(d: PosterDisplay): Record<string, string> {
+  return {
+    objectPosition: `${d.posX}% ${d.posY}%`,
+    transform: `scale(${d.zoom})`,
+    transformOrigin: `${d.posX}% ${d.posY}%`
+  }
+}

--- a/supabase/migrations/20260624000000_event_poster_display.sql
+++ b/supabase/migrations/20260624000000_event_poster_display.sql
@@ -1,0 +1,5 @@
+-- Per-event poster display settings for the overview header: header aspect ratio,
+-- focal point, and zoom. Stored as jsonb (mirrors invite_options). Read/clamped
+-- via shared/utils/posterDisplay.ts; null = the default (banner, centered, cover).
+-- No new policy needed — covered by the existing admin-only update policy on events.
+alter table public.events add column if not exists poster_display jsonb;

--- a/test/EventHero.nuxt.test.ts
+++ b/test/EventHero.nuxt.test.ts
@@ -21,11 +21,21 @@ describe('EventHero', () => {
     expect(w.text()).toContain('Dazed and Confused')
   })
 
-  it('paints the poster as the background when a backdrop is provided', async () => {
+  it('renders the poster as an image when a backdrop is provided', async () => {
     const w = await mountSuspended(EventHero, { props: { event: baseEvent, backdrop: 'https://img/poster.jpg' } })
-    const bg = w.find('div').attributes('style') ?? ''
-    expect(bg).toContain('background-image')
-    expect(bg).toContain('https://img/poster.jpg')
+    const img = w.find('img')
+    expect(img.exists()).toBe(true)
+    expect(img.attributes('src')).toBe('https://img/poster.jpg')
+    expect(img.classes()).toContain('object-cover')
+  })
+
+  it('applies the event poster_display (ratio, focal point, zoom) to the header', async () => {
+    const event = { ...baseEvent, poster_display: { ratio: 'tall', posX: 20, posY: 80, zoom: 1.5 } }
+    const w = await mountSuspended(EventHero, { props: { event, backdrop: 'https://img/p.jpg' } })
+    expect(w.find('button').classes()).toContain('aspect-[4/3]')
+    const style = w.find('img').attributes('style') ?? ''
+    expect(style).toContain('object-position: 20% 80%')
+    expect(style).toContain('scale(1.5)')
   })
 
   it('labels an upcoming event as Upcoming', async () => {

--- a/test/PosterAdjuster.nuxt.test.ts
+++ b/test/PosterAdjuster.nuxt.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import PosterAdjuster from '../app/components/PosterAdjuster.vue'
+import type { PosterDisplay } from '../shared/utils/posterDisplay'
+
+const base: PosterDisplay = { ratio: 'banner', posX: 50, posY: 50, zoom: 1 }
+
+function mount() {
+  return mountSuspended(PosterAdjuster, { props: { posterUrl: 'https://img/p.jpg', modelValue: { ...base } } })
+}
+
+describe('PosterAdjuster', () => {
+  it('renders the poster preview image', async () => {
+    const w = await mount()
+    expect(w.find('img').attributes('src')).toBe('https://img/p.jpg')
+  })
+
+  it('emits a ratio change when a preset is clicked', async () => {
+    const w = await mount()
+    const tall = w.findAll('button').find(b => b.text() === 'Tall')
+    await tall!.trigger('click')
+    const last = w.emitted('update:modelValue')!.at(-1)![0] as PosterDisplay
+    expect(last.ratio).toBe('tall')
+  })
+
+  it('emits a zoom change from the range slider', async () => {
+    const w = await mount()
+    const range = w.find('input[type="range"]')
+    ;(range.element as HTMLInputElement).value = '2'
+    await range.trigger('input')
+    const last = w.emitted('update:modelValue')!.at(-1)![0] as PosterDisplay
+    expect(last.zoom).toBe(2)
+  })
+})

--- a/test/posterDisplay.test.ts
+++ b/test/posterDisplay.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_POSTER_DISPLAY, normalizePosterDisplay, posterFillStyle, posterRatioClass } from '../shared/utils/posterDisplay'
+
+describe('posterDisplay', () => {
+  it('falls back to the default for null or garbage input', () => {
+    expect(normalizePosterDisplay(null)).toEqual(DEFAULT_POSTER_DISPLAY)
+    expect(normalizePosterDisplay({ ratio: 'nope', posX: 'x' })).toEqual(DEFAULT_POSTER_DISPLAY)
+  })
+
+  it('clamps position (0–100) and zoom (0.5–3) into range', () => {
+    expect(normalizePosterDisplay({ ratio: 'wide', posX: 150, posY: -10, zoom: 9 }))
+      .toEqual({ ratio: 'wide', posX: 100, posY: 0, zoom: 3 })
+    expect(normalizePosterDisplay({ zoom: 0.1 }).zoom).toBe(0.5)
+  })
+
+  it('keeps valid values unchanged', () => {
+    expect(normalizePosterDisplay({ ratio: 'cinema', posX: 30, posY: 70, zoom: 1.2 }))
+      .toEqual({ ratio: 'cinema', posX: 30, posY: 70, zoom: 1.2 })
+  })
+
+  it('maps each ratio to an aspect class', () => {
+    expect(posterRatioClass('banner')).toBe('aspect-[3/1]')
+    expect(posterRatioClass('tall')).toBe('aspect-[4/3]')
+  })
+
+  it('builds the fill style from focal point + zoom', () => {
+    expect(posterFillStyle({ ratio: 'wide', posX: 25, posY: 75, zoom: 2 })).toEqual({
+      objectPosition: '25% 75%',
+      transform: 'scale(2)',
+      transformOrigin: '25% 75%'
+    })
+  })
+})


### PR DESCRIPTION
## Scope

The overview header rendered every poster as a fixed `cover`/`center` crop at a fixed height — so a tall, hi-res poster looked overly zoomed and cut off. This adds **per-event** control over how the poster fills the header: aspect **ratio**, **focal point** (which part shows), and **zoom**.

## Implementation

- **Migration** `events.poster_display jsonb` (mirrors `invite_options`).
- **`shared/utils/posterDisplay.ts`** — `PosterDisplay` (`ratio`/`posX`/`posY`/`zoom`), a clamping normalizer for the untrusted jsonb, and the aspect-class + img-style helpers used by **both** the header and the editor → the editor is **WYSIWYG**.
- **`EventHero`** — renders the poster as an `<img>` with `object-cover` + the focal point and zoom; the header takes the chosen aspect ratio. The hover-scale moved to a wrapper so it composes with the per-event zoom.
- **`PosterAdjuster`** (new, admin) — ratio presets (Banner/Wide/Cinematic/Tall) + a **drag-to-reposition** live preview + a **zoom slider** (50–300%).
- Wired through `EventFormModal` → `admin` onSave → `useEventAdmin` (+ `database.types`).

Existing events (null `poster_display`) fall back to the default (banner, centered, cover) — visually close to today.

## How to Test

- `test/posterDisplay.test.ts` — normalize/clamp, ratio class, fill style.
- `test/PosterAdjuster.nuxt.test.ts` — ratio preset + zoom slider emit updates.
- `test/EventHero.nuxt.test.ts` — header applies the event's ratio/focal point/zoom.
- 283 passing, lint 0 errors, typecheck clean.

Manual: edit an event with a poster → drag to reposition, slide zoom, pick a ratio (live preview) → save → overview header matches the preview.

## Invariants & Risk

Deploys a DB migration (additive nullable column; existing admin-update RLS covers it — no new policy). No auth/key/vote/HTML-render surface touched. The jsonb is clamped on read, so a bad value can't break the header. Medium-touch UI + a migration.

> Note (release): per the open thread, you'll need to re-run Release (or pick A/B) to tag; the migration deploys on merge regardless.