### PR TITLE
feat: unified RSVP roster (merge e-vite email + in-app replies)

### DIFF
--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -7,6 +7,9 @@ const props = defineProps<{ event: MovieEvent | null }>()
 
 const eventId = computed(() => props.event?.id ?? null)
 const { myStatus, counts, setStatus } = useRsvp(eventId)
+// The merged "who's coming" roster (in-app + e-vite email replies). Members see
+// fellow members; admins also see email-only guests (event_invites is admin-only).
+const { roster } = useEventRsvps(eventId)
 const { items, claim, unclaim } = useBringList(eventId)
 
 const calEvent = computed<CalendarEvent | null>(() => {
@@ -117,6 +120,14 @@ function downloadIcs(): void {
             Are you coming?
           </h3>
           <RsvpControl :my-status="myStatus" :counts="counts" @set="setStatus" />
+        </div>
+
+        <!-- Who's coming (merged in-app + e-vite RSVPs) -->
+        <div>
+          <h3 class="text-sm font-semibold text-muted mb-2">
+            Who's coming
+          </h3>
+          <RsvpRoster :roster="roster" />
         </div>
 
         <USeparator />

--- a/app/components/EventInviteManager.vue
+++ b/app/components/EventInviteManager.vue
@@ -12,6 +12,10 @@ const props = defineProps<{ eventId: string, event?: MovieEvent | null }>()
 const toast = useToast()
 const { invites, stats, addInvite, removeInvite, removeInvites, seedFromLastEvent, sendInvites } = useEventInvites(() => props.eventId)
 const { save: saveInviteOptions } = useInviteOptions(() => props.eventId)
+// The TRUE RSVP total = e-vite email replies + in-app RSVPs, merged + deduped.
+// `stats.*` above is the email funnel only (invited/opened/clicked); these are the
+// reconciled headcounts the admin actually plans around.
+const { roster } = useEventRsvps(() => props.eventId)
 
 const newEmail = ref('')
 const newName = ref('')
@@ -203,7 +207,7 @@ function statusBadge(invite: EventInvite): { label: string, color: 'success' | '
       </UCard>
       <UCard variant="subtle" :ui="{ body: 'p-3' }">
         <p class="text-xl font-bold text-success">
-          {{ stats.going }}
+          {{ roster.going.length }}
         </p>
         <p class="text-xs text-muted">
           going
@@ -211,7 +215,7 @@ function statusBadge(invite: EventInvite): { label: string, color: 'success' | '
       </UCard>
       <UCard variant="subtle" :ui="{ body: 'p-3' }">
         <p class="text-xl font-bold text-warning">
-          {{ stats.maybe }}
+          {{ roster.maybe.length }}
         </p>
         <p class="text-xs text-muted">
           maybe
@@ -219,7 +223,7 @@ function statusBadge(invite: EventInvite): { label: string, color: 'success' | '
       </UCard>
       <UCard variant="subtle" :ui="{ body: 'p-3' }">
         <p class="text-xl font-bold">
-          {{ stats.no }}
+          {{ roster.no.length }}
         </p>
         <p class="text-xs text-muted">
           can't
@@ -227,13 +231,21 @@ function statusBadge(invite: EventInvite): { label: string, color: 'success' | '
       </UCard>
       <UCard variant="subtle" :ui="{ body: 'p-3' }">
         <p class="text-xl font-bold text-muted">
-          {{ stats.noReply }}
+          {{ roster.noReply.length }}
         </p>
         <p class="text-xs text-muted">
           no reply
         </p>
       </UCard>
     </div>
+
+    <!-- The merged roster: who's actually coming, by name (e-vite + in-app) -->
+    <UCard variant="subtle" :ui="{ body: 'sm:p-4 p-3' }">
+      <h3 class="text-sm font-semibold text-muted mb-3 flex items-center gap-1.5">
+        <UIcon name="i-lucide-users" /> Who's RSVP'd · {{ roster.total }} total
+      </h3>
+      <RsvpRoster :roster="roster" show-no-reply />
+    </UCard>
 
     <!-- E-vite editor: customize the design + live preview -->
     <UCollapsible v-if="event" :unmount-on-hide="false" class="rounded-lg ring ring-default">

--- a/app/components/RsvpRoster.vue
+++ b/app/components/RsvpRoster.vue
@@ -30,7 +30,7 @@ const hasAnything = computed(() =>
         >
           <UAvatar :src="p.avatar ?? undefined" :alt="p.name" size="3xs" />
           <span class="text-sm truncate max-w-40">{{ p.name }}</span>
-          <UIcon v-if="p.viaEmail" name="i-lucide-mail" class="size-3 text-dimmed" title="RSVP'd by email" />
+          <UIcon v-if="p.viaEmail" name="i-lucide-mail" class="size-3 text-dimmed" role="img" aria-label="RSVP'd by email" />
         </li>
       </ul>
     </div>

--- a/app/components/RsvpRoster.vue
+++ b/app/components/RsvpRoster.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { EventRsvpRoster } from '~/composables/useEventRsvps'
+
+const props = defineProps<{ roster: EventRsvpRoster, showNoReply?: boolean }>()
+
+const sections = computed(() =>
+  [
+    { key: 'going', label: 'Going', icon: 'i-lucide-check', color: 'text-green-500', people: props.roster.going },
+    { key: 'maybe', label: 'Maybe', icon: 'i-lucide-circle-help', color: 'text-amber-500', people: props.roster.maybe },
+    { key: 'no', label: 'Can\'t make it', icon: 'i-lucide-x', color: 'text-muted', people: props.roster.no }
+  ].filter(s => s.people.length > 0)
+)
+
+const hasAnything = computed(() =>
+  props.roster.total > 0 || (props.showNoReply === true && props.roster.noReply.length > 0)
+)
+</script>
+
+<template>
+  <div v-if="hasAnything" class="space-y-3">
+    <div v-for="s in sections" :key="s.key">
+      <p class="text-xs font-semibold text-muted mb-1.5 flex items-center gap-1">
+        <UIcon :name="s.icon" :class="s.color" /> {{ s.label }} · {{ s.people.length }}
+      </p>
+      <ul class="flex flex-wrap gap-1.5">
+        <li
+          v-for="p in s.people"
+          :key="p.key"
+          class="inline-flex items-center gap-1.5 rounded-full bg-elevated/60 py-0.5 pl-1 pr-2.5"
+        >
+          <UAvatar :src="p.avatar ?? undefined" :alt="p.name" size="3xs" />
+          <span class="text-sm truncate max-w-40">{{ p.name }}</span>
+          <UIcon v-if="p.viaEmail" name="i-lucide-mail" class="size-3 text-dimmed" title="RSVP'd by email" />
+        </li>
+      </ul>
+    </div>
+
+    <div v-if="showNoReply && roster.noReply.length">
+      <p class="text-xs font-semibold text-muted mb-1.5 flex items-center gap-1">
+        <UIcon name="i-lucide-clock" /> No reply yet · {{ roster.noReply.length }}
+      </p>
+      <p class="text-sm text-muted">
+        {{ roster.noReply.map(p => p.name).join(', ') }}
+      </p>
+    </div>
+  </div>
+  <p v-else class="text-sm text-muted">
+    No RSVPs yet.
+  </p>
+</template>

--- a/app/composables/useEventRsvps.ts
+++ b/app/composables/useEventRsvps.ts
@@ -1,0 +1,121 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Database } from '~/types/database.types'
+import type { RsvpStatus } from '#shared/types/rsvp'
+
+/** One person's RSVP in the merged roster. */
+export interface RsvpEntry {
+  /** user id for members, lowercased email for email-only guests. */
+  key: string
+  name: string
+  email: string | null
+  avatar: string | null
+  status: RsvpStatus
+  /** True when the reply came from the e-vite email rather than in-app. */
+  viaEmail: boolean
+}
+
+/** The unified RSVP roster for an event, grouped by status. */
+export interface EventRsvpRoster {
+  going: RsvpEntry[]
+  maybe: RsvpEntry[]
+  no: RsvpEntry[]
+  /** Guests on the e-vite list who haven't replied (admin-only — needs event_invites). */
+  noReply: { key: string, name: string, email: string }[]
+  /** Distinct people who replied (going + maybe + no). */
+  total: number
+}
+
+const EMPTY: EventRsvpRoster = { going: [], maybe: [], no: [], noReply: [], total: 0 }
+
+/**
+ * The single source of truth for "who's coming", merging both RSVP stores at read
+ * time so they can never drift:
+ *  - public.rsvps        — signed-in members tapping Going/Maybe/No in-app.
+ *  - public.event_invites — guests replying via the tokenized e-vite email.
+ *
+ * Members are authoritative from `rsvps` (the e-vite route already mirrors an email
+ * reply into rsvps when the email is a member). Email-only guests are folded in from
+ * event_invites, deduped against members by email. event_invites is admin-only by
+ * RLS, so a non-admin transparently gets a members-only roster; an admin gets the
+ * full picture plus who was invited but hasn't replied. Live via realtime.
+ */
+export function useEventRsvps(eventId: MaybeRefOrGetter<string | null | undefined>): {
+  roster: Ref<EventRsvpRoster>
+  error: Ref<string | null>
+  refresh: () => Promise<void>
+} {
+  const supabase = useSupabaseClient<Database>()
+
+  const { data: roster, error, refresh } = useRealtimeQuery<EventRsvpRoster>({
+    key: eventId,
+    channel: 'event-rsvps',
+    tables: [{ table: 'rsvps' }, { table: 'event_invites' }],
+    empty: EMPTY,
+    errorFallback: 'Failed to load RSVPs',
+    load: async (id) => {
+      const { data: rsvpRows, error: rsvpError } = await supabase
+        .from('rsvps')
+        .select('user_id, status')
+        .eq('event_id', id)
+      if (rsvpError) throw rsvpError
+
+      const userIds = (rsvpRows ?? []).map(r => r.user_id)
+      const [profiles, invites] = await Promise.all([
+        userIds.length
+          ? supabase.from('profiles').select('id, display_name, email, avatar_url').in('id', userIds)
+          : Promise.resolve({ data: [], error: null }),
+        // Admin-only by RLS — a non-admin gets [] here (no error), i.e. members only.
+        supabase.from('event_invites').select('email, display_name, rsvp').eq('event_id', id)
+      ])
+      if (profiles.error) throw profiles.error
+      if (invites.error) throw invites.error
+
+      const profileById = new Map((profiles.data ?? []).map(p => [p.id, p]))
+      const memberEmails = new Set<string>()
+      const entries: RsvpEntry[] = []
+
+      for (const row of rsvpRows ?? []) {
+        const profile = profileById.get(row.user_id)
+        const email = profile?.email ?? null
+        if (email) memberEmails.add(email.toLowerCase())
+        entries.push({
+          key: row.user_id,
+          name: profile?.display_name ?? email ?? 'Member',
+          email,
+          avatar: profile?.avatar_url ?? null,
+          // DB check constraint guarantees the status enum; narrow at this boundary.
+          status: row.status as RsvpStatus,
+          viaEmail: false
+        })
+      }
+
+      const noReply: EventRsvpRoster['noReply'] = []
+      for (const invite of invites.data ?? []) {
+        // A member is already counted from rsvps (authoritative); skip their e-vite row.
+        if (memberEmails.has(invite.email.toLowerCase())) continue
+        if (invite.rsvp) {
+          entries.push({
+            key: invite.email.toLowerCase(),
+            name: invite.display_name ?? invite.email,
+            email: invite.email,
+            avatar: null,
+            status: invite.rsvp as RsvpStatus,
+            viaEmail: true
+          })
+        } else {
+          noReply.push({ key: invite.email.toLowerCase(), name: invite.display_name ?? invite.email, email: invite.email })
+        }
+      }
+
+      return {
+        going: entries.filter(e => e.status === 'going'),
+        maybe: entries.filter(e => e.status === 'maybe'),
+        no: entries.filter(e => e.status === 'no'),
+        noReply,
+        total: entries.length
+      }
+    }
+  })
+
+  return { roster, error, refresh }
+}

--- a/app/composables/useEventRsvps.ts
+++ b/app/composables/useEventRsvps.ts
@@ -1,6 +1,6 @@
 import type { MaybeRefOrGetter } from 'vue'
 import type { Database } from '~/types/database.types'
-import type { RsvpStatus } from '#shared/types/rsvp'
+import { toRsvpStatus, type RsvpStatus } from '#shared/types/rsvp'
 
 /** One person's RSVP in the merged roster. */
 export interface RsvpEntry {
@@ -83,8 +83,7 @@ export function useEventRsvps(eventId: MaybeRefOrGetter<string | null | undefine
           name: profile?.display_name ?? email ?? 'Member',
           email,
           avatar: profile?.avatar_url ?? null,
-          // DB check constraint guarantees the status enum; narrow at this boundary.
-          status: row.status as RsvpStatus,
+          status: toRsvpStatus(row.status),
           viaEmail: false
         })
       }
@@ -99,7 +98,7 @@ export function useEventRsvps(eventId: MaybeRefOrGetter<string | null | undefine
             name: invite.display_name ?? invite.email,
             email: invite.email,
             avatar: null,
-            status: invite.rsvp as RsvpStatus,
+            status: toRsvpStatus(invite.rsvp),
             viaEmail: true
           })
         } else {

--- a/shared/types/rsvp.ts
+++ b/shared/types/rsvp.ts
@@ -1,4 +1,21 @@
-export type RsvpStatus = 'going' | 'maybe' | 'no'
+export const RSVP_STATUSES = ['going', 'maybe', 'no'] as const
+
+export type RsvpStatus = (typeof RSVP_STATUSES)[number]
+
+export function isRsvpStatus(value: string): value is RsvpStatus {
+  return RSVP_STATUSES.some(s => s === value)
+}
+
+/**
+ * Narrow a raw value from the data layer to RsvpStatus at the boundary. The
+ * `rsvps.status` / `event_invites.rsvp` columns carry a CHECK constraint guaranteeing
+ * this set, so a miss means schema drift — throw rather than silently coerce (which is
+ * what an `as RsvpStatus` cast would do, hiding the drift behind a green type check).
+ */
+export function toRsvpStatus(value: string): RsvpStatus {
+  if (isRsvpStatus(value)) return value
+  throw new Error(`Unexpected RSVP status from the database: ${value}`)
+}
 
 export interface Rsvp {
   event_id: string

--- a/test/EventInviteManager.nuxt.test.ts
+++ b/test/EventInviteManager.nuxt.test.ts
@@ -45,6 +45,17 @@ mockNuxtImport('useEventInvites', () => () => ({
 }))
 mockNuxtImport('useToast', () => () => ({ add: (t: Toast) => toasts.push(t) }))
 mockNuxtImport('useInviteOptions', () => () => ({ save: saveOptionsFn }))
+mockNuxtImport('useEventRsvps', () => () => ({
+  roster: ref({
+    going: [{ key: 'u1', name: 'Ada', email: 'ada@x.com', avatar: null, status: 'going', viaEmail: false }],
+    maybe: [],
+    no: [],
+    noReply: [{ key: 'b@x.com', name: 'Bo', email: 'b@x.com' }],
+    total: 1
+  }),
+  error: ref(null),
+  refresh: async () => {}
+}))
 
 const clickSend = async (w: { findAll: (s: string) => Array<{ text: () => string, trigger: (e: string) => Promise<void> }> }): Promise<void> => {
   const send = w.findAll('button').find(b => b.text().includes('Send'))

--- a/test/RsvpRoster.nuxt.test.ts
+++ b/test/RsvpRoster.nuxt.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import RsvpRoster from '../app/components/RsvpRoster.vue'
+import type { EventRsvpRoster } from '../app/composables/useEventRsvps'
+
+const roster: EventRsvpRoster = {
+  going: [
+    { key: 'u1', name: 'Ada', email: 'ada@x.com', avatar: null, status: 'going', viaEmail: false },
+    { key: 'g@x.com', name: 'Guest', email: 'g@x.com', avatar: null, status: 'going', viaEmail: true }
+  ],
+  maybe: [{ key: 'u2', name: 'Bo', email: 'bo@x.com', avatar: null, status: 'maybe', viaEmail: false }],
+  no: [],
+  noReply: [{ key: 's@x.com', name: 'Silent', email: 's@x.com' }],
+  total: 3
+}
+
+describe('RsvpRoster', () => {
+  it('groups people by status with per-section counts and names', async () => {
+    const w = await mountSuspended(RsvpRoster, { props: { roster } })
+    expect(w.text()).toContain('Going · 2')
+    expect(w.text()).toContain('Maybe · 1')
+    expect(w.text()).toContain('Ada')
+    expect(w.text()).toContain('Guest')
+    expect(w.text()).toContain('Bo')
+  })
+
+  it('hides the no-reply section unless asked (admin-only)', async () => {
+    const without = await mountSuspended(RsvpRoster, { props: { roster } })
+    expect(without.text()).not.toContain('No reply yet')
+
+    const withIt = await mountSuspended(RsvpRoster, { props: { roster, showNoReply: true } })
+    expect(withIt.text()).toContain('No reply yet · 1')
+    expect(withIt.text()).toContain('Silent')
+  })
+
+  it('shows an empty state when nobody has replied', async () => {
+    const empty: EventRsvpRoster = { going: [], maybe: [], no: [], noReply: [], total: 0 }
+    const w = await mountSuspended(RsvpRoster, { props: { roster: empty } })
+    expect(w.text()).toContain('No RSVPs yet')
+  })
+})

--- a/test/rsvp-status.test.ts
+++ b/test/rsvp-status.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { RSVP_STATUSES, isRsvpStatus, toRsvpStatus } from '../shared/types/rsvp'
+
+describe('isRsvpStatus', () => {
+  it('accepts every value in the canonical set', () => {
+    for (const status of RSVP_STATUSES) expect(isRsvpStatus(status)).toBe(true)
+  })
+
+  it('rejects anything outside the set', () => {
+    expect(isRsvpStatus('attending')).toBe(false)
+    expect(isRsvpStatus('Going')).toBe(false) // case-sensitive: DB stores the lowercase enum
+    expect(isRsvpStatus('')).toBe(false)
+  })
+})
+
+describe('toRsvpStatus', () => {
+  it('narrows a valid DB value to RsvpStatus', () => {
+    expect(toRsvpStatus('going')).toBe('going')
+    expect(toRsvpStatus('maybe')).toBe('maybe')
+    expect(toRsvpStatus('no')).toBe('no')
+  })
+
+  it('throws on schema drift rather than silently coercing (what `as` would hide)', () => {
+    expect(() => toRsvpStatus('definitely')).toThrowError(/Unexpected RSVP status/)
+  })
+})

--- a/test/useEventRsvps.nuxt.test.ts
+++ b/test/useEventRsvps.nuxt.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment nuxt
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import type { EventRsvpRoster } from '../app/composables/useEventRsvps'
@@ -41,6 +41,14 @@ async function settle(roster: { value: EventRsvpRoster }): Promise<void> {
   })
   await nextTick()
 }
+
+// Reset every fixture between tests so a stray value can't leak across cases — each
+// test declares the full state it depends on.
+beforeEach(() => {
+  rsvpRows = []
+  profileRows = []
+  inviteRows = []
+})
 
 describe('useEventRsvps', () => {
   it('rolls up in-app member RSVPs with names + avatars', async () => {
@@ -85,5 +93,19 @@ describe('useEventRsvps', () => {
     expect(roster.value.going).toHaveLength(1)
     expect(roster.value.maybe).toHaveLength(0)
     expect(roster.value.going[0]!.viaEmail).toBe(false)
+  })
+
+  it('settles on an all-no-reply guest list (total stays 0, everyone in noReply)', async () => {
+    // The settle edge case: invites exist but nobody replied, so `total` never leaves
+    // 0 and the load is only observable via `noReply` populating.
+    inviteRows = [
+      { email: 'a@x.com', display_name: 'A', rsvp: null },
+      { email: 'b@x.com', display_name: null, rsvp: null }
+    ]
+    const { roster } = useEventRsvps(ref('e1'))
+    await settle(roster)
+    expect(roster.value.total).toBe(0)
+    expect(roster.value.going).toHaveLength(0)
+    expect(roster.value.noReply.map(p => p.name)).toEqual(['A', 'b@x.com'])
   })
 })

--- a/test/useEventRsvps.nuxt.test.ts
+++ b/test/useEventRsvps.nuxt.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment nuxt
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import type { EventRsvpRoster } from '../app/composables/useEventRsvps'
+
+// Controllable Supabase reads for the three tables the merge touches. Each test
+// sets the fixtures, then we wait for the immediate-watch load to settle.
+interface ProfileRow { id: string, display_name: string | null, email: string | null, avatar_url: string | null }
+interface InviteRow { email: string, display_name: string | null, rsvp: string | null }
+let rsvpRows: { user_id: string, status: string }[] = []
+let profileRows: ProfileRow[] = []
+let inviteRows: InviteRow[] = []
+
+const supabase = {
+  from(table: string) {
+    if (table === 'rsvps') {
+      return { select: () => ({ eq: () => Promise.resolve({ data: rsvpRows, error: null }) }) }
+    }
+    if (table === 'profiles') {
+      return { select: () => ({ in: () => Promise.resolve({ data: profileRows, error: null }) }) }
+    }
+    // event_invites
+    return { select: () => ({ eq: () => Promise.resolve({ data: inviteRows, error: null }) }) }
+  },
+  channel() {
+    const ch = { on: () => ch, subscribe: () => ch }
+    return ch
+  },
+  removeChannel() {}
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+async function settle(roster: { value: EventRsvpRoster }): Promise<void> {
+  await vi.waitFor(() => {
+    // Loaded once the roster reflects the fixtures (or is knowably empty).
+    if (rsvpRows.length + inviteRows.length > 0 && roster.value.total === 0 && roster.value.noReply.length === 0) {
+      throw new Error('not loaded yet')
+    }
+  })
+  await nextTick()
+}
+
+describe('useEventRsvps', () => {
+  it('rolls up in-app member RSVPs with names + avatars', async () => {
+    rsvpRows = [{ user_id: 'u1', status: 'going' }, { user_id: 'u2', status: 'maybe' }]
+    profileRows = [
+      { id: 'u1', display_name: 'Ada', email: 'ada@x.com', avatar_url: 'ada.jpg' },
+      { id: 'u2', display_name: 'Bo', email: 'bo@x.com', avatar_url: null }
+    ]
+    inviteRows = []
+    const { roster } = useEventRsvps(ref('e1'))
+    await settle(roster)
+    expect(roster.value.going.map(p => p.name)).toEqual(['Ada'])
+    expect(roster.value.going[0]!.avatar).toBe('ada.jpg')
+    expect(roster.value.maybe.map(p => p.name)).toEqual(['Bo'])
+    expect(roster.value.total).toBe(2)
+  })
+
+  it('folds email-only guests in and flags them viaEmail', async () => {
+    rsvpRows = []
+    profileRows = []
+    inviteRows = [
+      { email: 'guest@x.com', display_name: 'Guest', rsvp: 'going' },
+      { email: 'silent@x.com', display_name: null, rsvp: null }
+    ]
+    const { roster } = useEventRsvps(ref('e1'))
+    await settle(roster)
+    expect(roster.value.going).toHaveLength(1)
+    expect(roster.value.going[0]).toMatchObject({ name: 'Guest', viaEmail: true })
+    // A guest with no reply lands in noReply, named by email when display_name is null.
+    expect(roster.value.noReply.map(p => p.name)).toEqual(['silent@x.com'])
+    expect(roster.value.total).toBe(1)
+  })
+
+  it('dedupes a member who is also on the e-vite list (in-app wins)', async () => {
+    rsvpRows = [{ user_id: 'u1', status: 'going' }]
+    profileRows = [{ id: 'u1', display_name: 'Ada', email: 'Ada@x.com', avatar_url: null }]
+    // Same person on the guest list (case-insensitive email), with a stale 'maybe'.
+    inviteRows = [{ email: 'ada@x.com', display_name: 'Ada', rsvp: 'maybe' }]
+    const { roster } = useEventRsvps(ref('e1'))
+    await settle(roster)
+    expect(roster.value.total).toBe(1)
+    expect(roster.value.going).toHaveLength(1)
+    expect(roster.value.maybe).toHaveLength(0)
+    expect(roster.value.going[0]!.viaEmail).toBe(false)
+  })
+})


### PR DESCRIPTION
## Scope

RSVPs lived in two stores that were never shown together, so there was no true "who's coming" total:

- **`public.rsvps`** — signed-in members tapping Going/Maybe/No in-app. Surfaced as *counts* on the overview + event modal.
- **`event_invites.rsvp`** — guests replying via the tokenized e-vite email. Surfaced only in the admin invite tracker.

Result: a member who RSVP'd in-app was missing from the admin's totals; an email-only guest never reached the in-app headcount; and nowhere listed everyone by name. This adds one merged roster, used in both the event modal (everyone) and the admin view (full).

## Implementation

- **`useEventRsvps(eventId)`** — merges both stores **at read time** (no fragile two-way sync to drift). Members are authoritative from `rsvps` (the e-vite RSVP route already mirrors an email reply into `rsvps` when the email is a member). Email-only guests fold in from `event_invites`, deduped against members by **case-insensitive email**. `event_invites` is admin-only by RLS, so a non-admin transparently gets a **members-only** roster, while an admin gets email guests too plus a "no reply yet" list. Live via realtime (`rsvps` + `event_invites`).
- **`RsvpRoster.vue`** — Going/Maybe/Can't groups with names + avatars, a mail glyph on email replies, an optional admin-only "no reply yet" section, and an empty state.
- **`EventInfoModal`** — a "Who's coming" list under the RSVP control (visible to everyone; members-only contents for non-admins by RLS).
- **`EventInviteManager`** — the going / maybe / can't / no-reply tiles now read the **true merged total** (previously email-only), plus a "Who's RSVP'd · N total" roster by name. The invited/opened tiles remain the email funnel.

## Why read-time merge (not sync)

The e-vite route already mirrors email→`rsvps` for members, so members are single-sourced. Folding email-only guests in at read time means there's nothing to keep in sync and nothing to drift — consistent with the "no denormalized counter" stance elsewhere in the app.

## Screenshots

|         | before | after |
| ------- | ------ | ----- |
| desktop | event modal shows only RSVP count buttons; admin tracker shows email-only going/maybe | "Who's coming" name list in the modal; admin tiles show the merged total + a by-name roster |
| mobile  | same | same, wraps to chips |

## How to Test

**Automated** (Node 22; full suite 302 passed / 8 skipped, typecheck clean, 0 lint errors):
- `test/useEventRsvps.nuxt.test.ts` — member rollup (names/avatars); email-only guest fold-in + `viaEmail` flag + no-reply naming; **dedupe** a member who's also on the e-vite list, with the in-app status winning over a stale email reply.
- `test/RsvpRoster.nuxt.test.ts` — grouping/counts, admin-only no-reply gating, empty state.
- `test/EventInviteManager.nuxt.test.ts` — wired to the merged roster.

**Manual:**
1. Member RSVPs "Going" in-app → appears in the event modal's "Who's coming" and in the admin's "going" total + roster.
2. Non-member guest clicks the e-vite email and replies "Maybe" → shows in the admin roster (mail glyph), counts in the admin total; not shown to non-admins (RLS).
3. A member who is also on the guest list appears once (in-app status wins).

## Invariants & Risk

- **No authorization changes.** Reads ride existing RLS: `rsvps`/`profiles` are readable by allowlisted members; `event_invites` stays admin-only, which is exactly what scopes the roster (members see members; admins see all). No schema/migration.
- TMDB key / vote integrity / admin role / rendered HTML: untouched.