### PR TITLE
fix: poster rendering (whole image, zoom-out reveals more, mobile header fit)

### DIFF
--- a/app/components/EventHero.vue
+++ b/app/components/EventHero.vue
@@ -15,27 +15,29 @@ const display = computed(() => normalizePosterDisplay(props.event.poster_display
 <template>
   <button
     type="button"
-    class="group relative block w-full cursor-pointer overflow-hidden rounded-xl text-left ring ring-default bg-black transition hover:ring-primary/40 min-h-44 sm:min-h-56"
+    class="group relative flex flex-col justify-end w-full cursor-pointer overflow-hidden rounded-xl text-left ring ring-default bg-black transition hover:ring-primary/40 min-h-44 sm:min-h-56"
     :style="posterRatioStyle(display.ratio)"
     :aria-label="`${event.title} — view event details`"
     @click="$emit('open')"
   >
-    <!-- Poster (object-cover with the event's focal point + zoom; falls back to a
-         neutral surface when none is set). Hover-scale lives on the wrapper so it
-         composes with the per-event zoom on the image. -->
+    <!-- Blurred fill so a contained poster rests on a soft backdrop, not black bars. -->
+    <img v-if="backdrop" :src="backdrop" alt="" class="absolute inset-0 size-full object-cover scale-110 blur-2xl opacity-50">
+    <!-- The poster itself: object-contain (whole image visible) with the event's
+         focal point + zoom. Hover-scale on the wrapper composes with the zoom. -->
     <div
       v-if="backdrop"
       class="absolute inset-0 transition-transform duration-500 group-hover:scale-105"
     >
-      <img :src="backdrop" alt="" class="size-full object-cover" :style="posterFillStyle(display)">
+      <img :src="backdrop" alt="" class="size-full object-contain" :style="posterFillStyle(display)">
     </div>
     <div v-else class="absolute inset-0 bg-elevated" />
 
     <!-- Legibility gradient so the title is readable over any poster -->
     <div class="absolute inset-0 bg-gradient-to-t from-black/85 via-black/45 to-black/10" />
 
-    <!-- Title block, anchored to the bottom -->
-    <div class="absolute inset-x-0 bottom-0 p-5 sm:p-6">
+    <!-- Title block. In normal flow (justify-end pins it to the bottom) so the
+         header grows to fit the text on narrow screens instead of clipping it. -->
+    <div class="relative p-5 sm:p-6">
       <div class="flex flex-wrap items-center gap-2 mb-2">
         <UBadge
           :color="upcoming ? 'primary' : 'neutral'"

--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -38,7 +38,7 @@ function downloadIcs(): void {
           v-if="event.poster_url"
           :src="event.poster_url"
           :alt="`${event.title} poster`"
-          class="w-full max-h-72 object-cover rounded-lg ring ring-default"
+          class="w-full max-h-96 object-contain rounded-lg ring ring-default bg-black"
         >
 
         <!-- Date / status / logistics -->

--- a/app/components/PosterAdjuster.vue
+++ b/app/components/PosterAdjuster.vue
@@ -78,7 +78,8 @@ function reset(): void {
       @pointerup="onPointerUp"
       @pointercancel="onPointerUp"
     >
-      <img :src="posterUrl" alt="" class="size-full object-cover pointer-events-none" :style="posterFillStyle(model)">
+      <img :src="posterUrl" alt="" class="absolute inset-0 size-full object-cover scale-110 blur-2xl opacity-50 pointer-events-none">
+      <img :src="posterUrl" alt="" class="absolute inset-0 size-full object-contain pointer-events-none" :style="posterFillStyle(model)">
       <div class="absolute inset-0 ring-1 ring-inset ring-white/15 pointer-events-none" />
       <span class="absolute bottom-1 left-1/2 -translate-x-1/2 rounded bg-black/50 px-1.5 py-0.5 text-[10px] text-white/80 pointer-events-none">
         Drag to reposition

--- a/test/EventHero.nuxt.test.ts
+++ b/test/EventHero.nuxt.test.ts
@@ -21,19 +21,18 @@ describe('EventHero', () => {
     expect(w.text()).toContain('Dazed and Confused')
   })
 
-  it('renders the poster as an image when a backdrop is provided', async () => {
+  it('renders the poster as a contained image (whole image visible)', async () => {
     const w = await mountSuspended(EventHero, { props: { event: baseEvent, backdrop: 'https://img/poster.jpg' } })
-    const img = w.find('img')
-    expect(img.exists()).toBe(true)
-    expect(img.attributes('src')).toBe('https://img/poster.jpg')
-    expect(img.classes()).toContain('object-cover')
+    const poster = w.findAll('img').find(i => i.classes().includes('object-contain'))
+    expect(poster?.attributes('src')).toBe('https://img/poster.jpg')
   })
 
   it('applies the event poster_display (ratio, focal point, zoom) to the header', async () => {
     const event = { ...baseEvent, poster_display: { ratio: 'tall', posX: 20, posY: 80, zoom: 1.5 } }
     const w = await mountSuspended(EventHero, { props: { event, backdrop: 'https://img/p.jpg' } })
     expect(w.find('button').attributes('style') ?? '').toContain('aspect-ratio: 4 / 3')
-    const style = w.find('img').attributes('style') ?? ''
+    const poster = w.findAll('img').find(i => i.classes().includes('object-contain'))
+    const style = poster?.attributes('style') ?? ''
     expect(style).toContain('object-position: 20% 80%')
     expect(style).toContain('scale(1.5)')
   })


### PR DESCRIPTION
Addresses several poster issues:

1. **Zoom out now reveals more of the poster.** The header/editor used `object-cover`, so zooming out just shrank the *same crop* and added black. Switched to **`object-contain`** — zoom out shows the whole poster, zoom in crops. A **blurred fill** sits behind so the letterbox area is a soft backdrop instead of black bars. (EventHero + the PosterAdjuster preview match, so it stays WYSIWYG.)
2. **Mobile header text no longer clips.** The title block was `absolute bottom-0`, so it couldn't grow the header — long titles + the address + weather overflowed on narrow screens. The header is now `flex flex-col justify-end` with the text in normal flow, so it grows to fit (with the aspect ratio / min-height as a floor).
3. **Event pop-up shows the whole poster.** `EventInfoModal` used `object-cover` (cropped); now `object-contain` (scaled to fit).

## Test
EventHero/PosterAdjuster tests updated to target the contained poster; full suite green, lint + typecheck clean. Manual: drag/zoom in the editor (zoom out → whole poster), check the overview header on mobile (text fits), open the event pop-up (whole poster).

> Still open: responsive/multiple-resolution poster images for mobile — that's a separate, bigger change (see my note).