### PR TITLE
feat: float a heart up on vote / a sad heart on unvote

### DIFF
--- a/app/components/FloatingHearts.vue
+++ b/app/components/FloatingHearts.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+// A tiny flourish: spawn a heart that floats up and fades when the user (un)votes.
+// 'vote' → a red heart rising; 'unvote' → a grayscale broken heart. Self-cleaning:
+// each heart removes itself on animationend so the list never grows unbounded.
+type HeartKind = 'vote' | 'unvote'
+interface Heart { id: number, kind: HeartKind, drift: number }
+
+const hearts = ref<Heart[]>([])
+let seq = 0
+
+function spawn(kind: HeartKind): void {
+  // A little horizontal drift so repeated taps don't stack in a single column.
+  const drift = Math.round((Math.random() - 0.5) * 22)
+  hearts.value = [...hearts.value, { id: seq++, kind, drift }]
+}
+
+function remove(id: number): void {
+  hearts.value = hearts.value.filter(h => h.id !== id)
+}
+
+defineExpose({ spawn })
+</script>
+
+<template>
+  <div class="floating-hearts pointer-events-none absolute inset-0 overflow-visible">
+    <UIcon
+      v-for="h in hearts"
+      :key="h.id"
+      :name="h.kind === 'vote' ? 'i-lucide-heart' : 'i-lucide-heart-crack'"
+      :class="[
+        'floating-heart absolute left-1/2 top-1/2 size-5',
+        h.kind === 'vote' ? 'text-red-500' : 'text-neutral-400 grayscale'
+      ]"
+      :style="{ '--drift': `${h.drift}px` }"
+      @animationend="remove(h.id)"
+    />
+  </div>
+</template>
+
+<style scoped>
+@keyframes floating-heart {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.4);
+  }
+  25% {
+    opacity: 1;
+    transform: translate(calc(-50% + var(--drift) * 0.4), -120%) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(calc(-50% + var(--drift)), -260%) scale(1.15);
+  }
+}
+
+.floating-heart {
+  animation: floating-heart 0.9s ease-out forwards;
+}
+
+/* Respect users who prefer no motion — show nothing rather than a jump. */
+@media (prefers-reduced-motion: reduce) {
+  .floating-heart {
+    animation: none;
+    opacity: 0;
+  }
+}
+</style>

--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -31,6 +31,19 @@ const rankClass = computed(() => {
   }
 })
 const highlight = computed(() => props.rank === 1 && voteCount.value > 0)
+
+// The floating-heart flourish lives over the vote button; spawn it optimistically
+// on click (it's a flourish, not a state indicator) then emit the actual action.
+const hearts = useTemplateRef<{ spawn: (kind: 'vote' | 'unvote') => void }>('hearts')
+function onHeartClick(): void {
+  if (hasVoted.value) {
+    hearts.value?.spawn('unvote')
+    emit('unvote')
+  } else {
+    hearts.value?.spawn('vote')
+    emit('vote')
+  }
+}
 </script>
 
 <template>
@@ -60,19 +73,20 @@ const highlight = computed(() => props.rank === 1 && voteCount.value > 0)
             size="md"
             class="shrink-0"
           />
-          <UButton
-            v-else
-            :color="hasVoted ? 'error' : 'neutral'"
-            :variant="hasVoted ? 'soft' : 'outline'"
-            icon="i-lucide-heart"
-            :label="String(voteCount)"
-            size="sm"
-            class="shrink-0"
-            :disabled="voteDisabled"
-            :title="voteDisabled ? 'Vote limit reached — remove a vote to switch your pick' : undefined"
-            :aria-label="hasVoted ? 'Remove vote' : 'Vote'"
-            @click="hasVoted ? emit('unvote') : emit('vote')"
-          />
+          <div v-else class="relative shrink-0">
+            <UButton
+              :color="hasVoted ? 'error' : 'neutral'"
+              :variant="hasVoted ? 'soft' : 'outline'"
+              icon="i-lucide-heart"
+              :label="String(voteCount)"
+              size="sm"
+              :disabled="voteDisabled"
+              :title="voteDisabled ? 'Vote limit reached — remove a vote to switch your pick' : undefined"
+              :aria-label="hasVoted ? 'Remove vote' : 'Vote'"
+              @click="onHeartClick"
+            />
+            <FloatingHearts ref="hearts" />
+          </div>
         </div>
 
         <!-- relative vote bar -->

--- a/test/FloatingHearts.nuxt.test.ts
+++ b/test/FloatingHearts.nuxt.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import FloatingHearts from '../app/components/FloatingHearts.vue'
+
+interface Spawner { spawn: (kind: 'vote' | 'unvote') => void }
+
+describe('FloatingHearts', () => {
+  it('starts empty', async () => {
+    const w = await mountSuspended(FloatingHearts)
+    expect(w.findAll('.floating-heart')).toHaveLength(0)
+  })
+
+  it('spawns a red heart for a vote and a grayscale one for an unvote', async () => {
+    const w = await mountSuspended(FloatingHearts)
+    const vm = w.vm as unknown as Spawner
+    vm.spawn('vote')
+    await nextTick()
+    expect(w.find('.floating-heart').classes()).toContain('text-red-500')
+
+    vm.spawn('unvote')
+    await nextTick()
+    const all = w.findAll('.floating-heart')
+    expect(all).toHaveLength(2)
+    expect(all[1]!.classes()).toContain('grayscale')
+  })
+
+  it('removes each heart when its float animation ends', async () => {
+    const w = await mountSuspended(FloatingHearts)
+    const vm = w.vm as unknown as Spawner
+    vm.spawn('vote')
+    await nextTick()
+    expect(w.findAll('.floating-heart')).toHaveLength(1)
+
+    await w.find('.floating-heart').trigger('animationend')
+    await nextTick()
+    expect(w.findAll('.floating-heart')).toHaveLength(0)
+  })
+})

--- a/test/SuggestionCard.nuxt.test.ts
+++ b/test/SuggestionCard.nuxt.test.ts
@@ -32,6 +32,25 @@ describe('SuggestionCard', () => {
     expect(w.emitted('vote')).toBeFalsy()
   })
 
+  it('floats a red heart up when I cast a vote', async () => {
+    const notVoted = { ...suggestion, votes: [{ user_id: 'bob' }] }
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion: notVoted, rank: 1, maxVotes: 2 } })
+    await w.get('[aria-label="Vote"]').trigger('click')
+    const heart = w.find('.floating-heart')
+    expect(heart.exists()).toBe(true)
+    expect(heart.classes()).toContain('text-red-500')
+    expect(w.emitted('vote')).toBeTruthy()
+  })
+
+  it('floats a grayscale broken heart up when I remove my vote', async () => {
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2 } })
+    await w.get('[aria-label="Remove vote"]').trigger('click')
+    const heart = w.find('.floating-heart')
+    expect(heart.exists()).toBe(true)
+    expect(heart.classes()).toContain('grayscale')
+    expect(w.emitted('unvote')).toBeTruthy()
+  })
+
   it('emits trailer from the Trailer button', async () => {
     const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2 } })
     const trailerBtn = w.findAll('button').find(b => b.text().includes('Trailer'))


### PR DESCRIPTION
## Scope

A small bit of delight on the suggestion card: casting a vote floats a red heart up and fades it out; removing a vote floats a grayscale broken heart up instead. Pure client-side flourish — no backend.

## Implementation

- **`FloatingHearts.vue`** — a `pointer-events-none` overlay anchored over the vote button. `spawn('vote' | 'unvote')` pushes an animated heart; `'vote'` → red `i-lucide-heart`, `'unvote'` → grayscale `i-lucide-heart-crack`. Each heart removes itself on `animationend`, so the list never grows. A little random horizontal drift keeps rapid taps from stacking in one column, and it honors `prefers-reduced-motion` (renders nothing rather than jumping).
- **`SuggestionCard.vue`** — the vote button is wrapped in a `relative` container with `<FloatingHearts ref="hearts" />`; the click handler spawns the matching heart optimistically (it's a flourish, not a state indicator) and then emits `vote`/`unvote` exactly as before.

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop | _(static heart button)_ | red heart rises + fades on vote; grayscale broken heart on unvote |
| mobile  | _(static heart button)_ | same |

_(Animation — easiest to see live by clicking the heart.)_

## How to Test

**Automated** (Node 22; full suite 301 passed / 8 skipped, typecheck clean, 0 lint errors):
- `test/FloatingHearts.nuxt.test.ts` — spawns a red heart for a vote and a grayscale one for an unvote; removes each on `animationend`.
- `test/SuggestionCard.nuxt.test.ts` — clicking Vote floats a red heart (and emits `vote`); clicking Remove vote floats a grayscale broken heart (and emits `unvote`).

**Manual:** click the heart on a suggestion → red heart floats up; click again to remove → grayscale broken heart floats up. With `prefers-reduced-motion` enabled, no animation plays.

## Invariants & Risk

- None touched — purely presentational. Vote/unvote behavior and emitted events are unchanged.

> Heads-up: this and #107 both touch `SuggestionCard.vue` (different spots — #107 changes the count source, this changes the button's click handler). Whichever merges second will need a trivial rebase.