### PR TITLE
feat: who's-online presence on the overview page

### DIFF
--- a/app/components/WhoOnline.vue
+++ b/app/components/WhoOnline.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import type { OnlineUser } from '~/composables/usePresence'
+
+const props = defineProps<{ online: OnlineUser[] }>()
+const open = ref(false)
+
+const MAX_SHOWN = 4
+const count = computed(() => props.online.length)
+// Nothing to show until presence has synced (you'll always be in it once it has).
+const hasAnyone = computed(() => count.value > 0)
+</script>
+
+<template>
+  <div v-if="hasAnyone">
+    <button
+      type="button"
+      class="inline-flex items-center gap-2 rounded-full px-2 py-1 hover:bg-elevated/60 transition-colors cursor-pointer"
+      :aria-label="`${count} watching now — see who's online`"
+      @click="open = true"
+    >
+      <span class="relative flex size-2 shrink-0">
+        <span class="absolute inline-flex size-full animate-ping rounded-full bg-green-500 opacity-75" />
+        <span class="relative inline-flex size-2 rounded-full bg-green-500" />
+      </span>
+      <UAvatarGroup :max="MAX_SHOWN" size="2xs">
+        <UAvatar
+          v-for="u in online"
+          :key="u.id"
+          :src="u.avatar ?? undefined"
+          :alt="u.name"
+        />
+      </UAvatarGroup>
+      <span class="text-sm text-muted whitespace-nowrap">{{ count }} watching</span>
+    </button>
+
+    <UModal v-model:open="open" title="Who's online">
+      <template #body>
+        <ul class="space-y-3">
+          <li v-for="u in online" :key="u.id" class="flex items-center gap-3">
+            <UAvatar :src="u.avatar ?? undefined" :alt="u.name" size="sm" />
+            <span class="font-medium truncate">{{ u.name }}</span>
+          </li>
+        </ul>
+      </template>
+    </UModal>
+  </div>
+</template>

--- a/app/composables/usePresence.ts
+++ b/app/composables/usePresence.ts
@@ -1,0 +1,64 @@
+import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { RealtimeChannel } from '@supabase/supabase-js'
+import type { Database } from '~/types/database.types'
+
+/** A person currently viewing the same page. */
+export interface OnlineUser {
+  id: string
+  name: string
+  avatar: string | null
+}
+
+/**
+ * Tracks who is currently on the page via Supabase Realtime Presence. Everyone who
+ * joins the same `topic` channel publishes a small {id,name,avatar} payload; the
+ * channel gossips joins/leaves and we expose the deduped roster — one entry per
+ * user even across multiple tabs (the presence key is the user id). Nothing is
+ * written to the database; presence lives only in Realtime, so it clears when the
+ * tab closes. Re-keys (and re-tracks) whenever the topic changes.
+ */
+export function usePresence(topic: MaybeRefOrGetter<string | null | undefined>): { online: Ref<OnlineUser[]> } {
+  const supabase = useSupabaseClient<Database>()
+  const { account, myId } = useAuth()
+  const online = ref<OnlineUser[]>([])
+  let channel: RealtimeChannel | null = null
+
+  function syncRoster(): void {
+    if (!channel) return
+    const state = channel.presenceState<OnlineUser>()
+    const byId = new Map<string, OnlineUser>()
+    for (const presences of Object.values(state)) {
+      for (const p of presences) byId.set(p.id, { id: p.id, name: p.name, avatar: p.avatar })
+    }
+    online.value = [...byId.values()]
+  }
+
+  watch(() => toValue(topic), (t) => {
+    if (channel) {
+      supabase.removeChannel(channel)
+      channel = null
+    }
+    online.value = []
+    const me = myId.value
+    if (!t || !me) return
+    channel = supabase.channel(`presence:${t}`, { config: { presence: { key: me } } })
+    channel
+      .on('presence', { event: 'sync' }, syncRoster)
+      .on('presence', { event: 'join' }, syncRoster)
+      .on('presence', { event: 'leave' }, syncRoster)
+      .subscribe((status) => {
+        if (status !== 'SUBSCRIBED') return
+        void channel?.track({
+          id: me,
+          name: account.value?.displayName ?? 'Someone',
+          avatar: account.value?.avatarUrl ?? null
+        })
+      })
+  }, { immediate: true })
+
+  onScopeDispose(() => {
+    if (channel) supabase.removeChannel(channel)
+  })
+
+  return { online }
+}

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -25,6 +25,8 @@ const currentEventId = computed(() => currentEvent.value?.id ?? null)
 
 const { suggestions, alreadySuggested, suggest, vote, unvote, removeSuggestion } = useSuggestions(currentEventId)
 const { myStatus, counts, setStatus } = useRsvp(currentEventId)
+// Who else is looking at this movie night right now (Realtime Presence).
+const { online } = usePresence(currentEventId)
 
 const suggestedMovieIds = computed(() => suggestions.value.map(s => s.tmdb_movie.id))
 const maxVotes = computed(() => Math.max(1, ...suggestions.value.map(s => s.votes?.length ?? 0)))
@@ -142,6 +144,11 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
           aria-label="Next event"
           @click="nextEvent"
         />
+      </div>
+
+      <!-- Live "who's watching this movie night" presence -->
+      <div class="flex justify-end mb-2 min-h-7">
+        <WhoOnline :online="online" />
       </div>
 
       <!-- Poster-backed header for the active event -->

--- a/test/WhoOnline.nuxt.test.ts
+++ b/test/WhoOnline.nuxt.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import WhoOnline from '../app/components/WhoOnline.vue'
+
+const online = [
+  { id: 'me', name: 'Pat', avatar: null },
+  { id: 'bob', name: 'Bob', avatar: 'bob.jpg' }
+]
+
+describe('WhoOnline', () => {
+  it('shows the live count of who is watching', async () => {
+    const w = await mountSuspended(WhoOnline, { props: { online } })
+    expect(w.text()).toContain('2 watching')
+    expect(w.find('button').attributes('aria-label')).toContain('2 watching')
+  })
+
+  it('renders nothing when no one is present', async () => {
+    const w = await mountSuspended(WhoOnline, { props: { online: [] } })
+    expect(w.find('button').exists()).toBe(false)
+  })
+
+  it('opens a roster modal listing everyone online', async () => {
+    const w = await mountSuspended(WhoOnline, { props: { online } })
+    await w.find('button').trigger('click')
+    await nextTick()
+    // The modal teleports to the document body.
+    expect(document.body.textContent).toContain('Who\'s online')
+    expect(document.body.textContent).toContain('Pat')
+    expect(document.body.textContent).toContain('Bob')
+  })
+})

--- a/test/overview.nuxt.test.ts
+++ b/test/overview.nuxt.test.ts
@@ -43,6 +43,7 @@ mockNuxtImport('useAppSettings', () => () => ({
   maxSuggestions: ref<number | null>(null),
   maxVotes: ref<number | null>(null)
 }))
+mockNuxtImport('usePresence', () => () => ({ online: ref([]) }))
 
 // Heavy children pull in their own composables/network — stub them; this page
 // test only cares about the header + the admin-gated selector.
@@ -52,7 +53,8 @@ const stubs = {
   MovieFinder: true,
   SuggestionCard: true,
   EventInfoModal: true,
-  TrailerModal: true
+  TrailerModal: true,
+  WhoOnline: true
 }
 
 beforeEach(() => {

--- a/test/usePresence.nuxt.test.ts
+++ b/test/usePresence.nuxt.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import type { OnlineUser } from '../app/composables/usePresence'
+
+// A controllable Realtime-Presence channel: capture the presence callbacks, fire
+// SUBSCRIBED on subscribe, record what we track, and return a settable roster.
+const presenceCallbacks: Record<string, () => void> = {}
+let tracked: Record<string, unknown> | null = null
+let roster: Record<string, OnlineUser[]> = {}
+
+const channelObj = {
+  on(_type: string, filter: { event: string }, cb: () => void) {
+    presenceCallbacks[filter.event] = cb
+    return channelObj
+  },
+  subscribe(cb?: (status: string) => void) {
+    cb?.('SUBSCRIBED')
+    return channelObj
+  },
+  track(payload: Record<string, unknown>) {
+    tracked = payload
+    return Promise.resolve('ok')
+  },
+  presenceState() {
+    return roster
+  }
+}
+
+const supabase = { channel: () => channelObj, removeChannel() {} }
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+mockNuxtImport('useAuth', () => () => ({
+  account: ref({ id: 'me', displayName: 'Pat', avatarUrl: 'pat.jpg' }),
+  myId: ref('me')
+}))
+
+beforeEach(() => {
+  tracked = null
+  roster = {}
+})
+
+describe('usePresence', () => {
+  it('tracks the current user (id, name, avatar) once subscribed', async () => {
+    usePresence(ref('e1'))
+    await nextTick()
+    expect(tracked).toMatchObject({ id: 'me', name: 'Pat', avatar: 'pat.jpg' })
+  })
+
+  it('exposes the deduped roster from presence state on sync', async () => {
+    const { online } = usePresence(ref('e1'))
+    roster = {
+      me: [{ id: 'me', name: 'Pat', avatar: null }],
+      bob: [{ id: 'bob', name: 'Bob', avatar: 'bob.jpg' }]
+    }
+    presenceCallbacks.sync?.()
+    await nextTick()
+    expect(online.value.map(u => u.id)).toEqual(['me', 'bob'])
+  })
+
+  it('collapses a user with multiple tabs into one entry', async () => {
+    const { online } = usePresence(ref('e1'))
+    roster = { me: [{ id: 'me', name: 'Pat', avatar: null }, { id: 'me', name: 'Pat', avatar: null }] }
+    presenceCallbacks.join?.()
+    await nextTick()
+    expect(online.value).toHaveLength(1)
+  })
+
+  it('stays empty (and does not track) until an event id is set', async () => {
+    usePresence(ref(null))
+    await nextTick()
+    expect(tracked).toBeNull()
+  })
+})


### PR DESCRIPTION
## Scope

A live "who's watching this movie night" indicator on the overview — a fun bit of social presence so you can see who else is deciding right now. Backed by **Supabase Realtime Presence**: no database rows, nothing persisted; presence lives only in Realtime and clears the moment a tab closes.

## Implementation

- **`usePresence(topic)`** — joins a per-event presence channel (`presence:<eventId>`), tracks a small `{ id, name, avatar }` payload for the current user once subscribed, and exposes the **deduped** online roster (one entry per user even with multiple tabs, since the presence key is the user id). Re-keys + re-tracks when the active event changes; torn down on scope dispose.
- **`WhoOnline.vue`** — a pulsing green dot + overlapping avatar stack with the live count; clicking opens a modal listing everyone online. Renders nothing until presence has synced (you're always in your own roster once it has).
- **Wired into `overview.vue`** scoped to the active event, so it reflects who's on the same movie night (for non-admins that's everyone, since they all see the active event).

No backend/RLS/schema changes — Presence is a pure Realtime feature.

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop | _(no presence indicator)_ | avatar stack + "3 watching" above the event header; modal lists names |
| mobile  | _(no presence indicator)_ | same, right-aligned and compact |

_(Realtime presence — easiest to see live with two browsers on the same event.)_

## How to Test

**Automated** (Node 22; full suite 303 passed / 8 skipped, typecheck clean, 0 lint errors):
- `test/usePresence.nuxt.test.ts` — tracks the current user (id/name/avatar) on subscribe; surfaces the deduped roster on sync; collapses a multi-tab user to one entry; stays empty (and doesn't track) with no event id.
- `test/WhoOnline.nuxt.test.ts` — shows the live count, renders nothing when empty, opens the roster modal listing everyone.

**Manual:**
1. Open the overview in two different browsers/profiles signed in as different users → each sees "2 watching" with both avatars; the modal lists both names.
2. Close one tab → the other drops back to "1 watching" within a moment (presence leave).

## Invariants & Risk

- No authorization, schema, key, or vote-integrity surface touched. Presence carries only display name + avatar (already visible app-wide) and no sensitive data.