### PR TITLE
fix: email poster, bigger nav logo, hero address+weather, land authed users on overview

### DIFF
--- a/app/components/EventHero.vue
+++ b/app/components/EventHero.vue
@@ -49,12 +49,15 @@ const display = computed(() => normalizePosterDisplay(props.event.poster_display
       <h1 class="text-2xl sm:text-3xl font-bold text-white drop-shadow-md text-balance underline-offset-4 decoration-2 decoration-white/40 group-hover:underline">
         {{ event.title }}
       </h1>
+      <p v-if="event.location" class="mt-1.5 inline-flex items-center gap-1.5 text-sm text-white/80">
+        <UIcon name="i-lucide-map-pin" class="shrink-0" /> {{ event.location }}
+      </p>
       <WeatherForecast
         v-if="upcoming && event.location"
         :location="event.location"
         :date="event.event_date"
         tone="light"
-        class="mt-2"
+        class="mt-1"
       />
       <p class="mt-1.5 inline-flex items-center gap-1 text-xs text-white/70">
         <UIcon name="i-lucide-info" /> Tap for details

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -34,7 +34,7 @@ async function handleSignOut(): Promise<void> {
   <div>
     <UHeader to="/overview" :ui="{ center: 'gap-1' }">
       <template #title>
-        <img src="/img/bsotg_logo.svg" alt="Benteen Screen On The Green" class="h-7 w-auto">
+        <img src="/img/bsotg_logo.svg" alt="Benteen Screen On The Green" class="h-10 w-auto">
       </template>
 
       <UNavigationMenu :items="links" />

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -5,7 +5,7 @@ const { user } = useAuth()
 // Already signed in? The splash is the logged-OUT front door — send members
 // straight to the app instead of making them click through it.
 watchEffect(() => {
-  if (user.value) navigateTo('/overview')
+  if (user.value) void navigateTo('/overview')
 })
 const ctaTo = computed(() => (user.value ? '/overview' : '/login'))
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,6 +2,11 @@
 definePageMeta({ layout: false })
 
 const { user } = useAuth()
+// Already signed in? The splash is the logged-OUT front door — send members
+// straight to the app instead of making them click through it.
+watchEffect(() => {
+  if (user.value) navigateTo('/overview')
+})
 const ctaTo = computed(() => (user.value ? '/overview' : '/login'))
 
 const features = [

--- a/shared/utils/email.ts
+++ b/shared/utils/email.ts
@@ -183,7 +183,7 @@ export function buildEventInviteEmail(opts: {
     : ''
 
   const posterHtml = showPoster
-    ? `<img src="${escapeHtml(opts.posterUrl ?? '')}" alt="${escapeHtml(opts.eventTitle)} poster" width="600" style="display:block;width:100%;max-height:360px;object-fit:cover">`
+    ? `<img src="${escapeHtml(opts.posterUrl ?? '')}" alt="${escapeHtml(opts.eventTitle)} poster" width="600" style="display:block;width:100%;height:auto">`
     : ''
 
   const lineupHtml = opts.appUrl

--- a/test/EventHero.nuxt.test.ts
+++ b/test/EventHero.nuxt.test.ts
@@ -76,4 +76,20 @@ describe('EventHero', () => {
     })
     expect(w.find('.wf-stub').exists()).toBe(false)
   })
+
+  it('shows the event location when set', async () => {
+    const w = await mountSuspended(EventHero, {
+      props: { event: { ...baseEvent, location: 'Benteen Field' }, backdrop: null },
+      global: { stubs: { WeatherForecast: { template: '<div />' } } }
+    })
+    expect(w.text()).toContain('Benteen Field')
+  })
+
+  it('omits the location line when there is no location', async () => {
+    const w = await mountSuspended(EventHero, {
+      props: { event: baseEvent, backdrop: null },
+      global: { stubs: { WeatherForecast: { template: '<div />' } } }
+    })
+    expect(w.text()).not.toContain('Benteen Field')
+  })
 })

--- a/test/email.test.ts
+++ b/test/email.test.ts
@@ -35,9 +35,12 @@ describe('buildEventInviteEmail', () => {
     theme: 'marquee', accent: 'green', message: '', showPoster: true, showDetails: true, ...over
   })
 
-  it('includes the poster when showPoster is on', () => {
+  it('includes the poster when showPoster is on, showing the whole image (not cropped)', () => {
     const m = buildEventInviteEmail({ eventTitle: 'Jaws', eventDate: null, posterUrl: 'https://img/jaws.jpg', inviterName: null, rsvpUrl: 'https://x/rsvp?token=abc', options: opts({}) })
     expect(m.html).toContain('https://img/jaws.jpg')
+    // Whole poster, scaled to width — not object-fit:cover (which cropped top/bottom).
+    expect(m.html).toContain('height:auto')
+    expect(m.html).not.toContain('object-fit')
   })
 
   it('omits the poster when showPoster is off', () => {

--- a/test/index.nuxt.test.ts
+++ b/test/index.nuxt.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import IndexPage from '../app/pages/index.vue'
+
+// hoisted: mockNuxtImport's factory returns navigateTo directly, so it must exist
+// before the (hoisted) mock runs. (useAuth's inner fn accesses `user` lazily.)
+const navigateTo = vi.hoisted(() => vi.fn())
+const user = ref<unknown>(null)
+mockNuxtImport('useAuth', () => () => ({ user }))
+mockNuxtImport('navigateTo', () => navigateTo)
+
+// UColorModeButton needs useColorMode (not wired in the test runtime) — stub it.
+const mountOpts = { global: { stubs: { UColorModeButton: true } } }
+
+beforeEach(() => {
+  navigateTo.mockClear()
+  user.value = null
+})
+
+describe('index (splash) page', () => {
+  it('redirects signed-in visitors straight to /overview', async () => {
+    user.value = { id: 'u1' }
+    await mountSuspended(IndexPage, mountOpts)
+    expect(navigateTo).toHaveBeenCalledWith('/overview')
+  })
+
+  it('stays on the splash for signed-out visitors', async () => {
+    await mountSuspended(IndexPage, mountOpts)
+    expect(navigateTo).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Four quick fixes:

1. **Email e-vite poster** — was `object-fit:cover; max-height:360px` (cut off top & bottom). Now `width:100%; height:auto` so the **whole poster shows, scaled down**.
2. **Nav logo** — `h-7` → `h-10` (bigger on the overview/app header).
3. **Hero address + weather** — the overview header now shows the event **address** (map-pin) with the **weather forecast right beneath it** (it previously sat under the title, and the address wasn't shown).
4. **Login flow** — signed-in users hitting the splash (`/`) now **redirect straight to `/overview`** instead of landing on the splash. (Logged-out users still get the splash as the front door → Sign in.)

## Test
283 passing, lint 0 errors, typecheck clean. Manual: open an e-vite email (whole poster), check the overview header (bigger logo, address + weather), and visit `/` while logged in (→ overview).

> On the "splash = where people log in": this lands authed users on overview and keeps the splash as the logged-out entry (its CTA → /login). If you'd rather the **login form itself live on the splash** (drop the separate /login page), that's a quick follow-up — say the word.