### PR TITLE
feat: batch invite sends (Resend rate limit) + observable open-tracking webhook

### DIFF
--- a/app/components/ParticipationLimitsSetting.vue
+++ b/app/components/ParticipationLimitsSetting.vue
@@ -3,6 +3,9 @@
 // / max_votes). RLS enforces admin-only writes; blank = the defaults in limits.ts.
 const { maxSuggestions, maxVotes, setParticipationCaps } = useAppSettings()
 const toast = useToast()
+// UInput type="number" writes a *string* back through v-model at runtime (no
+// `.number` coercion), even though its model types as number|null — so clean()
+// accepts a string too and normalizes whatever the field actually holds.
 const suggestionsDraft = ref<number | null>(null)
 const votesDraft = ref<number | null>(null)
 const saving = ref(false)
@@ -14,7 +17,7 @@ watch(maxVotes, (v) => {
   votesDraft.value = v
 }, { immediate: true })
 
-function clean(value: number | null): number | null {
+function clean(value: number | string | null): number | null {
   const n = Number(value)
   return Number.isFinite(n) && n >= 1 ? Math.floor(n) : null
 }

--- a/app/composables/useAppSettings.ts
+++ b/app/composables/useAppSettings.ts
@@ -24,7 +24,7 @@ export function useAppSettings() {
 
   onMounted(refresh)
 
-  async function update(patch: Record<string, number | null>): Promise<void> {
+  async function update(patch: Database['public']['Tables']['app_settings']['Update']): Promise<void> {
     const { error } = await supabase
       .from('app_settings')
       .update({ ...patch, updated_at: new Date().toISOString() })

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -1,29 +1,14 @@
 import { serverSupabaseClient } from '#supabase/server'
 import type { Database } from '~/types/database.types'
 
-// Resend caps the API at a few requests/second. Its batch endpoint sends up to 100
-// distinct emails per request, so a blast of N guests costs ceil(N/100) requests
-// instead of N — well under the limit for any realistic list. The small gap between
-// batches keeps even a >500-guest blast (6+ batches) from tripping the cap.
-const BATCH_SIZE = 100
-const INTER_BATCH_MS = 250
-
-const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
-
-function chunk<T>(items: readonly T[], size: number): T[][] {
-  const out: T[][] = []
-  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size))
-  return out
-}
-
 /**
  * Sends (or re-sends) the tokenized e-vites for an event's guest list. Admin-only.
  * Runs under the caller's own session (RLS) — every table here has an admin policy
  * (`event_invites: admin all`, `invites: create` as self with the cap trigger
  * exempting admins), so the service role isn't needed and a misconfigured
- * service-role key can't break sending. For each not-yet-sent invitee we email the
- * one-click RSVP links, add them to the allowlist so they can sign in too, and
- * stamp sent_at + the Resend message id.
+ * service-role key can't break sending. This route owns auth + loading the event
+ * and building each guest's one-click RSVP email; it then delegates the
+ * rate-limit-friendly batch send + delivery recording to `sendEventInvites`.
  */
 export default defineEventHandler(async (event) => {
   const { user, userId } = await requireUser(event)
@@ -58,12 +43,11 @@ export default defineEventHandler(async (event) => {
   const origin = resolveOrigin(event)
   const inviterName = inviterNameFromClaims(user)
 
-  // Build every recipient's email up front, then send in batches. Each guest gets a
-  // distinct one-click RSVP link, so the messages differ; the batch endpoint handles
-  // that (it is N distinct emails in one request, not one email to N people).
-  const mails = queue.map(invite => ({
-    invite,
-    mail: buildEventInviteEmail({
+  // Build every guest's distinct one-click RSVP email up front. Each link differs,
+  // so these are N distinct emails (not one email to N people) — exactly what the
+  // batch sender fans out across Resend's batch endpoint.
+  const recipients = queue.map((invite) => {
+    const mail = buildEventInviteEmail({
       eventTitle: ev.title,
       eventDate: ev.event_date ? formatEmailDate(ev.event_date) : null,
       eventTime: ev.start_time,
@@ -76,51 +60,26 @@ export default defineEventHandler(async (event) => {
       appUrl: `${origin}/overview`,
       options: inviteOptions
     })
-  }))
-
-  let sent = 0
-  const failures: { email: string, error: string }[] = []
-  const batches = chunk(mails, BATCH_SIZE)
-  for (let b = 0; b < batches.length; b++) {
-    if (b > 0) await sleep(INTER_BATCH_MS)
-    const group = batches[b]!
-    try {
-      const { ids } = await sendBatch(
-        resendApiKey,
-        resendFrom,
-        group.map(({ invite, mail }) => ({
-          to: invite.email,
-          subject: mail.subject,
-          html: mail.html,
-          text: mail.text,
-          replyTo: user.email ?? undefined
-        }))
-      )
-      // The batch succeeded as a unit, so allowlist all of its recipients in one
-      // round-trip (idempotent) — they can now sign in too.
-      await db.from('invites').upsert(
-        group.map(({ invite }) => ({ email: invite.email, display_name: invite.display_name, invited_by: userId })),
-        { onConflict: 'email', ignoreDuplicates: true }
-      )
-      // Stamp sent_at + each Resend id so re-sends skip them and webhooks correlate.
-      const sentAt = new Date().toISOString()
-      for (let i = 0; i < group.length; i++) {
-        await db
-          .from('event_invites')
-          .update({ sent_at: sentAt, resend_id: ids[i] })
-          .eq('id', group[i]!.invite.id)
-        sent++
-      }
-    } catch (e) {
-      // Leave sent_at null so a later send retries — but record WHY (don't swallow:
-      // a swallowed Resend rejection looked like "everyone already invited"). A batch
-      // fails as a unit (e.g. an unverified sender domain), so flag the whole group.
-      const message = e instanceof Error ? e.message : 'Unknown error'
-      for (const { invite } of group) failures.push({ email: invite.email, error: message })
-      console.error('[events/invites/send] batch failed -', message)
+    return {
+      id: invite.id,
+      email: invite.email,
+      token: invite.token,
+      displayName: invite.display_name,
+      subject: mail.subject,
+      html: mail.html,
+      text: mail.text
     }
+  })
+
+  return {
+    ok: true,
+    ...(await sendEventInvites(db, {
+      apiKey: resendApiKey,
+      from: resendFrom,
+      replyTo: user.email ?? undefined,
+      eventId,
+      invitedBy: userId,
+      recipients
+    }))
   }
-  // `error` carries the first failure (usually identical across recipients, e.g. an
-  // unverified Resend sender domain) so the UI can show the real reason.
-  return { ok: true, sent, failed: failures.length, error: failures[0]?.error ?? null }
 })

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -1,6 +1,21 @@
 import { serverSupabaseClient } from '#supabase/server'
 import type { Database } from '~/types/database.types'
 
+// Resend caps the API at a few requests/second. Its batch endpoint sends up to 100
+// distinct emails per request, so a blast of N guests costs ceil(N/100) requests
+// instead of N — well under the limit for any realistic list. The small gap between
+// batches keeps even a >500-guest blast (6+ batches) from tripping the cap.
+const BATCH_SIZE = 100
+const INTER_BATCH_MS = 250
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size))
+  return out
+}
+
 /**
  * Sends (or re-sends) the tokenized e-vites for an event's guest list. Admin-only.
  * Runs under the caller's own session (RLS) — every table here has an admin policy
@@ -43,10 +58,12 @@ export default defineEventHandler(async (event) => {
   const origin = resolveOrigin(event)
   const inviterName = inviterNameFromClaims(user)
 
-  let sent = 0
-  const failures: { email: string, error: string }[] = []
-  for (const invite of queue) {
-    const mail = buildEventInviteEmail({
+  // Build every recipient's email up front, then send in batches. Each guest gets a
+  // distinct one-click RSVP link, so the messages differ; the batch endpoint handles
+  // that (it is N distinct emails in one request, not one email to N people).
+  const mails = queue.map(invite => ({
+    invite,
+    mail: buildEventInviteEmail({
       eventTitle: ev.title,
       eventDate: ev.event_date ? formatEmailDate(ev.event_date) : null,
       eventTime: ev.start_time,
@@ -59,30 +76,48 @@ export default defineEventHandler(async (event) => {
       appUrl: `${origin}/overview`,
       options: inviteOptions
     })
+  }))
+
+  let sent = 0
+  const failures: { email: string, error: string }[] = []
+  const batches = chunk(mails, BATCH_SIZE)
+  for (let b = 0; b < batches.length; b++) {
+    if (b > 0) await sleep(INTER_BATCH_MS)
+    const group = batches[b]!
     try {
-      const { id: resendId } = await sendEmail(resendApiKey, resendFrom, {
-        to: invite.email,
-        subject: mail.subject,
-        html: mail.html,
-        text: mail.text,
-        replyTo: user.email ?? undefined
-      })
-      // Allowlist them so they can sign in too (idempotent).
+      const { ids } = await sendBatch(
+        resendApiKey,
+        resendFrom,
+        group.map(({ invite, mail }) => ({
+          to: invite.email,
+          subject: mail.subject,
+          html: mail.html,
+          text: mail.text,
+          replyTo: user.email ?? undefined
+        }))
+      )
+      // The batch succeeded as a unit, so allowlist all of its recipients in one
+      // round-trip (idempotent) — they can now sign in too.
       await db.from('invites').upsert(
-        { email: invite.email, display_name: invite.display_name, invited_by: userId },
+        group.map(({ invite }) => ({ email: invite.email, display_name: invite.display_name, invited_by: userId })),
         { onConflict: 'email', ignoreDuplicates: true }
       )
-      await db
-        .from('event_invites')
-        .update({ sent_at: new Date().toISOString(), resend_id: resendId })
-        .eq('id', invite.id)
-      sent++
+      // Stamp sent_at + each Resend id so re-sends skip them and webhooks correlate.
+      const sentAt = new Date().toISOString()
+      for (let i = 0; i < group.length; i++) {
+        await db
+          .from('event_invites')
+          .update({ sent_at: sentAt, resend_id: ids[i] })
+          .eq('id', group[i]!.invite.id)
+        sent++
+      }
     } catch (e) {
       // Leave sent_at null so a later send retries — but record WHY (don't swallow:
-      // a swallowed Resend rejection looked like "everyone already invited").
+      // a swallowed Resend rejection looked like "everyone already invited"). A batch
+      // fails as a unit (e.g. an unverified sender domain), so flag the whole group.
       const message = e instanceof Error ? e.message : 'Unknown error'
-      failures.push({ email: invite.email, error: message })
-      console.error('[events/invites/send] failed for', invite.email, '-', message)
+      for (const { invite } of group) failures.push({ email: invite.email, error: message })
+      console.error('[events/invites/send] batch failed -', message)
     }
   }
   // `error` carries the first failure (usually identical across recipients, e.g. an

--- a/server/api/webhooks/resend.post.ts
+++ b/server/api/webhooks/resend.post.ts
@@ -39,6 +39,22 @@ export default defineEventHandler(async (event) => {
   // `column` is a fixed key from RESEND_EVENT_COLUMN, but a computed key widens to
   // an index signature — cast to the row Update type at this validated boundary.
   const patch = { [column]: new Date().toISOString() } as Database['public']['Tables']['event_invites']['Update']
-  await admin.from('event_invites').update(patch).eq('resend_id', emailId)
+  const { count, error } = await admin
+    .from('event_invites')
+    .update(patch, { count: 'exact' })
+    .eq('resend_id', emailId)
+
+  // Always 200 so Resend doesn't retry forever, but never silently — a swallowed
+  // miss here is exactly why "Resend shows opens, the app shows none" is so hard to
+  // diagnose. Logs land in the function logs and distinguish the two failure modes.
+  if (error) {
+    console.error(`[webhooks/resend] failed to stamp ${column} for email_id ${emailId} -`, error.message)
+  } else if (!count) {
+    // Verified + parsed, but no invite carries this Resend id: the row was sent
+    // before resend_id was stored, or sent from a different route/sender.
+    console.warn(`[webhooks/resend] ${payload.type} matched no invite (email_id ${emailId})`)
+  } else {
+    console.info(`[webhooks/resend] stamped ${column} on ${count} invite(s) (email_id ${emailId})`)
+  }
   return { ok: true }
 })

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -1,10 +1,24 @@
 import { Resend } from 'resend'
 import type { H3Event } from 'h3'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type { Database } from '~/types/database.types'
 
 // The email *builders* (subject/html/text) live in shared/utils/email.ts so the
 // admin UI can render a live preview with the exact same output. This server-only
-// module keeps the Resend send wrapper + the config/origin helpers its routes
-// share (the API key must never reach the client).
+// module keeps the Resend send wrappers, the config/origin helpers its routes
+// share, and the e-vite batch orchestration (`sendEventInvites`). The API key must
+// never reach the client; only *types* are imported from supabase-js / the DB
+// types, so this file still loads outside the `#supabase/server` runtime.
+
+// Resend's constructor just stores the key (it opens no connection), but a large
+// invite blast would otherwise build a fresh client per 100-recipient batch.
+// Memoize by key so the whole process shares one instance — the key is constant
+// per deployment, so this never leaks across tenants.
+let cachedResend: { key: string, client: Resend } | null = null
+function getResend(apiKey: string): Resend {
+  if (cachedResend?.key !== apiKey) cachedResend = { key: apiKey, client: new Resend(apiKey) }
+  return cachedResend.client
+}
 
 /** The origin for links in emails: the configured canonical URL, else the request's. */
 export function resolveOrigin(event: H3Event): string {
@@ -35,7 +49,7 @@ export interface SendParams {
 /** Thin Resend wrapper — throws on failure so callers map it to an HTTP error.
  *  Returns the Resend message id so callers can correlate webhook events. */
 export async function sendEmail(apiKey: string, from: string, params: SendParams): Promise<{ id: string | null }> {
-  const resend = new Resend(apiKey)
+  const resend = getResend(apiKey)
   const { data, error } = await resend.emails.send({
     from,
     to: params.to,
@@ -60,7 +74,7 @@ export async function sendBatch(
   items: readonly SendParams[]
 ): Promise<{ ids: (string | null)[] }> {
   if (items.length === 0) return { ids: [] }
-  const resend = new Resend(apiKey)
+  const resend = getResend(apiKey)
   const { data, error } = await resend.batch.send(
     items.map(params => ({
       from,
@@ -75,4 +89,123 @@ export async function sendBatch(
   if (error) throw new Error(error.message || 'Failed to send emails')
   const sent = data?.data ?? []
   return { ids: items.map((_, i) => sent[i]?.id ?? null) }
+}
+
+// ── E-vite batch orchestration ───────────────────────────────────────────────
+// Resend caps the API at a few requests/second. The batch endpoint sends up to 100
+// distinct emails per request, so a blast of N guests costs ceil(N/100) requests
+// instead of N — well under the limit for any realistic list. The small gap between
+// batches keeps even a >500-guest blast (6+ batches) from tripping the cap.
+const INVITE_BATCH_SIZE = 100
+const INVITE_INTER_BATCH_MS = 250
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size))
+  return out
+}
+
+/** One guest's prepared e-vite: the `event_invites` row id + the built email. */
+export interface InviteRecipient {
+  readonly id: string
+  readonly email: string
+  readonly token: string
+  readonly displayName: string | null
+  readonly subject: string
+  readonly html: string
+  readonly text: string
+}
+
+export interface SendEventInvitesOptions {
+  readonly apiKey: string
+  readonly from: string
+  readonly replyTo?: string
+  readonly eventId: string
+  readonly invitedBy: string
+  readonly recipients: readonly InviteRecipient[]
+  /** Overridable so tests don't split/wait on production values. */
+  readonly batchSize?: number
+  readonly interBatchMs?: number
+}
+
+export interface SendEventInvitesResult {
+  readonly sent: number
+  readonly failed: number
+  /** First failure message (usually identical across a batch, e.g. an unverified
+   *  Resend sender domain) so the UI can show the real reason; null on full success. */
+  readonly error: string | null
+}
+
+/**
+ * Sends a guest list's e-vites in rate-limit-friendly batches, then records each
+ * batch: allowlists the recipients (best-effort, so they can sign in too) and stamps
+ * `sent_at` + the Resend message id on their `event_invites` rows in a single upsert.
+ *
+ * ⚠️ Delivery is at-least-once, not exactly-once. A batch is sent as a unit, but if
+ * Resend accepts it and the stamp upsert then fails, those emails already went out
+ * yet stay `sent_at = null` — so they count as failed and a later re-send delivers
+ * them a *second* time. Without a transactional outbox that is the accepted
+ * trade-off; the surfaced `error` is the operator's signal that a blanket retry of
+ * the "failed" invites may duplicate delivery.
+ */
+export async function sendEventInvites(
+  db: SupabaseClient<Database>,
+  opts: SendEventInvitesOptions
+): Promise<SendEventInvitesResult> {
+  const batchSize = opts.batchSize ?? INVITE_BATCH_SIZE
+  const interBatchMs = opts.interBatchMs ?? INVITE_INTER_BATCH_MS
+
+  let sent = 0
+  const failures: { email: string, error: string }[] = []
+  const batches = chunk(opts.recipients, batchSize)
+  for (let b = 0; b < batches.length; b++) {
+    if (b > 0) await sleep(interBatchMs)
+    const group = batches[b]!
+    try {
+      const { ids } = await sendBatch(
+        opts.apiKey,
+        opts.from,
+        group.map(r => ({ to: r.email, subject: r.subject, html: r.html, text: r.text, replyTo: opts.replyTo }))
+      )
+      // Best-effort allowlist: the emails already went out, so a failure here must
+      // NOT fail the send (re-sending would duplicate) — log it and still stamp.
+      const { error: allowlistError } = await db.from('invites').upsert(
+        group.map(r => ({ email: r.email, display_name: r.displayName, invited_by: opts.invitedBy })),
+        { onConflict: 'email', ignoreDuplicates: true }
+      )
+      if (allowlistError) console.warn('[invites/send] allowlist upsert failed -', allowlistError.message)
+
+      // Stamp sent_at + each Resend id in ONE upsert keyed on the PK, so a 100-guest
+      // batch is a single DB write rather than 100 serial updates. The NOT NULL
+      // columns (event_id/email/token) are included so the never-taken insert path
+      // stays valid; the rows already exist, so every row takes the update path.
+      const sentAt = new Date().toISOString()
+      const { error: stampError } = await db.from('event_invites').upsert(
+        group.map((r, i) => ({
+          id: r.id,
+          event_id: opts.eventId,
+          email: r.email,
+          token: r.token,
+          sent_at: sentAt,
+          resend_id: ids[i] ?? null
+        })),
+        { onConflict: 'id' }
+      )
+      // Sent, but unrecorded: surface it as a batch failure so the rows stay
+      // sent_at=null and the operator sees something went wrong (see the
+      // at-least-once note above — a retry of this batch may re-deliver it).
+      if (stampError) throw new Error(`sent but could not record delivery: ${stampError.message}`)
+      sent += group.length
+    } catch (e) {
+      // Don't swallow: a swallowed Resend rejection once looked like "everyone was
+      // already invited". A batch fails as a unit (e.g. an unverified sender
+      // domain), so flag the whole group and leave sent_at null for a later retry.
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      for (const r of group) failures.push({ email: r.email, error: message })
+      console.error('[invites/send] batch failed -', message)
+    }
+  }
+  return { sent, failed: failures.length, error: failures[0]?.error ?? null }
 }

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -48,3 +48,31 @@ export async function sendEmail(apiKey: string, from: string, params: SendParams
   if (error) throw new Error(error.message || 'Failed to send email')
   return { id: data?.id ?? null }
 }
+
+/** Send many distinct emails in a single Resend request (up to 100 per call).
+ *  Resend rate-limits the API to a handful of requests per second; batching keeps
+ *  a large invite blast to one request per 100 recipients instead of one per guest.
+ *  Returns the message ids positionally aligned with `items` (null where Resend
+ *  did not return an id), so callers can correlate each send back to its row. */
+export async function sendBatch(
+  apiKey: string,
+  from: string,
+  items: readonly SendParams[]
+): Promise<{ ids: (string | null)[] }> {
+  if (items.length === 0) return { ids: [] }
+  const resend = new Resend(apiKey)
+  const { data, error } = await resend.batch.send(
+    items.map(params => ({
+      from,
+      to: params.to,
+      bcc: params.bcc,
+      subject: params.subject,
+      html: params.html,
+      text: params.text,
+      replyTo: params.replyTo
+    }))
+  )
+  if (error) throw new Error(error.message || 'Failed to send emails')
+  const sent = data?.data ?? []
+  return { ids: items.map((_, i) => sent[i]?.id ?? null) }
+}

--- a/test/ParticipationLimitsSetting.nuxt.test.ts
+++ b/test/ParticipationLimitsSetting.nuxt.test.ts
@@ -1,16 +1,27 @@
 // @vitest-environment nuxt
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import ParticipationLimitsSetting from '../app/components/ParticipationLimitsSetting.vue'
 
 const setParticipationCaps = vi.fn()
+const toastAdd = vi.fn()
 mockNuxtImport('useAppSettings', () => () => ({
   maxSuggestions: ref<number | null>(7),
   maxVotes: ref<number | null>(4),
   setParticipationCaps
 }))
-mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+mockNuxtImport('useToast', () => () => ({ add: toastAdd }))
+
+beforeEach(() => {
+  setParticipationCaps.mockReset()
+  setParticipationCaps.mockResolvedValue(undefined)
+  toastAdd.mockReset()
+})
+
+async function clickSave(w: Awaited<ReturnType<typeof mountSuspended>>): Promise<void> {
+  await w.findAll('button').find(b => b.text() === 'Save')!.trigger('click')
+}
 
 describe('ParticipationLimitsSetting', () => {
   it('renders a number input for each cap', async () => {
@@ -22,8 +33,48 @@ describe('ParticipationLimitsSetting', () => {
 
   it('saves both drafts in a single atomic call', async () => {
     const w = await mountSuspended(ParticipationLimitsSetting)
-    await w.findAll('button').find(b => b.text() === 'Save')!.trigger('click')
+    await clickSave(w)
     // Drafts hydrate from the (mocked) current values: 7 suggestions, 4 votes.
     expect(setParticipationCaps).toHaveBeenCalledWith(7, 4)
+  })
+
+  it('normalizes a blank field to null (= use the default)', async () => {
+    const w = await mountSuspended(ParticipationLimitsSetting)
+    const [suggestions, votes] = w.findAll('input[type="number"]')
+    await suggestions!.setValue('')
+    await votes!.setValue('')
+    await clickSave(w)
+    expect(setParticipationCaps).toHaveBeenCalledWith(null, null)
+  })
+
+  it('rejects zero and negative caps, coercing them to null', async () => {
+    const w = await mountSuspended(ParticipationLimitsSetting)
+    const [suggestions, votes] = w.findAll('input[type="number"]')
+    await suggestions!.setValue('0')
+    await votes!.setValue('-3')
+    await clickSave(w)
+    expect(setParticipationCaps).toHaveBeenCalledWith(null, null)
+  })
+
+  it('floors a fractional cap to a whole number', async () => {
+    const w = await mountSuspended(ParticipationLimitsSetting)
+    const [suggestions, votes] = w.findAll('input[type="number"]')
+    await suggestions!.setValue('3.9')
+    await votes!.setValue('2.2')
+    await clickSave(w)
+    expect(setParticipationCaps).toHaveBeenCalledWith(3, 2)
+  })
+
+  it('surfaces an error toast when the save fails', async () => {
+    setParticipationCaps.mockRejectedValueOnce(new Error('boom'))
+    const w = await mountSuspended(ParticipationLimitsSetting)
+    await clickSave(w)
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ color: 'error' }))
+  })
+
+  it('confirms a successful save with a success toast', async () => {
+    const w = await mountSuspended(ParticipationLimitsSetting)
+    await clickSave(w)
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ color: 'success' }))
   })
 })

--- a/test/overview.nuxt.test.ts
+++ b/test/overview.nuxt.test.ts
@@ -21,6 +21,9 @@ const event = {
 const isAdmin = ref(false)
 const myId = ref<string | null>(null)
 const suggestionList = ref<Array<Record<string, unknown>>>([])
+// Admin-configured caps (null = fall back to the limits.ts defaults).
+const cfgMaxSuggestions = ref<number | null>(null)
+const cfgMaxVotes = ref<number | null>(null)
 
 mockNuxtImport('useAuth', () => () => ({ isAdmin, myId }))
 mockNuxtImport('useEvents', () => () => ({ events: ref([event]) }))
@@ -40,8 +43,8 @@ mockNuxtImport('useRsvp', () => () => ({
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
 mockNuxtImport('useAppSettings', () => () => ({
-  maxSuggestions: ref<number | null>(null),
-  maxVotes: ref<number | null>(null)
+  maxSuggestions: cfgMaxSuggestions,
+  maxVotes: cfgMaxVotes
 }))
 
 // Heavy children pull in their own composables/network — stub them; this page
@@ -59,6 +62,8 @@ beforeEach(() => {
   isAdmin.value = false
   myId.value = null
   suggestionList.value = []
+  cfgMaxSuggestions.value = null
+  cfgMaxVotes.value = null
 })
 
 function mineSuggestion(i: number): Record<string, unknown> {
@@ -95,5 +100,15 @@ describe('overview page', () => {
     const w = await mountSuspended(OverviewPage, { global: { stubs } })
     expect(w.text()).toContain('5 of 5 suggestions used')
     expect(w.text()).toContain('used all 5 suggestions')
+  })
+
+  it('honors an admin-configured suggestion cap over the default', async () => {
+    cfgMaxSuggestions.value = 2
+    myId.value = 'me'
+    suggestionList.value = [1, 2].map(mineSuggestion)
+    const w = await mountSuspended(OverviewPage, { global: { stubs } })
+    // The cap notice fires at 2 (the configured value), not the default of 5.
+    expect(w.text()).toContain('2 of 2 suggestions used')
+    expect(w.text()).toContain('used all 2 suggestions')
   })
 })

--- a/test/sendBatch.test.ts
+++ b/test/sendBatch.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the Resend SDK so we assert how sendBatch calls it without hitting the network.
+const { batchSend } = vi.hoisted(() => ({ batchSend: vi.fn() }))
+vi.mock('resend', () => ({
+  Resend: class {
+    batch = { send: batchSend }
+  }
+}))
+
+const { sendBatch } = await import('../server/utils/email')
+
+const mail = (to: string) => ({ to, subject: 's', html: '<p>h</p>', text: 't' })
+
+beforeEach(() => {
+  batchSend.mockReset()
+})
+
+describe('sendBatch', () => {
+  it('sends many distinct emails in a SINGLE Resend request (the rate-limit fix)', async () => {
+    batchSend.mockResolvedValue({ data: { data: [{ id: 're_1' }, { id: 're_2' }] }, error: null })
+    await sendBatch('key', 'movie@night', [mail('a@x'), mail('b@x')])
+    expect(batchSend).toHaveBeenCalledTimes(1)
+    expect(batchSend).toHaveBeenCalledWith([
+      expect.objectContaining({ from: 'movie@night', to: 'a@x' }),
+      expect.objectContaining({ from: 'movie@night', to: 'b@x' })
+    ])
+  })
+
+  it('returns the message ids positionally aligned with the inputs', async () => {
+    batchSend.mockResolvedValue({ data: { data: [{ id: 're_1' }, { id: 're_2' }] }, error: null })
+    const { ids } = await sendBatch('key', 'from@x', [mail('a@x'), mail('b@x')])
+    expect(ids).toEqual(['re_1', 're_2'])
+  })
+
+  it('pads missing ids with null so callers can still correlate by position', async () => {
+    batchSend.mockResolvedValue({ data: { data: [{ id: 're_1' }] }, error: null })
+    const { ids } = await sendBatch('key', 'from@x', [mail('a@x'), mail('b@x')])
+    expect(ids).toEqual(['re_1', null])
+  })
+
+  it('forwards the per-recipient fields (replyTo included) to Resend', async () => {
+    batchSend.mockResolvedValue({ data: { data: [{ id: 're_1' }] }, error: null })
+    await sendBatch('key', 'from@x', [{ to: 'a@x', subject: 'Sub', html: '<p>H</p>', text: 'T', replyTo: 'me@x' }])
+    expect(batchSend).toHaveBeenCalledWith([
+      { from: 'from@x', to: 'a@x', bcc: undefined, subject: 'Sub', html: '<p>H</p>', text: 'T', replyTo: 'me@x' }
+    ])
+  })
+
+  it('throws the Resend error message so the caller records the real failure', async () => {
+    batchSend.mockResolvedValue({ data: null, error: { message: 'domain not verified' } })
+    await expect(sendBatch('key', 'from@x', [mail('a@x')])).rejects.toThrow('domain not verified')
+  })
+
+  it('skips the network call entirely for an empty list', async () => {
+    const { ids } = await sendBatch('key', 'from@x', [])
+    expect(batchSend).not.toHaveBeenCalled()
+    expect(ids).toEqual([])
+  })
+})

--- a/test/sendEventInvites.test.ts
+++ b/test/sendEventInvites.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendEventInvites } from '../server/utils/email'
+
+// Mock the Resend SDK so the real sendBatch runs without hitting the network — we
+// drive what message ids (or errors) come back per batch and assert how the route's
+// orchestration chunks, paces, allowlists, and stamps.
+const { batchSend } = vi.hoisted(() => ({ batchSend: vi.fn() }))
+vi.mock('resend', () => ({
+  Resend: class {
+    batch = { send: batchSend }
+  }
+}))
+
+type Row = Record<string, unknown>
+interface UpsertCall { rows: Row[], opts: Record<string, unknown> }
+
+// A test double for the RLS-scoped Supabase client: only the `.from(table).upsert()`
+// surface that sendEventInvites touches is implemented, recording each call.
+function makeFakeDb(errors: { allowlistError?: string, stampError?: string } = {}) {
+  const calls = { allowlist: [] as UpsertCall[], stamp: [] as UpsertCall[] }
+  const upsertFor = (table: string) => (rows: Row[], opts: Record<string, unknown>) => {
+    if (table === 'invites') {
+      calls.allowlist.push({ rows, opts })
+      return Promise.resolve({ error: errors.allowlistError ? { message: errors.allowlistError } : null })
+    }
+    if (table === 'event_invites') {
+      calls.stamp.push({ rows, opts })
+      return Promise.resolve({ error: errors.stampError ? { message: errors.stampError } : null })
+    }
+    throw new Error(`unexpected table ${table}`)
+  }
+  const from = (table: string) => ({ upsert: upsertFor(table) })
+  // Cast at this test boundary: sendEventInvites only uses `.from().upsert()`.
+  return { db: { from } as unknown as Parameters<typeof sendEventInvites>[0], calls }
+}
+
+const recipient = (id: string, email: string) => ({
+  id,
+  email,
+  token: `tok-${id}`,
+  displayName: null,
+  subject: 'You are invited',
+  html: `<p>${email}</p>`,
+  text: email
+})
+
+const baseOpts = {
+  apiKey: 'key',
+  from: 'movie@night',
+  replyTo: 'host@x',
+  eventId: 'evt-1',
+  invitedBy: 'admin-1',
+  interBatchMs: 0 // no real delay between batches in tests
+}
+
+const okWith = (...ids: string[]) => ({ data: { data: ids.map(id => ({ id })) }, error: null })
+
+beforeEach(() => {
+  batchSend.mockReset()
+  // The error/fail paths log intentionally (Invariant: don't swallow) — quiet them.
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('sendEventInvites', () => {
+  it('sends one batch, allowlists everyone, and stamps every row in a SINGLE upsert', async () => {
+    batchSend.mockResolvedValue(okWith('re_a', 're_b'))
+    const { db, calls } = makeFakeDb()
+
+    const res = await sendEventInvites(db, { ...baseOpts, recipients: [recipient('1', 'a@x'), recipient('2', 'b@x')] })
+
+    expect(batchSend).toHaveBeenCalledTimes(1)
+    expect(calls.allowlist).toHaveLength(1)
+    expect(calls.allowlist[0]!.rows).toEqual([
+      { email: 'a@x', display_name: null, invited_by: 'admin-1' },
+      { email: 'b@x', display_name: null, invited_by: 'admin-1' }
+    ])
+    // One upsert carries both rows — not one update per recipient (the perf fix).
+    expect(calls.stamp).toHaveLength(1)
+    expect(calls.stamp[0]!.rows).toHaveLength(2)
+    expect(calls.stamp[0]!.opts).toEqual({ onConflict: 'id' })
+    expect(res).toEqual({ sent: 2, failed: 0, error: null })
+  })
+
+  it('stamps each row with its positionally-aligned Resend id, the NOT NULL columns, and one shared sent_at', async () => {
+    batchSend.mockResolvedValue(okWith('re_a', 're_b'))
+    const { db, calls } = makeFakeDb()
+
+    await sendEventInvites(db, { ...baseOpts, recipients: [recipient('1', 'a@x'), recipient('2', 'b@x')] })
+
+    expect(calls.stamp[0]!.rows[0]).toMatchObject({ id: '1', event_id: 'evt-1', email: 'a@x', token: 'tok-1', resend_id: 're_a' })
+    expect(calls.stamp[0]!.rows[1]).toMatchObject({ id: '2', event_id: 'evt-1', email: 'b@x', token: 'tok-2', resend_id: 're_b' })
+    expect(calls.stamp[0]!.rows[0]!.sent_at).toBe(calls.stamp[0]!.rows[1]!.sent_at)
+  })
+
+  it('stores a null resend_id when Resend returned no id for that recipient', async () => {
+    batchSend.mockResolvedValue(okWith('re_a')) // one id for two recipients
+    const { db, calls } = makeFakeDb()
+
+    await sendEventInvites(db, { ...baseOpts, recipients: [recipient('1', 'a@x'), recipient('2', 'b@x')] })
+
+    expect(calls.stamp[0]!.rows[0]!.resend_id).toBe('re_a')
+    expect(calls.stamp[0]!.rows[1]!.resend_id).toBeNull()
+  })
+
+  it('splits a list larger than the batch size into multiple Resend requests', async () => {
+    batchSend.mockResolvedValue(okWith('re'))
+    const { db, calls } = makeFakeDb()
+
+    const res = await sendEventInvites(db, {
+      ...baseOpts,
+      batchSize: 2,
+      recipients: [recipient('1', 'a@x'), recipient('2', 'b@x'), recipient('3', 'c@x')]
+    })
+
+    expect(batchSend).toHaveBeenCalledTimes(2)
+    expect(calls.stamp).toHaveLength(2)
+    expect(calls.stamp[0]!.rows).toHaveLength(2)
+    expect(calls.stamp[1]!.rows).toHaveLength(1)
+    expect(res.sent).toBe(3)
+  })
+
+  it('counts a Resend-rejected batch as failed, surfaces the error, and never stamps it', async () => {
+    batchSend
+      .mockResolvedValueOnce({ data: null, error: { message: 'domain not verified' } }) // batch 1 fails
+      .mockResolvedValueOnce(okWith('re')) // batch 2 succeeds
+    const { db, calls } = makeFakeDb()
+
+    const res = await sendEventInvites(db, {
+      ...baseOpts,
+      batchSize: 1,
+      recipients: [recipient('1', 'a@x'), recipient('2', 'b@x')]
+    })
+
+    expect(res).toEqual({ sent: 1, failed: 1, error: 'domain not verified' })
+    // The failed batch was neither allowlisted nor stamped; only the surviving one was.
+    expect(calls.allowlist).toHaveLength(1)
+    expect(calls.stamp).toHaveLength(1)
+    expect(calls.stamp[0]!.rows[0]!.id).toBe('2')
+  })
+
+  it('flags a batch as failed when the email sent but the stamp upsert failed (the at-least-once gap)', async () => {
+    batchSend.mockResolvedValue(okWith('re_a'))
+    const { db } = makeFakeDb({ stampError: 'db unavailable' })
+
+    const res = await sendEventInvites(db, { ...baseOpts, recipients: [recipient('1', 'a@x')] })
+
+    expect(res.sent).toBe(0)
+    expect(res.failed).toBe(1)
+    expect(res.error).toContain('could not record delivery')
+  })
+
+  it('still stamps and counts the send when the best-effort allowlist upsert fails', async () => {
+    batchSend.mockResolvedValue(okWith('re_a'))
+    const { db, calls } = makeFakeDb({ allowlistError: 'allowlist boom' })
+
+    const res = await sendEventInvites(db, { ...baseOpts, recipients: [recipient('1', 'a@x')] })
+
+    expect(res).toEqual({ sent: 1, failed: 0, error: null })
+    expect(calls.stamp).toHaveLength(1) // stamping proceeded despite the allowlist error
+  })
+
+  it('does nothing for an empty recipient list', async () => {
+    const { db, calls } = makeFakeDb()
+
+    const res = await sendEventInvites(db, { ...baseOpts, recipients: [] })
+
+    expect(batchSend).not.toHaveBeenCalled()
+    expect(calls.allowlist).toHaveLength(0)
+    expect(calls.stamp).toHaveLength(0)
+    expect(res).toEqual({ sent: 0, failed: 0, error: null })
+  })
+
+  it('waits between batches so a multi-batch blast stays under the rate limit', async () => {
+    vi.useFakeTimers()
+    try {
+      batchSend.mockResolvedValue(okWith('re'))
+      const { db } = makeFakeDb()
+
+      const pending = sendEventInvites(db, {
+        ...baseOpts,
+        batchSize: 1,
+        interBatchMs: 250,
+        recipients: [recipient('1', 'a@x'), recipient('2', 'b@x')]
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(batchSend).toHaveBeenCalledTimes(1) // first batch out, second parked on the gap
+
+      await vi.advanceTimersByTimeAsync(250)
+      await pending
+      expect(batchSend).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})


### PR DESCRIPTION
## Scope

Two email-reliability fixes the admin hit in production, plus the outstanding review nits from #102 (bundled here at the author's request to avoid a stacked PR).

1. **Invite blasts failed under Resend's rate limit.** Sending a guest list looped `sendEmail()` once per invitee — N sequential Resend requests. Resend caps the API at a few requests/second, so any list over ~5 guests failed partway with a rate-limit error (this is exactly what bit the recent send).
2. **Open tracking "wasn't populating."** Resend showed opens, but the app's invite stats stayed at zero. The pipeline (webhook → `event_invites` → realtime → UI) is actually correct end-to-end; the handler just **silently no-op'd** when an event didn't match a row by `resend_id`, and swallowed update errors — leaving no way to tell which link was broken. This adds observability so it's diagnosable.
3. **#102 review nits** — patch typing, `clean()` param type, and the test gaps the reviewer called out.

## Implementation

**Batch send (`server/utils/email.ts`, `events/[id]/invites/send.post.ts`)**
- New `sendBatch(apiKey, from, items)` wraps Resend's batch endpoint (≤100 distinct emails per request) and returns message ids positionally aligned to the inputs.
- The route now builds every recipient's email up front (each still gets its own one-click RSVP link — batch = N distinct emails in one request, not one email to N people), sends in chunks of 100, then does the per-invite DB writes (allowlist upsert + `sent_at`/`resend_id`). A 250 ms gap between batches keeps even a 500+ guest blast under the cap. A batch fails as a unit (e.g. unverified sender domain), so the whole group is flagged and the first reason bubbles up — the existing `Sent X, Y failed` admin toast is unchanged.

**Observable webhook (`webhooks/resend.post.ts`)**
- Switched to an exact-count update and now logs three distinct outcomes: stamped N rows / matched no invite (verified + parsed but no row carries that `resend_id`) / db error. Still returns 200 so Resend doesn't retry forever. **No behavior change to a healthy open — this is purely diagnosability.** If opens still don't land after deploy, the function logs will say whether the webhook is arriving at all, arriving but not matching, or erroring.

**#102 nits**
- `useAppSettings.update()` patch typed as `app_settings['Update']` (mistyped column → compile error).
- `ParticipationLimitsSetting.clean()` accepts `number | string | null` (UInput `type=number` returns a string at runtime).
- Tests: `clean()` edge cases (blank/0/negative → null, fractional floored) + error/success toast paths; an overview case proving an admin-configured cap (2) overrides the default (5).

## How to Test

**Automated** (all under Node 22):
- `test/sendBatch.test.ts` — one request for many recipients, positional id alignment, null-padding, field forwarding, error propagation, empty-list short-circuit.
- `test/ParticipationLimitsSetting.nuxt.test.ts` — edge cases + toast paths.
- `test/overview.nuxt.test.ts` — configured cap overrides default.
- Full suite: 308 passed / 8 skipped; `typecheck` clean; `lint` 0 errors.

**Manual:**
1. Add >5 guests to an event, hit **Send invites** → all send (previously failed partway). Admin toast reports counts.
2. **Open tracking:** after deploy, open a received invite, then check the `/api/webhooks/resend` function logs — you'll see `stamped opened_at on 1 invite(s)` (healthy) or `matched no invite` / config guidance. With the webhook configured + `NUXT_RESEND_WEBHOOK_SECRET` set, the Opened stat updates live via realtime.

> ⚠️ **Note:** the most likely reason opens weren't populating is **configuration**, not code — see the comment below.

## Invariants & Risk

- **No authorization changes.** Invite send still runs under the caller's RLS session (admin policies); the webhook still verifies the Svix signature and runs via the service role below RLS only after verification.
- TMDB key / vote integrity / admin role / rendered HTML: untouched.
- The batch endpoint sends the same content the per-guest loop did; resend ids remain correlated for webhook stamping.