### PR TITLE
fix: poster header collapsed to 0 height (invisible header)

### DIFF
--- a/app/components/EventHero.vue
+++ b/app/components/EventHero.vue
@@ -15,8 +15,8 @@ const display = computed(() => normalizePosterDisplay(props.event.poster_display
 <template>
   <button
     type="button"
-    class="group relative block w-full cursor-pointer overflow-hidden rounded-xl text-left ring ring-default bg-black transition hover:ring-primary/40"
-    :class="posterRatioClass(display.ratio)"
+    class="group relative block w-full cursor-pointer overflow-hidden rounded-xl text-left ring ring-default bg-black transition hover:ring-primary/40 min-h-44 sm:min-h-56"
+    :style="posterRatioStyle(display.ratio)"
     :aria-label="`${event.title} — view event details`"
     @click="$emit('open')"
   >

--- a/app/components/PosterAdjuster.vue
+++ b/app/components/PosterAdjuster.vue
@@ -72,7 +72,7 @@ function reset(): void {
     <div
       ref="previewRef"
       class="relative w-full overflow-hidden rounded-lg bg-black ring ring-default cursor-move touch-none select-none"
-      :class="posterRatioClass(model.ratio)"
+      :style="posterRatioStyle(model.ratio)"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"

--- a/shared/utils/posterDisplay.ts
+++ b/shared/utils/posterDisplay.ts
@@ -30,11 +30,11 @@ export const POSTER_RATIO_LABELS: Record<PosterRatio, string> = {
   tall: 'Tall'
 }
 
-const RATIO_CLASS: Record<PosterRatio, string> = {
-  banner: 'aspect-[3/1]',
-  wide: 'aspect-[16/9]',
-  cinema: 'aspect-[21/9]',
-  tall: 'aspect-[4/3]'
+const RATIO_ASPECT: Record<PosterRatio, string> = {
+  banner: '3 / 1',
+  wide: '16 / 9',
+  cinema: '21 / 9',
+  tall: '4 / 3'
 }
 
 function clamp(n: number, min: number, max: number, fallback: number): number {
@@ -53,9 +53,12 @@ export function normalizePosterDisplay(raw: unknown): PosterDisplay {
   }
 }
 
-/** Tailwind aspect-ratio class for the header container. */
-export function posterRatioClass(ratio: PosterRatio): string {
-  return RATIO_CLASS[ratio]
+/** Inline aspect-ratio style for the header container. Not a Tailwind class:
+ *  the arbitrary `aspect-[x/y]` values only ever appeared in this .ts file, which
+ *  Tailwind doesn't scan, so the class was never generated — collapsing the
+ *  header to 0 height. An inline style works regardless of what Tailwind scans. */
+export function posterRatioStyle(ratio: PosterRatio): Record<string, string> {
+  return { aspectRatio: RATIO_ASPECT[ratio] }
 }
 
 /** Inline style for the poster <img> (object-cover): focal point + zoom. */

--- a/test/EventHero.nuxt.test.ts
+++ b/test/EventHero.nuxt.test.ts
@@ -32,7 +32,7 @@ describe('EventHero', () => {
   it('applies the event poster_display (ratio, focal point, zoom) to the header', async () => {
     const event = { ...baseEvent, poster_display: { ratio: 'tall', posX: 20, posY: 80, zoom: 1.5 } }
     const w = await mountSuspended(EventHero, { props: { event, backdrop: 'https://img/p.jpg' } })
-    expect(w.find('button').classes()).toContain('aspect-[4/3]')
+    expect(w.find('button').attributes('style') ?? '').toContain('aspect-ratio: 4 / 3')
     const style = w.find('img').attributes('style') ?? ''
     expect(style).toContain('object-position: 20% 80%')
     expect(style).toContain('scale(1.5)')

--- a/test/posterDisplay.test.ts
+++ b/test/posterDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_POSTER_DISPLAY, normalizePosterDisplay, posterFillStyle, posterRatioClass } from '../shared/utils/posterDisplay'
+import { DEFAULT_POSTER_DISPLAY, normalizePosterDisplay, posterFillStyle, posterRatioStyle } from '../shared/utils/posterDisplay'
 
 describe('posterDisplay', () => {
   it('falls back to the default for null or garbage input', () => {
@@ -18,9 +18,9 @@ describe('posterDisplay', () => {
       .toEqual({ ratio: 'cinema', posX: 30, posY: 70, zoom: 1.2 })
   })
 
-  it('maps each ratio to an aspect class', () => {
-    expect(posterRatioClass('banner')).toBe('aspect-[3/1]')
-    expect(posterRatioClass('tall')).toBe('aspect-[4/3]')
+  it('maps each ratio to an inline aspect-ratio style', () => {
+    expect(posterRatioStyle('banner')).toEqual({ aspectRatio: '3 / 1' })
+    expect(posterRatioStyle('tall')).toEqual({ aspectRatio: '4 / 3' })
   })
 
   it('builds the fill style from focal point + zoom', () => {


### PR DESCRIPTION
## Scope

After the poster-display feature, the overview **header poster card disappeared**.

## Cause

The header height was set by a Tailwind class `aspect-[3/1]` (etc.) returned from `posterRatioClass()` **in `shared/utils/posterDisplay.ts`**. Tailwind doesn't scan that `.ts` file for those arbitrary classes, so the CSS was never generated. With the old `min-h-44` removed and every child absolutely positioned, the button collapsed to **0px** → invisible.

## Fix

- `posterRatioStyle()` returns an **inline `aspect-ratio` style** (no Tailwind scanning dependency), replacing `posterRatioClass()`.
- Restore `min-h-44 sm:min-h-56` as a floor so the header can never be invisible again.
- `EventHero` + `PosterAdjuster` use the inline style.

## Test

posterDisplay/EventHero/PosterAdjuster tests updated (style instead of class), 17 pass; lint + typecheck clean. Manual: overview header shows again, ratio presets still change the shape.

**Merge this to un-break the header in prod.**