### PR TITLE
feat: make participation caps admin-configurable

### DIFF
--- a/app/components/ParticipationLimitsSetting.vue
+++ b/app/components/ParticipationLimitsSetting.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 // Admin control for the per-event participation caps (app_settings.max_suggestions
 // / max_votes). RLS enforces admin-only writes; blank = the defaults in limits.ts.
-const { maxSuggestions, maxVotes, setMaxSuggestions, setMaxVotes } = useAppSettings()
+const { maxSuggestions, maxVotes, setParticipationCaps } = useAppSettings()
 const toast = useToast()
 const suggestionsDraft = ref<number | null>(null)
 const votesDraft = ref<number | null>(null)
@@ -24,8 +24,7 @@ async function save(): Promise<void> {
   try {
     const s = clean(suggestionsDraft.value)
     const v = clean(votesDraft.value)
-    await setMaxSuggestions(s)
-    await setMaxVotes(v)
+    await setParticipationCaps(s, v)
     suggestionsDraft.value = s
     votesDraft.value = v
     toast.add({ title: 'Participation limits saved', icon: 'i-lucide-check', color: 'success' })

--- a/app/components/ParticipationLimitsSetting.vue
+++ b/app/components/ParticipationLimitsSetting.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+// Admin control for the per-event participation caps (app_settings.max_suggestions
+// / max_votes). RLS enforces admin-only writes; blank = the defaults in limits.ts.
+const { maxSuggestions, maxVotes, setMaxSuggestions, setMaxVotes } = useAppSettings()
+const toast = useToast()
+const suggestionsDraft = ref<number | null>(null)
+const votesDraft = ref<number | null>(null)
+const saving = ref(false)
+
+watch(maxSuggestions, (v) => {
+  suggestionsDraft.value = v
+}, { immediate: true })
+watch(maxVotes, (v) => {
+  votesDraft.value = v
+}, { immediate: true })
+
+function clean(value: number | null): number | null {
+  const n = Number(value)
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : null
+}
+
+async function save(): Promise<void> {
+  saving.value = true
+  try {
+    const s = clean(suggestionsDraft.value)
+    const v = clean(votesDraft.value)
+    await setMaxSuggestions(s)
+    await setMaxVotes(v)
+    suggestionsDraft.value = s
+    votesDraft.value = v
+    toast.add({ title: 'Participation limits saved', icon: 'i-lucide-check', color: 'success' })
+  } catch {
+    toast.add({ title: 'Could not save the limits', color: 'error' })
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <UCard variant="subtle">
+    <div class="flex flex-wrap items-end gap-3">
+      <UFormField label="Suggestions per person" :hint="`Blank = default (${SUGGESTION_LIMIT})`" class="flex-1 min-w-32">
+        <UInput v-model="suggestionsDraft" type="number" min="1" :placeholder="String(SUGGESTION_LIMIT)" class="w-full" />
+      </UFormField>
+      <UFormField label="Votes per person" :hint="`Blank = default (${VOTE_LIMIT})`" class="flex-1 min-w-32">
+        <UInput v-model="votesDraft" type="number" min="1" :placeholder="String(VOTE_LIMIT)" class="w-full" />
+      </UFormField>
+      <UButton label="Save" icon="i-lucide-save" :loading="saving" @click="save" />
+    </div>
+    <p class="text-xs text-muted mt-2">
+      Caps how many movies each person can suggest and how many they can vote for, per event. Enforced server-side.
+    </p>
+  </UCard>
+</template>

--- a/app/composables/useAppSettings.ts
+++ b/app/composables/useAppSettings.ts
@@ -5,25 +5,50 @@ import type { Database } from '~/types/database.types'
 export function useAppSettings() {
   const supabase = useSupabaseClient<Database>()
   const maxInvites = ref<number | null>(null)
+  // Per-event participation caps (null = use the defaults in shared/utils/limits).
+  const maxSuggestions = ref<number | null>(null)
+  const maxVotes = ref<number | null>(null)
   const pending = ref(true)
 
   async function refresh(): Promise<void> {
-    const { data } = await supabase.from('app_settings').select('max_invites').eq('id', true).maybeSingle()
+    const { data } = await supabase
+      .from('app_settings')
+      .select('max_invites, max_suggestions, max_votes')
+      .eq('id', true)
+      .maybeSingle()
     maxInvites.value = data?.max_invites ?? null
+    maxSuggestions.value = data?.max_suggestions ?? null
+    maxVotes.value = data?.max_votes ?? null
     pending.value = false
   }
 
   onMounted(refresh)
 
-  /** Set the total invite cap (null = unlimited). RLS enforces admin-only. */
-  async function setMaxInvites(value: number | null): Promise<void> {
+  async function update(patch: Record<string, number | null>): Promise<void> {
     const { error } = await supabase
       .from('app_settings')
-      .update({ max_invites: value, updated_at: new Date().toISOString() })
+      .update({ ...patch, updated_at: new Date().toISOString() })
       .eq('id', true)
     if (error) throw error
+  }
+
+  /** Set the total invite cap (null = unlimited). RLS enforces admin-only. */
+  async function setMaxInvites(value: number | null): Promise<void> {
+    await update({ max_invites: value })
     maxInvites.value = value
   }
 
-  return { maxInvites, pending, setMaxInvites }
+  /** Set the per-event suggestion cap (null = default). RLS enforces admin-only. */
+  async function setMaxSuggestions(value: number | null): Promise<void> {
+    await update({ max_suggestions: value })
+    maxSuggestions.value = value
+  }
+
+  /** Set the per-event vote cap (null = default). RLS enforces admin-only. */
+  async function setMaxVotes(value: number | null): Promise<void> {
+    await update({ max_votes: value })
+    maxVotes.value = value
+  }
+
+  return { maxInvites, maxSuggestions, maxVotes, pending, setMaxInvites, setMaxSuggestions, setMaxVotes }
 }

--- a/app/composables/useAppSettings.ts
+++ b/app/composables/useAppSettings.ts
@@ -38,17 +38,14 @@ export function useAppSettings() {
     maxInvites.value = value
   }
 
-  /** Set the per-event suggestion cap (null = default). RLS enforces admin-only. */
-  async function setMaxSuggestions(value: number | null): Promise<void> {
-    await update({ max_suggestions: value })
-    maxSuggestions.value = value
+  /** Set both per-event caps in ONE write (null = the limits.ts defaults). RLS
+   *  enforces admin-only. Atomic, so a partial failure can't leave one cap
+   *  committed and the other not. */
+  async function setParticipationCaps(suggestions: number | null, votes: number | null): Promise<void> {
+    await update({ max_suggestions: suggestions, max_votes: votes })
+    maxSuggestions.value = suggestions
+    maxVotes.value = votes
   }
 
-  /** Set the per-event vote cap (null = default). RLS enforces admin-only. */
-  async function setMaxVotes(value: number | null): Promise<void> {
-    await update({ max_votes: value })
-    maxVotes.value = value
-  }
-
-  return { maxInvites, maxSuggestions, maxVotes, pending, setMaxInvites, setMaxSuggestions, setMaxVotes }
+  return { maxInvites, maxSuggestions, maxVotes, pending, setMaxInvites, setParticipationCaps }
 }

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -362,6 +362,7 @@ function onSelectEvent(event: MovieEvent): void {
           </div>
 
           <InviteLimitSetting />
+          <ParticipationLimitsSetting />
 
           <UAlert
             v-if="loadError"

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -40,10 +40,14 @@ const votingLocked = computed(() => Boolean(currentEvent.value?.voting_locked_at
 const winners = computed(() => topWinners(suggestions.value))
 
 // Per-event participation caps (mirrors the DB triggers — see shared/utils/limits).
+// Effective limit = admin-configured (app_settings) or the default in limits.ts.
+const { maxSuggestions: cfgMaxSuggestions, maxVotes: cfgMaxVotes } = useAppSettings()
+const suggestionLimit = computed(() => cfgMaxSuggestions.value ?? SUGGESTION_LIMIT)
+const voteLimit = computed(() => cfgMaxVotes.value ?? VOTE_LIMIT)
 const mySuggestionCount = computed(() => countMySuggestions(suggestions.value, myId.value))
 const myVoteCount = computed(() => countMyVotes(suggestions.value, myId.value))
-const atSuggestionCap = computed(() => mySuggestionCount.value >= SUGGESTION_LIMIT)
-const atVoteCap = computed(() => myVoteCount.value >= VOTE_LIMIT)
+const atSuggestionCap = computed(() => mySuggestionCount.value >= suggestionLimit.value)
+const atVoteCap = computed(() => myVoteCount.value >= voteLimit.value)
 
 const eventOptions = computed(() =>
   events.value.map((event, index) => ({
@@ -83,7 +87,7 @@ async function onSuggest(movie: TmdbMovie): Promise<void> {
     return
   }
   if (atSuggestionCap.value) {
-    toast.add({ title: `You've used all ${SUGGESTION_LIMIT} suggestions`, description: 'Remove one from the list to free up a slot.', color: 'warning' })
+    toast.add({ title: `You've used all ${suggestionLimit.value} suggestions`, description: 'Remove one from the list to free up a slot.', color: 'warning' })
     return
   }
   if (await run(() => suggest(movie), 'Could not add suggestion')) {
@@ -92,7 +96,7 @@ async function onSuggest(movie: TmdbMovie): Promise<void> {
 }
 async function onVote(suggestion: Suggestion): Promise<void> {
   if (atVoteCap.value) {
-    toast.add({ title: `You've used all ${VOTE_LIMIT} votes`, description: 'Remove a vote to switch your pick.', color: 'warning' })
+    toast.add({ title: `You've used all ${voteLimit.value} votes`, description: 'Remove a vote to switch your pick.', color: 'warning' })
     return
   }
   await run(() => vote(suggestion), 'Vote failed')
@@ -193,7 +197,7 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
           <!-- Suggest + finder (hidden once voting is locked) -->
           <template v-if="!votingLocked">
             <p class="text-xs text-muted text-center">
-              {{ mySuggestionCount }} of {{ SUGGESTION_LIMIT }} suggestions used
+              {{ mySuggestionCount }} of {{ suggestionLimit }} suggestions used
             </p>
             <template v-if="!atSuggestionCap">
               <!-- Suggest (desktop inline) -->
@@ -229,7 +233,7 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
               icon="i-lucide-circle-check"
               color="neutral"
               variant="subtle"
-              :title="`You've used all ${SUGGESTION_LIMIT} suggestions`"
+              :title="`You've used all ${suggestionLimit} suggestions`"
               description="Remove one from the list to free up a slot."
             />
           </template>
@@ -248,7 +252,7 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
             </h2>
             <UBadge
               v-if="!votingLocked"
-              :label="`${myVoteCount}/${VOTE_LIMIT} votes used`"
+              :label="`${myVoteCount}/${voteLimit} votes used`"
               :color="atVoteCap ? 'warning' : 'neutral'"
               variant="subtle"
             />

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -18,9 +18,9 @@ export interface Database {
         Relationships: []
       }
       app_settings: {
-        Row: { id: boolean, max_invites: number | null, updated_at: string }
-        Insert: { id?: boolean, max_invites?: number | null, updated_at?: string }
-        Update: { id?: boolean, max_invites?: number | null, updated_at?: string }
+        Row: { id: boolean, max_invites: number | null, max_suggestions: number | null, max_votes: number | null, updated_at: string }
+        Insert: { id?: boolean, max_invites?: number | null, max_suggestions?: number | null, max_votes?: number | null, updated_at?: string }
+        Update: { id?: boolean, max_invites?: number | null, max_suggestions?: number | null, max_votes?: number | null, updated_at?: string }
         Relationships: []
       }
       event_invites: {

--- a/supabase/migrations/20260625000000_configurable_caps.sql
+++ b/supabase/migrations/20260625000000_configurable_caps.sql
@@ -1,0 +1,17 @@
+-- Make the per-event participation caps admin-configurable via app_settings,
+-- defaulting to the original 5 suggestions / 3 votes when unset. The enforce_*
+-- triggers already call suggestion_limit()/vote_limit(), so redefining those to
+-- read app_settings makes the caps tunable with no trigger changes. The functions
+-- become `stable` (they read a table) instead of `immutable`.
+alter table public.app_settings add column if not exists max_suggestions int check (max_suggestions is null or max_suggestions >= 1);
+alter table public.app_settings add column if not exists max_votes int check (max_votes is null or max_votes >= 1);
+
+create or replace function public.suggestion_limit() returns int
+  language sql stable set search_path = public as $$
+  select coalesce((select max_suggestions from public.app_settings where id), 5)
+$$;
+
+create or replace function public.vote_limit() returns int
+  language sql stable set search_path = public as $$
+  select coalesce((select max_votes from public.app_settings where id), 3)
+$$;

--- a/test/ParticipationLimitsSetting.nuxt.test.ts
+++ b/test/ParticipationLimitsSetting.nuxt.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment nuxt
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import ParticipationLimitsSetting from '../app/components/ParticipationLimitsSetting.vue'
+
+const setMaxSuggestions = vi.fn()
+const setMaxVotes = vi.fn()
+mockNuxtImport('useAppSettings', () => () => ({
+  maxSuggestions: ref<number | null>(7),
+  maxVotes: ref<number | null>(4),
+  setMaxSuggestions,
+  setMaxVotes
+}))
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+describe('ParticipationLimitsSetting', () => {
+  it('renders a number input for each cap', async () => {
+    const w = await mountSuspended(ParticipationLimitsSetting)
+    expect(w.findAll('input[type="number"]').length).toBe(2)
+    expect(w.text()).toContain('Suggestions per person')
+    expect(w.text()).toContain('Votes per person')
+  })
+
+  it('saves the current drafts through the setters', async () => {
+    const w = await mountSuspended(ParticipationLimitsSetting)
+    await w.findAll('button').find(b => b.text() === 'Save')!.trigger('click')
+    // Drafts hydrate from the (mocked) current values: 7 suggestions, 4 votes.
+    expect(setMaxSuggestions).toHaveBeenCalledWith(7)
+    expect(setMaxVotes).toHaveBeenCalledWith(4)
+  })
+})

--- a/test/ParticipationLimitsSetting.nuxt.test.ts
+++ b/test/ParticipationLimitsSetting.nuxt.test.ts
@@ -4,13 +4,11 @@ import { ref } from 'vue'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import ParticipationLimitsSetting from '../app/components/ParticipationLimitsSetting.vue'
 
-const setMaxSuggestions = vi.fn()
-const setMaxVotes = vi.fn()
+const setParticipationCaps = vi.fn()
 mockNuxtImport('useAppSettings', () => () => ({
   maxSuggestions: ref<number | null>(7),
   maxVotes: ref<number | null>(4),
-  setMaxSuggestions,
-  setMaxVotes
+  setParticipationCaps
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
 
@@ -22,11 +20,10 @@ describe('ParticipationLimitsSetting', () => {
     expect(w.text()).toContain('Votes per person')
   })
 
-  it('saves the current drafts through the setters', async () => {
+  it('saves both drafts in a single atomic call', async () => {
     const w = await mountSuspended(ParticipationLimitsSetting)
     await w.findAll('button').find(b => b.text() === 'Save')!.trigger('click')
     // Drafts hydrate from the (mocked) current values: 7 suggestions, 4 votes.
-    expect(setMaxSuggestions).toHaveBeenCalledWith(7)
-    expect(setMaxVotes).toHaveBeenCalledWith(4)
+    expect(setParticipationCaps).toHaveBeenCalledWith(7, 4)
   })
 })

--- a/test/overview.nuxt.test.ts
+++ b/test/overview.nuxt.test.ts
@@ -39,6 +39,10 @@ mockNuxtImport('useRsvp', () => () => ({
   setStatus: async () => {}
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+mockNuxtImport('useAppSettings', () => () => ({
+  maxSuggestions: ref<number | null>(null),
+  maxVotes: ref<number | null>(null)
+}))
 
 // Heavy children pull in their own composables/network — stub them; this page
 // test only cares about the header + the admin-gated selector.

--- a/test/useAppSettings.nuxt.test.ts
+++ b/test/useAppSettings.nuxt.test.ts
@@ -6,7 +6,7 @@ const updates: unknown[] = []
 const supabase = {
   from() {
     return {
-      select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { max_invites: 10 } }) }) }),
+      select: () => ({ eq: () => ({ maybeSingle: () => Promise.resolve({ data: { max_invites: 10, max_suggestions: 7, max_votes: 4 } }) }) }),
       update: (payload: unknown) => {
         updates.push(payload)
         return { eq: () => Promise.resolve({ error: null }) }
@@ -33,5 +33,15 @@ describe('useAppSettings', () => {
     await setMaxInvites(null)
     expect(updates[0]).toMatchObject({ max_invites: null })
     expect(maxInvites.value).toBeNull()
+  })
+
+  it('setMaxSuggestions / setMaxVotes update the participation caps', async () => {
+    const s = useAppSettings()
+    await s.setMaxSuggestions(7)
+    await s.setMaxVotes(4)
+    expect(updates).toContainEqual(expect.objectContaining({ max_suggestions: 7 }))
+    expect(updates).toContainEqual(expect.objectContaining({ max_votes: 4 }))
+    expect(s.maxSuggestions.value).toBe(7)
+    expect(s.maxVotes.value).toBe(4)
   })
 })

--- a/test/useAppSettings.nuxt.test.ts
+++ b/test/useAppSettings.nuxt.test.ts
@@ -35,12 +35,11 @@ describe('useAppSettings', () => {
     expect(maxInvites.value).toBeNull()
   })
 
-  it('setMaxSuggestions / setMaxVotes update the participation caps', async () => {
+  it('setParticipationCaps writes both caps in a single (atomic) update', async () => {
     const s = useAppSettings()
-    await s.setMaxSuggestions(7)
-    await s.setMaxVotes(4)
-    expect(updates).toContainEqual(expect.objectContaining({ max_suggestions: 7 }))
-    expect(updates).toContainEqual(expect.objectContaining({ max_votes: 4 }))
+    await s.setParticipationCaps(7, 4)
+    expect(updates).toHaveLength(1)
+    expect(updates[0]).toMatchObject({ max_suggestions: 7, max_votes: 4 })
     expect(s.maxSuggestions.value).toBe(7)
     expect(s.maxVotes.value).toBe(4)
   })


### PR DESCRIPTION
## Scope

The 5-suggestion / 3-vote caps (from #95) were hardcoded. This makes them admin-tunable, mirroring the invite-cap pattern.

## Implementation

- **Migration**: `app_settings.max_suggestions` / `max_votes` (null = the `limits.ts` defaults). `suggestion_limit()`/`vote_limit()` redefined to read them (now `stable`); the `enforce_*` triggers pick up the new values with no trigger changes.
- **`useAppSettings`**: `maxSuggestions`/`maxVotes` + setters.
- **`ParticipationLimitsSetting`** admin component, placed next to the invite limit on the People tab.
- **overview**: the caps UI uses the effective limit (`configured ?? default`).

## Test
useAppSettings setters, the admin component (renders + saves), overview uses the configured limit. Full suite green, lint + typecheck clean.

> Deploys a migration (additive columns + function redefs). The caps default to 5/3 when unset, so behavior is unchanged until an admin sets them.