### PR TITLE
fix: hide who voted for what from non-admins (tally + broadcast)

### DIFF
--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -8,7 +8,8 @@ const { myId } = useAuth()
 
 const movie = computed(() => props.suggestion.tmdb_movie)
 const year = computed(() => movieYear(movie.value))
-const voteCount = computed(() => props.suggestion.votes?.length ?? 0)
+// Public count from the tally (votes.length would only see the viewer's own vote).
+const voteCount = computed(() => props.suggestion.voteCount ?? 0)
 const hasVoted = computed(() =>
   Boolean(myId.value) && (props.suggestion.votes ?? []).some(v => v.user_id === myId.value)
 )

--- a/app/components/WinnersBanner.vue
+++ b/app/components/WinnersBanner.vue
@@ -28,7 +28,7 @@ const { posterUrl } = useTmdb()
             {{ winner.tmdb_movie.title }}
           </p>
           <p class="text-xs text-muted">
-            {{ winner.votes?.length ?? 0 }} vote{{ (winner.votes?.length ?? 0) === 1 ? '' : 's' }}
+            {{ winner.voteCount ?? 0 }} vote{{ (winner.voteCount ?? 0) === 1 ? '' : 's' }}
           </p>
         </div>
       </div>

--- a/app/composables/useAdminSuggestions.ts
+++ b/app/composables/useAdminSuggestions.ts
@@ -27,13 +27,16 @@ export function useAdminSuggestions(eventId: MaybeRefOrGetter<string | null | un
         .select(SELECT)
         .eq('event_id', id)
       if (error) throw error
-      return (data ?? []) as unknown as AdminSuggestion[]
+      // Admins read every vote row (RLS), so the count is just votes.length here —
+      // mirror it into voteCount to satisfy the shared Suggestion shape.
+      return ((data ?? []) as unknown as AdminSuggestion[])
+        .map(s => ({ ...s, voteCount: s.votes?.length ?? 0 }))
     }
   })
 
   // Most-voted first for display.
   const suggestions = computed(() =>
-    [...rows.value].sort((a, b) => (b.votes?.length ?? 0) - (a.votes?.length ?? 0))
+    [...rows.value].sort((a, b) => b.voteCount - a.voteCount)
   )
 
   async function setDeleted(id: string, deleted: boolean): Promise<void> {

--- a/app/composables/useEventStats.ts
+++ b/app/composables/useEventStats.ts
@@ -25,8 +25,10 @@ export function useEventStats(eventId: MaybeRefOrGetter<string | null>) {
 
     return computeEventStats({
       // The votes embed isn't declared in the generated types, so cast as
-      // useSuggestions does (the inferred shape doesn't match).
-      suggestions: (suggestions.data ?? []) as unknown as Suggestion[],
+      // useSuggestions does (the inferred shape doesn't match). Admins read every
+      // vote (RLS), so the count is votes.length — populate voteCount to match the
+      // shared Suggestion shape (the tally RPC is only needed where reads are scoped).
+      suggestions: ((suggestions.data ?? []) as unknown as Suggestion[]).map(s => ({ ...s, voteCount: s.votes?.length ?? 0 })),
       rsvps: rsvps.data ?? [],
       bringItems: bring.data ?? []
     })

--- a/app/composables/useSuggestions.ts
+++ b/app/composables/useSuggestions.ts
@@ -1,12 +1,20 @@
 import type { MaybeRefOrGetter } from 'vue'
+import type { RealtimeChannel } from '@supabase/supabase-js'
 import type { Database } from '~/types/database.types'
 import type { Suggestion } from '#shared/types/suggestion'
 import type { TmdbMovie } from '#shared/types/movie'
 
+// Rows as they come back from the suggestions query (votes = only those the viewer
+// may read; the public count is merged in from the tally RPC below).
+type RawSuggestion = Omit<Suggestion, 'voteCount'>
+
 /**
- * Realtime suggestions for an event + the write actions. Votes are normalized
- * rows, so vote integrity is automatic: one row per (suggestion, user) via the
- * PK, and the count is just `votes.length`.
+ * Realtime suggestions for an event + the write actions. Vote *counts* come from
+ * the `suggestion_vote_counts` tally (so non-admins never read who voted — see the
+ * voter-privacy migration), while each suggestion's `votes` array carries only the
+ * viewer's own vote, enough to answer "did I vote". Because the per-vote realtime
+ * stream is no longer visible across users, live counts ride a lightweight broadcast
+ * on a shared per-event topic: whoever votes pings it, everyone re-fetches the tally.
  */
 export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefined>) {
   const supabase = useSupabaseClient<Database>()
@@ -15,22 +23,51 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
   const { data: suggestions, error, refresh } = useRealtimeQuery<Suggestion[]>({
     key: eventId,
     channel: 'suggestions',
-    tables: [{ table: 'suggestions' }, { table: 'votes', global: true }],
+    tables: [{ table: 'suggestions' }],
     empty: [],
     errorFallback: 'Failed to load suggestions',
     load: async (id) => {
-      const { data, error } = await supabase
-        .from('suggestions')
-        .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
-        .eq('event_id', id)
-        .eq('deleted', false)
-      if (error) throw error
-      return ((data ?? []) as unknown as Suggestion[]).sort((a, b) => {
-        const diff = b.votes.length - a.votes.length
-        return diff !== 0 ? diff : new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-      })
+      const [rows, counts] = await Promise.all([
+        supabase
+          .from('suggestions')
+          .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
+          .eq('event_id', id)
+          .eq('deleted', false),
+        supabase.rpc('suggestion_vote_counts', { p_event_id: id })
+      ])
+      if (rows.error) throw rows.error
+      if (counts.error) throw counts.error
+      const countById = new Map((counts.data ?? []).map(c => [c.suggestion_id, Number(c.votes)]))
+      return ((rows.data ?? []) as unknown as RawSuggestion[])
+        .map(s => ({ ...s, voteCount: countById.get(s.id) ?? 0 }))
+        .sort((a, b) => {
+          const diff = b.voteCount - a.voteCount
+          return diff !== 0 ? diff : new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        })
     }
   })
+
+  // Shared per-event topic so every viewer re-fetches the tally when anyone votes.
+  // (Counts are derived server-side; the payload carries nothing sensitive.)
+  let voteChannel: RealtimeChannel | null = null
+  watch(() => toValue(eventId), (id) => {
+    if (voteChannel) {
+      supabase.removeChannel(voteChannel)
+      voteChannel = null
+    }
+    if (!id) return
+    voteChannel = supabase
+      .channel(`votes:${id}`)
+      .on('broadcast', { event: 'changed' }, () => void refresh())
+      .subscribe()
+  }, { immediate: true })
+  onScopeDispose(() => {
+    if (voteChannel) supabase.removeChannel(voteChannel)
+  })
+
+  function notifyVoteChange(): void {
+    void voteChannel?.send({ type: 'broadcast', event: 'changed', payload: {} })
+  }
 
   function alreadySuggested(movieId: number): boolean {
     return suggestions.value.some(s => s.tmdb_movie?.id === movieId)
@@ -53,6 +90,7 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
     const { error } = await supabase.from('votes').insert({ suggestion_id: suggestion.id })
     if (error) throw error
     await refresh()
+    notifyVoteChange()
   }
 
   async function unvote(suggestion: Suggestion): Promise<void> {
@@ -61,6 +99,7 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
     const { error } = await supabase.from('votes').delete().eq('suggestion_id', suggestion.id)
     if (error) throw error
     await refresh()
+    notifyVoteChange()
   }
 
   async function removeSuggestion(suggestion: Suggestion): Promise<void> {

--- a/app/composables/useUserStats.ts
+++ b/app/composables/useUserStats.ts
@@ -39,8 +39,11 @@ export function useUserStats(userId: MaybeRefOrGetter<string | null>) {
       .in('event_id', lockedIds)
     // The votes embed isn't declared in the generated types (no FK relationship
     // row), so PostgREST's inferred shape doesn't match — cast as useSuggestions does.
+    // Admin drill-down reads every vote (RLS), so the winner count is votes.length —
+    // populate voteCount so topWinners (which counts by voteCount) lines up.
     const byEvent = new Map<string, Suggestion[]>()
-    for (const s of (pool ?? []) as unknown as Suggestion[]) {
+    for (const row of (pool ?? []) as unknown as Suggestion[]) {
+      const s = { ...row, voteCount: row.votes?.length ?? 0 }
       const list = byEvent.get(s.event_id) ?? []
       list.push(s)
       byEvent.set(s.event_id, list)

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -27,8 +27,8 @@ const { suggestions, alreadySuggested, suggest, vote, unvote, removeSuggestion }
 const { myStatus, counts, setStatus } = useRsvp(currentEventId)
 
 const suggestedMovieIds = computed(() => suggestions.value.map(s => s.tmdb_movie.id))
-const maxVotes = computed(() => Math.max(1, ...suggestions.value.map(s => s.votes?.length ?? 0)))
-const totalVotes = computed(() => suggestions.value.reduce((sum, s) => sum + (s.votes?.length ?? 0), 0))
+const maxVotes = computed(() => Math.max(1, ...suggestions.value.map(s => s.voteCount ?? 0)))
+const totalVotes = computed(() => suggestions.value.reduce((sum, s) => sum + (s.voteCount ?? 0), 0))
 // Only surface a "leader" once votes exist — before that the order is just by date.
 const leadingTitle = computed(() => (totalVotes.value > 0 ? suggestions.value[0]?.tmdb_movie.title ?? null : null))
 const leadPoster = computed(() => (totalVotes.value > 0 ? posterUrl(suggestions.value[0]?.tmdb_movie.poster_path) : null))

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -65,6 +65,7 @@ export interface Database {
       admin_set_admin: { Args: { target_id: string, value: boolean }, Returns: undefined }
       admin_set_blocked: { Args: { target_id: string, value: boolean }, Returns: undefined }
       is_allowed: { Args: Record<string, never>, Returns: boolean }
+      suggestion_vote_counts: { Args: { p_event_id: string }, Returns: { suggestion_id: string, votes: number }[] }
     }
     Enums: { [_ in never]: never }
     CompositeTypes: { [_ in never]: never }

--- a/shared/types/suggestion.ts
+++ b/shared/types/suggestion.ts
@@ -1,9 +1,15 @@
 import type { TmdbMovie } from './movie'
 
 /**
- * A suggestion as read for the overview. `votes` is the normalized vote rows for
- * the suggestion; the vote count is just `votes.length` and "did I vote" is a
- * membership check — no separate counter to drift (was Product Invariant 3).
+ * A suggestion as read for the overview.
+ *
+ * `voteCount` is the public total, served by the `suggestion_vote_counts` tally
+ * (SECURITY DEFINER) so everyone sees accurate counts without seeing identities.
+ * `votes` holds only the vote rows the current viewer is allowed to read — their
+ * own for a normal user, all of them for an admin (RLS, see the voter-privacy
+ * migration) — so it answers "did I vote" via a membership check but must NOT be
+ * used for counting. Counts come from the tally, not `votes.length`: still no
+ * stored counter to drift (Invariant 3), just no longer client-visible per voter.
  */
 export interface Suggestion {
   id: string
@@ -12,6 +18,7 @@ export interface Suggestion {
   tmdb_movie: TmdbMovie
   deleted: boolean
   created_at: string
+  voteCount: number
   votes: { user_id: string }[]
 }
 

--- a/shared/utils/eventStats.ts
+++ b/shared/utils/eventStats.ts
@@ -31,7 +31,7 @@ export function computeEventStats(input: {
   const countStatus = (status: string): number => input.rsvps.filter(r => r.status === status).length
   return {
     suggestionCount: live.length,
-    voteCount: live.reduce((n, s) => n + (s.votes?.length ?? 0), 0),
+    voteCount: live.reduce((n, s) => n + (s.voteCount ?? 0), 0),
     submitterCount: submitters.size,
     voterCount: voters.size,
     going: countStatus('going'),
@@ -39,6 +39,6 @@ export function computeEventStats(input: {
     declined: countStatus('no'),
     bringTotal: input.bringItems.length,
     bringClaimed: input.bringItems.filter(b => b.user_id !== null).length,
-    topPicks: topWinners([...live]).map(s => ({ title: s.tmdb_movie.title, votes: s.votes?.length ?? 0 }))
+    topPicks: topWinners([...live]).map(s => ({ title: s.tmdb_movie.title, votes: s.voteCount ?? 0 }))
   }
 }

--- a/shared/utils/winners.ts
+++ b/shared/utils/winners.ts
@@ -5,10 +5,10 @@ import type { Suggestion } from '#shared/types/suggestion'
  *  suggested so the result is stable. */
 export function topWinners(suggestions: Suggestion[], count = 2): Suggestion[] {
   return suggestions
-    .filter(s => !s.deleted && (s.votes?.length ?? 0) > 0)
+    .filter(s => !s.deleted && (s.voteCount ?? 0) > 0)
     .slice()
     .sort((a, b) =>
-      (b.votes?.length ?? 0) - (a.votes?.length ?? 0)
+      (b.voteCount ?? 0) - (a.voteCount ?? 0)
       || (a.created_at ?? '').localeCompare(b.created_at ?? '')
     )
     .slice(0, count)

--- a/supabase/migrations/20260626000000_voter_privacy.sql
+++ b/supabase/migrations/20260626000000_voter_privacy.sql
@@ -21,6 +21,10 @@ create policy "votes: read own or admin" on public.votes
 
 -- 2. Public per-suggestion vote counts, no voter identities. SECURITY DEFINER so it
 --    can count rows the caller can no longer read directly; only counts are returned.
+--    `auth.uid()` inside a SECURITY DEFINER body still resolves to the *caller* (it
+--    reads request.jwt.claims), so the is_allowed() gate keeps this consistent with
+--    the invite-only model: a signed-in but non-invited user gets an empty result,
+--    not a back door around RLS via a guessed event UUID.
 create or replace function public.suggestion_vote_counts(p_event_id uuid)
   returns table (suggestion_id uuid, votes bigint)
   language sql security definer stable set search_path = public as $$
@@ -28,6 +32,7 @@ create or replace function public.suggestion_vote_counts(p_event_id uuid)
   from public.votes v
   join public.suggestions s on s.id = v.suggestion_id
   where s.event_id = p_event_id and s.deleted = false
+    and public.is_allowed()
   group by v.suggestion_id
 $$;
 revoke all on function public.suggestion_vote_counts(uuid) from public;

--- a/supabase/migrations/20260626000000_voter_privacy.sql
+++ b/supabase/migrations/20260626000000_voter_privacy.sql
@@ -1,0 +1,34 @@
+-- Voter privacy — hide who voted for what from non-admins.
+--
+-- Until now `votes: read` was `using (true)`: any signed-in user could read every
+-- vote row (including user_id) straight from the client. RLS — not the UI — is the
+-- authorization boundary (Invariant 1), so that leaked who voted for which movie to
+-- anyone with the browser console.
+--
+-- We tighten reads to "your own votes, or everything if you're an admin" (the admin
+-- drill-downs in admin.vue legitimately show voter names). Public per-suggestion vote
+-- COUNTS are served through a SECURITY DEFINER tally so the overview leaderboard still
+-- works without exposing identities. Vote integrity (Invariant 3) is preserved: counts
+-- are still computed from the normalized rows on demand — there is no stored counter to
+-- drift. Live counts for other users now ride a lightweight client broadcast (the
+-- per-vote postgres_changes stream is, correctly, no longer visible cross-user).
+
+-- 1. Tighten the read policy: own votes, or all for admins.
+drop policy "votes: read" on public.votes;
+create policy "votes: read own or admin" on public.votes
+  for select to authenticated
+  using (user_id = auth.uid() or public.is_admin());
+
+-- 2. Public per-suggestion vote counts, no voter identities. SECURITY DEFINER so it
+--    can count rows the caller can no longer read directly; only counts are returned.
+create or replace function public.suggestion_vote_counts(p_event_id uuid)
+  returns table (suggestion_id uuid, votes bigint)
+  language sql security definer stable set search_path = public as $$
+  select v.suggestion_id, count(*)::bigint
+  from public.votes v
+  join public.suggestions s on s.id = v.suggestion_id
+  where s.event_id = p_event_id and s.deleted = false
+  group by v.suggestion_id
+$$;
+revoke all on function public.suggestion_vote_counts(uuid) from public;
+grant execute on function public.suggestion_vote_counts(uuid) to authenticated;

--- a/test/SuggestionCard.nuxt.test.ts
+++ b/test/SuggestionCard.nuxt.test.ts
@@ -14,6 +14,7 @@ const suggestion = {
   deleted: false,
   created_at: '2026-01-01T00:00:00Z',
   tmdb_movie: { id: 1, title: 'Heat', release_date: '1995-12-15' },
+  voteCount: 2,
   votes: [{ user_id: 'me' }, { user_id: 'bob' }]
 }
 

--- a/test/WinnersBanner.nuxt.test.ts
+++ b/test/WinnersBanner.nuxt.test.ts
@@ -12,6 +12,7 @@ const winner = (id: string, title: string, votes: number) => ({
   deleted: false,
   created_at: '2026-01-01T00:00:00Z',
   tmdb_movie: { id: 1, title, poster_path: `${id}.jpg` },
+  voteCount: votes,
   votes: Array.from({ length: votes }, (_, i) => ({ user_id: `v${i}` }))
 })
 

--- a/test/eventStats.test.ts
+++ b/test/eventStats.test.ts
@@ -9,6 +9,7 @@ const sug = (id: string, userId: string, voters: string[], title = id, deleted =
   tmdb_movie: { id: 1, title },
   deleted,
   created_at: '2026-01-01T00:00:00Z',
+  voteCount: voters.length,
   votes: voters.map(user_id => ({ user_id }))
 })
 

--- a/test/limits.test.ts
+++ b/test/limits.test.ts
@@ -11,6 +11,7 @@ function mk(partial: Partial<Suggestion>): Suggestion {
     deleted: false,
     created_at: '2026-01-01T00:00:00Z',
     votes: [],
+    voteCount: 0,
     ...partial
   }
 }

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -157,4 +157,38 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('votes').delete().eq('user_id', memberId)
     await admin!.from('suggestions').delete().eq('event_id', eventId)
   })
+
+  it('voter privacy: a member sees only their own vote rows, but counts via the tally', async () => {
+    // Two voters on the same suggestion, seeded via the service role.
+    const otherEmail = `rls_other_${stamp}@example.com`
+    const otherId = await makeUser(otherEmail)
+    await admin!.from('invites').insert({ email: otherEmail })
+    const { data: seeded } = await admin!
+      .from('suggestions')
+      .insert({ event_id: eventId, user_id: memberId, tmdb_movie: { id: 500, title: 'Privacy' } })
+      .select('id')
+      .single()
+    const suggestionId = seeded!.id
+    await admin!.from('votes').insert([
+      { suggestion_id: suggestionId, user_id: memberId },
+      { suggestion_id: suggestionId, user_id: otherId }
+    ])
+
+    // The member can read ONLY their own vote row — not the other voter's identity.
+    const visible = await memberClient.from('votes').select('user_id').eq('suggestion_id', suggestionId)
+    expect((visible.data ?? []).map(v => v.user_id), 'a member must not see other voters').toEqual([memberId])
+
+    // …yet the SECURITY DEFINER tally still reports the true total (2), no identities.
+    const tally = await memberClient.rpc('suggestion_vote_counts', { p_event_id: eventId })
+    const row = (tally.data ?? []).find(r => r.suggestion_id === suggestionId)
+    expect(Number(row?.votes), 'the tally exposes the count without the voters').toBe(2)
+
+    // An admin still sees every voter (the admin drill-down needs the names).
+    const asAdmin = await admin!.from('votes').select('user_id').eq('suggestion_id', suggestionId)
+    expect((asAdmin.data ?? []).length, 'admin/service role sees all votes').toBe(2)
+
+    await admin!.from('votes').delete().eq('suggestion_id', suggestionId)
+    await admin!.from('suggestions').delete().eq('id', suggestionId)
+    await admin!.from('invites').delete().eq('email', otherEmail)
+  })
 })

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -183,6 +183,12 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     const row = (tally.data ?? []).find(r => r.suggestion_id === suggestionId)
     expect(Number(row?.votes), 'the tally exposes the count without the voters').toBe(2)
 
+    // A signed-in but non-invited user gets nothing from the tally: the SECURITY
+    // DEFINER function honors is_allowed() like every other gated path, so a guessed
+    // event UUID is not a back door around the invite-only model.
+    const outsiderTally = await outsiderClient.rpc('suggestion_vote_counts', { p_event_id: eventId })
+    expect(outsiderTally.data ?? [], 'a non-allowed user must not get vote counts').toEqual([])
+
     // An admin still sees every voter (the admin drill-down needs the names).
     const asAdmin = await admin!.from('votes').select('user_id').eq('suggestion_id', suggestionId)
     expect((asAdmin.data ?? []).length, 'admin/service role sees all votes').toBe(2)

--- a/test/useSuggestions-race.nuxt.test.ts
+++ b/test/useSuggestions-race.nuxt.test.ts
@@ -23,8 +23,10 @@ const supabase = {
     }
     return chain
   },
+  // Tally resolves immediately; the suggestions select (above) gates the race.
+  rpc: () => Promise.resolve({ data: [], error: null }),
   channel() {
-    const ch = { on: () => ch, subscribe: () => ch }
+    const ch = { on: () => ch, subscribe: () => ch, send: () => Promise.resolve('ok') }
     return ch
   },
   removeChannel() {}

--- a/test/useSuggestions-tally.nuxt.test.ts
+++ b/test/useSuggestions-tally.nuxt.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment nuxt
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+// The privacy model: a non-admin sees only their own vote in each suggestion's
+// `votes`, while the public count comes from the `suggestion_vote_counts` tally.
+// This pins both: voteCount tracks the tally (not votes.length), and a vote pings
+// the shared broadcast topic so other viewers re-fetch.
+const sendSpy = vi.fn(() => Promise.resolve('ok'))
+let lastChannelName = ''
+
+const ownVoteRow = {
+  id: 's1',
+  event_id: 'e1',
+  user_id: 'author',
+  tmdb_movie: { id: 1, title: 'Heat' },
+  deleted: false,
+  created_at: '2026-01-01T00:00:00Z',
+  votes: [{ user_id: 'me' }] // only MY vote is visible to me
+}
+
+const supabase = {
+  from() {
+    return {
+      select: () => ({ eq: () => ({ eq: () => Promise.resolve({ data: [ownVoteRow], error: null }) }) }),
+      insert: () => Promise.resolve({ error: null }),
+      delete: () => ({ eq: () => Promise.resolve({ error: null }) })
+    }
+  },
+  // Tally reports the TRUE total (7) even though I can only see my own vote.
+  rpc: () => Promise.resolve({ data: [{ suggestion_id: 's1', votes: 7 }], error: null }),
+  channel(name: string) {
+    lastChannelName = name
+    const ch = { on: () => ch, subscribe: () => ch, send: sendSpy }
+    return ch
+  },
+  removeChannel() {}
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+mockNuxtImport('useState', () => () => ref('me'))
+
+async function loaded(suggestions: { value: { voteCount: number, votes: unknown[] }[] }): Promise<void> {
+  await vi.waitFor(() => {
+    if (!suggestions.value.length) throw new Error('not loaded yet')
+  })
+}
+
+describe('useSuggestions — voter privacy', () => {
+  it('counts from the tally, not the viewer-visible votes array', async () => {
+    const { suggestions } = useSuggestions(ref('e1'))
+    await loaded(suggestions)
+    // Public count is the tally's 7…
+    expect(suggestions.value[0]!.voteCount).toBe(7)
+    // …even though I can only read my own single vote row.
+    expect(suggestions.value[0]!.votes).toHaveLength(1)
+  })
+
+  it('subscribes to the shared per-event topic for live counts', async () => {
+    const { suggestions } = useSuggestions(ref('e1'))
+    await loaded(suggestions)
+    expect(lastChannelName).toBe('votes:e1')
+  })
+
+  it('broadcasts a change when I vote so other viewers re-fetch', async () => {
+    sendSpy.mockClear()
+    const { vote } = useSuggestions(ref('e1'))
+    await vote({ id: 's1', votes: [] } as never)
+    expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'broadcast', event: 'changed' }))
+  })
+
+  it('broadcasts a change when I unvote', async () => {
+    sendSpy.mockClear()
+    const { unvote } = useSuggestions(ref('e1'))
+    await unvote({ id: 's1', votes: [{ user_id: 'me' }] } as never)
+    expect(sendSpy).toHaveBeenCalledWith(expect.objectContaining({ type: 'broadcast', event: 'changed' }))
+  })
+})

--- a/test/useSuggestions.nuxt.test.ts
+++ b/test/useSuggestions.nuxt.test.ts
@@ -32,8 +32,9 @@ const supabase = {
       select: () => ({ eq: () => ({ eq: () => Promise.resolve({ data: [] }) }) })
     }
   },
+  rpc: () => Promise.resolve({ data: [], error: null }),
   channel() {
-    const ch = { on: () => ch, subscribe: () => ch }
+    const ch = { on: () => ch, subscribe: () => ch, send: () => Promise.resolve('ok') }
     return ch
   },
   removeChannel() {}

--- a/test/winners.test.ts
+++ b/test/winners.test.ts
@@ -9,6 +9,7 @@ const make = (id: string, votes: number, created_at: string, deleted = false): S
   tmdb_movie: { id: Number(id.replace(/\D/g, '')) || 0, title: id, release_date: '2000-01-01' },
   deleted,
   created_at,
+  voteCount: votes,
   votes: Array.from({ length: votes }, (_, i) => ({ user_id: `voter-${i}` }))
 })
 


### PR DESCRIPTION
## Scope

**Privacy/authorization fix.** The `votes` RLS read policy was `using (true)`, so any signed-in user could read every vote row — including `user_id` — directly from the browser console. Since RLS (not the UI) is the authorization boundary (Invariant 1), that meant **who voted for which movie was visible to every non-admin**. This closes that.

The catch is that the leaderboard's vote counts *and* the realtime liveness both relied on that permissive read. So this keeps counts and live updates working while hiding identities — without adding a stored counter (Invariant 3).

## Implementation

**Migration (`20260626000000_voter_privacy.sql`)**
- Tighten `votes: read` → `using (user_id = auth.uid() or public.is_admin())`. A normal user reads only their own votes; admins still read all (the admin drill-downs legitimately show voter names).
- Add `suggestion_vote_counts(p_event_id)` — a `SECURITY DEFINER`, `stable` function returning `(suggestion_id, count)` only (no identities). `execute` granted to `authenticated`.

**Counts come from the tally, identity stays hidden**
- `Suggestion` gains `voteCount` (the public total). `votes` now means "the vote rows the viewer may read" — their own for a normal user, all for an admin — used only for the "did I vote" membership check, never for counting.
- `useSuggestions.load` fetches suggestions + the tally in parallel and merges `voteCount`. Every count derivation switched from `votes.length` → `voteCount`: `SuggestionCard`, `WinnersBanner`, `topWinners`, `computeEventStats`, and overview's `maxVotes`/`totalVotes`/leader. Admin composables (`useAdminSuggestions`/`useEventStats`/`useUserStats`) populate `voteCount` from `votes.length` (admins read all votes), so `voteCount` is the single count source everywhere.

**Live counts without the per-voter stream**
- With reads scoped per user, a non-admin no longer receives `votes` `postgres_changes` for *other* people's votes — so that table watch is dropped from the overview query. Instead, `useSuggestions` subscribes to a shared per-event broadcast topic `votes:<eventId>`; `vote()`/`unvote()` ping it (`event: 'changed'`, empty payload), and every viewer re-fetches the tally. Payload carries nothing sensitive.

## Invariants & Risk

- **Invariant 1 (RLS is the boundary):** strengthened — the leak was an over-permissive policy; this is the fix.
- **Invariant 3 (vote integrity / no counter):** preserved — counts are still computed from normalized rows on demand via the tally; no stored/denormalized counter was added.
- Admin voter-name views unaffected (admin RLS reads all votes).
- No change to TMDB key, the service-role key, or rendered HTML.

## How to Test

**Automated** (Node 22; full suite 300 passed / 9 skipped, typecheck clean, 0 lint errors):
- `test/useSuggestions-tally.nuxt.test.ts` — `voteCount` tracks the tally (7) while the viewer only sees their own 1 vote; subscribes to `votes:e1`; vote + unvote broadcast `changed`.
- `test/rls.integration.test.ts` — new case (runs against local Supabase): a member reads only their own vote row, the tally still returns the true total (2), and admin/service-role sees all voters.
- Updated `winners` / `eventStats` / `SuggestionCard` / `WinnersBanner` fixtures to carry `voteCount`.

**Manual:**
1. As a non-admin, open the overview, then in the console run `await useNuxtApp().$supabase ...` / the Supabase client `from('votes').select('user_id')` — you now get only your own rows (previously: everyone's).
2. Two browsers on the same event: vote in one → the other's count updates live (broadcast).
3. Admin → event/people drill-downs still list voter names and correct totals.

> Note: requires the migration to be applied (RLS + the `suggestion_vote_counts` function). Until then the overview tally call returns nothing and counts read as 0.