### PR TITLE
feat: +1 / guest count on RSVPs (e-vite + in-app)

### DIFF
--- a/app/components/EventHero.vue
+++ b/app/components/EventHero.vue
@@ -51,15 +51,16 @@ const display = computed(() => normalizePosterDisplay(props.event.poster_display
       <h1 class="text-2xl sm:text-3xl font-bold text-white drop-shadow-md text-balance underline-offset-4 decoration-2 decoration-white/40 group-hover:underline">
         {{ event.title }}
       </h1>
-      <p v-if="event.location" class="mt-1.5 inline-flex items-center gap-1.5 text-sm text-white/80">
+      <p v-if="event.location" class="mt-1.5 flex items-center gap-1.5 text-sm text-white/80">
         <UIcon name="i-lucide-map-pin" class="shrink-0" /> {{ event.location }}
       </p>
+      <!-- Weather sits on its own line beneath the address. -->
       <WeatherForecast
         v-if="upcoming && event.location"
         :location="event.location"
         :date="event.event_date"
         tone="light"
-        class="mt-1"
+        class="mt-1 flex"
       />
       <p class="mt-1.5 inline-flex items-center gap-1 text-xs text-white/70">
         <UIcon name="i-lucide-info" /> Tap for details

--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -6,7 +6,7 @@ const open = defineModel<boolean>('open', { default: false })
 const props = defineProps<{ event: MovieEvent | null }>()
 
 const eventId = computed(() => props.event?.id ?? null)
-const { myStatus, counts, setStatus } = useRsvp(eventId)
+const { myStatus, myPlusOnes, counts, setStatus, setGuests } = useRsvp(eventId)
 // The merged "who's coming" roster (in-app + e-vite email replies). Members see
 // fellow members; admins also see email-only guests (event_invites is admin-only).
 const { roster } = useEventRsvps(eventId)
@@ -119,7 +119,13 @@ function downloadIcs(): void {
           <h3 class="text-sm font-semibold text-muted mb-2">
             Are you coming?
           </h3>
-          <RsvpControl :my-status="myStatus" :counts="counts" @set="setStatus" />
+          <RsvpControl
+            :my-status="myStatus"
+            :my-plus-ones="myPlusOnes"
+            :counts="counts"
+            @set="setStatus"
+            @guests="setGuests"
+          />
         </div>
 
         <!-- Who's coming (merged in-app + e-vite RSVPs) -->

--- a/app/components/GuestStepper.vue
+++ b/app/components/GuestStepper.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { MAX_PLUS_ONES } from '#shared/types/rsvp'
+
+// A compact "− N +" stepper for the number of additional guests an attendee is
+// bringing (their "+1"s). Clamps to [0, max]; emits on every change.
+const model = defineModel<number>({ default: 0 })
+const props = withDefaults(defineProps<{ max?: number }>(), { max: MAX_PLUS_ONES })
+
+const atMin = computed(() => model.value <= 0)
+const atMax = computed(() => model.value >= props.max)
+
+function step(delta: number): void {
+  model.value = Math.min(props.max, Math.max(0, model.value + delta))
+}
+</script>
+
+<template>
+  <div class="inline-flex items-center gap-2">
+    <UButton
+      icon="i-lucide-minus"
+      size="xs"
+      color="neutral"
+      variant="outline"
+      :disabled="atMin"
+      aria-label="One fewer guest"
+      @click="step(-1)"
+    />
+    <span class="min-w-16 text-center text-sm tabular-nums" aria-live="polite">
+      {{ model === 0 ? 'just me' : `+${model} guest${model === 1 ? '' : 's'}` }}
+    </span>
+    <UButton
+      icon="i-lucide-plus"
+      size="xs"
+      color="neutral"
+      variant="outline"
+      :disabled="atMax"
+      aria-label="One more guest"
+      @click="step(1)"
+    />
+  </div>
+</template>

--- a/app/components/RsvpControl.vue
+++ b/app/components/RsvpControl.vue
@@ -1,14 +1,20 @@
 <script setup lang="ts">
 import type { RsvpStatus } from '#shared/types/rsvp'
 
-defineProps<{ myStatus: RsvpStatus | null, counts: { going: number, maybe: number, no: number } }>()
-const emit = defineEmits<{ set: [status: RsvpStatus] }>()
+const props = defineProps<{
+  myStatus: RsvpStatus | null
+  myPlusOnes?: number
+  counts: { going: number, maybe: number, no: number, guests?: number }
+}>()
+const emit = defineEmits<{ set: [status: RsvpStatus], guests: [count: number] }>()
 
 const options = [
   { status: 'going' as const, label: 'Going', icon: 'i-lucide-check', color: 'primary' as const },
   { status: 'maybe' as const, label: 'Maybe', icon: 'i-lucide-circle-help', color: 'warning' as const },
   { status: 'no' as const, label: 'Can\'t', icon: 'i-lucide-x', color: 'neutral' as const }
 ]
+
+const guests = computed(() => props.counts.guests ?? 0)
 </script>
 
 <template>
@@ -26,8 +32,16 @@ const options = [
         @click="emit('set', o.status)"
       />
     </div>
+
+    <!-- Bringing guests? Only while going. -->
+    <div v-if="myStatus === 'going'" class="mt-3 flex items-center justify-between gap-2">
+      <span class="text-sm text-muted">Bringing guests?</span>
+      <GuestStepper :model-value="myPlusOnes ?? 0" @update:model-value="emit('guests', $event)" />
+    </div>
+
     <p class="text-xs text-muted mt-2 text-center">
       <span class="text-primary font-medium">{{ counts.going }} going</span>
+      <span v-if="guests > 0"> (+{{ guests }} guest{{ guests === 1 ? '' : 's' }})</span>
       · {{ counts.maybe }} maybe
     </p>
   </div>

--- a/app/components/RsvpRoster.vue
+++ b/app/components/RsvpRoster.vue
@@ -14,10 +14,19 @@ const sections = computed(() =>
 const hasAnything = computed(() =>
   props.roster.total > 0 || (props.showNoReply === true && props.roster.noReply.length > 0)
 )
+
+// Extra guests across everyone going (headcount − the going people themselves).
+const guestCount = computed(() => Math.max(0, props.roster.headcount - props.roster.going.length))
 </script>
 
 <template>
   <div v-if="hasAnything" class="space-y-3">
+    <!-- Headcount including guests, when anyone is bringing a +1. -->
+    <p v-if="guestCount > 0" class="text-sm font-medium">
+      {{ roster.headcount }} expected
+      <span class="text-muted font-normal">({{ roster.going.length }} going + {{ guestCount }} guest{{ guestCount === 1 ? '' : 's' }})</span>
+    </p>
+
     <div v-for="s in sections" :key="s.key">
       <p class="text-xs font-semibold text-muted mb-1.5 flex items-center gap-1">
         <UIcon :name="s.icon" :class="s.color" /> {{ s.label }} · {{ s.people.length }}
@@ -30,6 +39,14 @@ const hasAnything = computed(() =>
         >
           <UAvatar :src="p.avatar ?? undefined" :alt="p.name" size="3xs" />
           <span class="text-sm truncate max-w-40">{{ p.name }}</span>
+          <UBadge
+            v-if="p.plusOnes > 0"
+            :label="`+${p.plusOnes}`"
+            color="primary"
+            variant="subtle"
+            size="sm"
+            :aria-label="`bringing ${p.plusOnes} guest${p.plusOnes === 1 ? '' : 's'}`"
+          />
           <UIcon v-if="p.viaEmail" name="i-lucide-mail" class="size-3 text-dimmed" role="img" aria-label="RSVP'd by email" />
         </li>
       </ul>

--- a/app/composables/useEventRsvps.ts
+++ b/app/composables/useEventRsvps.ts
@@ -10,6 +10,8 @@ export interface RsvpEntry {
   email: string | null
   avatar: string | null
   status: RsvpStatus
+  /** Additional guests this person is bringing (their "+1"s); 0 unless going. */
+  plusOnes: number
   /** True when the reply came from the e-vite email rather than in-app. */
   viaEmail: boolean
 }
@@ -23,9 +25,11 @@ export interface EventRsvpRoster {
   noReply: { key: string, name: string, email: string }[]
   /** Distinct people who replied (going + maybe + no). */
   total: number
+  /** Total bodies expected = everyone going + the guests they're bringing. */
+  headcount: number
 }
 
-const EMPTY: EventRsvpRoster = { going: [], maybe: [], no: [], noReply: [], total: 0 }
+const EMPTY: EventRsvpRoster = { going: [], maybe: [], no: [], noReply: [], total: 0, headcount: 0 }
 
 /**
  * The single source of truth for "who's coming", merging both RSVP stores at read
@@ -55,7 +59,7 @@ export function useEventRsvps(eventId: MaybeRefOrGetter<string | null | undefine
     load: async (id) => {
       const { data: rsvpRows, error: rsvpError } = await supabase
         .from('rsvps')
-        .select('user_id, status')
+        .select('user_id, status, plus_ones')
         .eq('event_id', id)
       if (rsvpError) throw rsvpError
 
@@ -65,7 +69,7 @@ export function useEventRsvps(eventId: MaybeRefOrGetter<string | null | undefine
           ? supabase.from('profiles').select('id, display_name, email, avatar_url').in('id', userIds)
           : Promise.resolve({ data: [], error: null }),
         // Admin-only by RLS — a non-admin gets [] here (no error), i.e. members only.
-        supabase.from('event_invites').select('email, display_name, rsvp').eq('event_id', id)
+        supabase.from('event_invites').select('email, display_name, rsvp, plus_ones').eq('event_id', id)
       ])
       if (profiles.error) throw profiles.error
       if (invites.error) throw invites.error
@@ -78,12 +82,14 @@ export function useEventRsvps(eventId: MaybeRefOrGetter<string | null | undefine
         const profile = profileById.get(row.user_id)
         const email = profile?.email ?? null
         if (email) memberEmails.add(email.toLowerCase())
+        const status = toRsvpStatus(row.status)
         entries.push({
           key: row.user_id,
           name: profile?.display_name ?? email ?? 'Member',
           email,
           avatar: profile?.avatar_url ?? null,
-          status: toRsvpStatus(row.status),
+          status,
+          plusOnes: status === 'going' ? (row.plus_ones ?? 0) : 0,
           viaEmail: false
         })
       }
@@ -93,12 +99,14 @@ export function useEventRsvps(eventId: MaybeRefOrGetter<string | null | undefine
         // A member is already counted from rsvps (authoritative); skip their e-vite row.
         if (memberEmails.has(invite.email.toLowerCase())) continue
         if (invite.rsvp) {
+          const status = toRsvpStatus(invite.rsvp)
           entries.push({
             key: invite.email.toLowerCase(),
             name: invite.display_name ?? invite.email,
             email: invite.email,
             avatar: null,
-            status: toRsvpStatus(invite.rsvp),
+            status,
+            plusOnes: status === 'going' ? (invite.plus_ones ?? 0) : 0,
             viaEmail: true
           })
         } else {
@@ -106,12 +114,15 @@ export function useEventRsvps(eventId: MaybeRefOrGetter<string | null | undefine
         }
       }
 
+      const going = entries.filter(e => e.status === 'going')
       return {
-        going: entries.filter(e => e.status === 'going'),
+        going,
         maybe: entries.filter(e => e.status === 'maybe'),
         no: entries.filter(e => e.status === 'no'),
         noReply,
-        total: entries.length
+        total: entries.length,
+        // Everyone going, plus the guests they're bringing.
+        headcount: going.reduce((n, e) => n + 1 + e.plusOnes, 0)
       }
     }
   })

--- a/app/composables/useRsvp.ts
+++ b/app/composables/useRsvp.ts
@@ -1,53 +1,75 @@
 import type { MaybeRefOrGetter } from 'vue'
 import type { Database } from '~/types/database.types'
-import type { RsvpStatus } from '#shared/types/rsvp'
+import { clampPlusOnes, type RsvpStatus } from '#shared/types/rsvp'
 
-/** RSVP state for an event: my status, live counts, and set/toggle. */
+/** RSVP state for an event: my status + guest count, live counts, and set/toggle. */
 export function useRsvp(eventId: MaybeRefOrGetter<string | null | undefined>) {
   const supabase = useSupabaseClient<Database>()
   const myId = useMyId()
 
-  const { data: rsvps, error, refresh } = useRealtimeQuery<{ user_id: string, status: string }[]>({
+  const { data: rsvps, error, refresh } = useRealtimeQuery<{ user_id: string, status: string, plus_ones: number }[]>({
     key: eventId,
     channel: 'rsvps',
     tables: [{ table: 'rsvps' }],
     empty: [],
     errorFallback: 'Failed to load RSVPs',
     load: async (id) => {
-      const { data, error } = await supabase.from('rsvps').select('user_id, status').eq('event_id', id)
+      const { data, error } = await supabase.from('rsvps').select('user_id, status, plus_ones').eq('event_id', id)
       if (error) throw error
       return data ?? []
     }
   })
 
-  const myStatus = computed<RsvpStatus | null>(() => {
-    const mine = rsvps.value.find(r => r.user_id === myId.value)
-    return (mine?.status as RsvpStatus | undefined) ?? null
-  })
-  const counts = computed(() => ({
-    going: rsvps.value.filter(r => r.status === 'going').length,
-    maybe: rsvps.value.filter(r => r.status === 'maybe').length,
-    no: rsvps.value.filter(r => r.status === 'no').length
-  }))
+  const mine = computed(() => rsvps.value.find(r => r.user_id === myId.value) ?? null)
+  const myStatus = computed<RsvpStatus | null>(() => (mine.value?.status as RsvpStatus | undefined) ?? null)
+  const myPlusOnes = computed(() => mine.value?.plus_ones ?? 0)
 
-  /** Set my status, or clear it if I tap the one I already have. */
+  const counts = computed(() => {
+    const going = rsvps.value.filter(r => r.status === 'going')
+    return {
+      going: going.length,
+      maybe: rsvps.value.filter(r => r.status === 'maybe').length,
+      no: rsvps.value.filter(r => r.status === 'no').length,
+      // Guests brought by those going — so the line can show the real headcount.
+      guests: going.reduce((sum, r) => sum + (r.plus_ones ?? 0), 0)
+    }
+  })
+
+  async function writeMine(status: RsvpStatus, plusOnes: number): Promise<void> {
+    const id = toValue(eventId)
+    if (!id || !myId.value) return
+    // Guests only count when going.
+    const guests = status === 'going' ? clampPlusOnes(plusOnes) : 0
+    const { error } = await supabase
+      .from('rsvps')
+      .upsert(
+        { event_id: id, user_id: myId.value, status, plus_ones: guests, updated_at: new Date().toISOString() },
+        { onConflict: 'event_id,user_id' }
+      )
+    if (error) throw error
+    await refresh()
+  }
+
+  /** Set my status, or clear it if I tap the one I already have. Switching to going
+   *  preserves a guest count I'd already set; leaving going drops it (writeMine zeroes
+   *  guests for non-going). */
   async function setStatus(status: RsvpStatus): Promise<void> {
     const id = toValue(eventId)
     if (!id || !myId.value) return
     if (myStatus.value === status) {
       const { error } = await supabase.from('rsvps').delete().eq('event_id', id).eq('user_id', myId.value)
       if (error) throw error
-    } else {
-      const { error } = await supabase
-        .from('rsvps')
-        .upsert(
-          { event_id: id, user_id: myId.value, status, updated_at: new Date().toISOString() },
-          { onConflict: 'event_id,user_id' }
-        )
-      if (error) throw error
+      await refresh()
+      return
     }
-    await refresh()
+    await writeMine(status, myPlusOnes.value)
   }
 
-  return { rsvps, error, myStatus, counts, setStatus }
+  /** Set how many guests I'm bringing (only meaningful while going). */
+  async function setGuests(plusOnes: number): Promise<void> {
+    if (myStatus.value !== 'going') return
+    await writeMine('going', plusOnes)
+  }
+
+  return { rsvps, error, myStatus, myPlusOnes, counts, setStatus, setGuests }
 }

--- a/app/composables/useRsvp.ts
+++ b/app/composables/useRsvp.ts
@@ -21,7 +21,7 @@ export function useRsvp(eventId: MaybeRefOrGetter<string | null | undefined>) {
   })
 
   const mine = computed(() => rsvps.value.find(r => r.user_id === myId.value) ?? null)
-  const myStatus = computed<RsvpStatus | null>(() => (mine.value?.status as RsvpStatus | undefined) ?? null)
+  const myStatus = computed<RsvpStatus | null>(() => (mine.value ? toRsvpStatus(mine.value.status) : null))
   const myPlusOnes = computed(() => mine.value?.plus_ones ?? 0)
 
   const counts = computed(() => {

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -24,7 +24,7 @@ const currentEvent = computed(() => events.value[eventIndex.value] ?? null)
 const currentEventId = computed(() => currentEvent.value?.id ?? null)
 
 const { suggestions, alreadySuggested, suggest, vote, unvote, removeSuggestion } = useSuggestions(currentEventId)
-const { myStatus, counts, setStatus } = useRsvp(currentEventId)
+const { myStatus, myPlusOnes, counts, setStatus, setGuests } = useRsvp(currentEventId)
 // Who else is looking at this movie night right now (Realtime Presence).
 const { online } = usePresence(currentEventId)
 
@@ -114,6 +114,9 @@ async function onRemove(suggestion: Suggestion): Promise<void> {
 async function onRsvp(status: RsvpStatus): Promise<void> {
   await run(() => setStatus(status), 'Could not update RSVP')
 }
+async function onGuests(count: number): Promise<void> {
+  await run(() => setGuests(count), 'Could not update guest count')
+}
 </script>
 
 <template>
@@ -162,7 +165,13 @@ async function onRsvp(status: RsvpStatus): Promise<void> {
             <h2 class="text-sm font-semibold text-muted mb-2">
               Are you coming?
             </h2>
-            <RsvpControl :my-status="myStatus" :counts="counts" @set="onRsvp" />
+            <RsvpControl
+              :my-status="myStatus"
+              :my-plus-ones="myPlusOnes"
+              :counts="counts"
+              @set="onRsvp"
+              @guests="onGuests"
+            />
             <p class="text-xs text-muted mt-3 text-center">
               <button type="button" class="text-primary underline inline-flex items-center gap-1" @click="eventInfoOpen = true">
                 <UIcon name="i-lucide-list" /> See the bring list

--- a/app/pages/rsvp.vue
+++ b/app/pages/rsvp.vue
@@ -12,6 +12,7 @@ const token = computed(() => (route.query.token ?? '').toString())
 
 const phase = ref<'saving' | 'done' | 'error'>('saving')
 const current = ref<RsvpStatus | null>(null)
+const guests = ref(0)
 
 const HEADLINE: Record<RsvpStatus, string> = {
   going: 'You\'re going! 🎉',
@@ -28,14 +29,22 @@ async function rsvp(status: RsvpStatus): Promise<void> {
     phase.value = 'error'
     return
   }
+  // Guests only ride along with going; switching away resets the local count.
+  if (status !== 'going') guests.value = 0
   phase.value = 'saving'
   try {
-    await $fetch('/api/rsvp', { method: 'POST', body: { token: token.value, status } })
+    await $fetch('/api/rsvp', { method: 'POST', body: { token: token.value, status, plusOnes: guests.value } })
     current.value = status
     phase.value = 'done'
   } catch {
     phase.value = 'error'
   }
+}
+
+/** Update the guest count and re-save (only while going). */
+async function setGuests(count: number): Promise<void> {
+  guests.value = count
+  if (current.value === 'going') await rsvp('going')
 }
 
 onMounted(() => {
@@ -65,6 +74,12 @@ onMounted(() => {
             <UButton label="Going" color="primary" :variant="current === 'going' ? 'solid' : 'outline'" @click="rsvp('going')" />
             <UButton label="Maybe" color="warning" :variant="current === 'maybe' ? 'solid' : 'outline'" @click="rsvp('maybe')" />
             <UButton label="Can't make it" color="neutral" :variant="current === 'no' ? 'solid' : 'outline'" @click="rsvp('no')" />
+          </div>
+
+          <!-- Bringing guests? Only while going. -->
+          <div v-if="current === 'going'" class="flex flex-col items-center gap-2 pt-1">
+            <span class="text-sm text-muted">Bringing guests?</span>
+            <GuestStepper :model-value="guests" @update:model-value="setGuests" />
           </div>
         </template>
 

--- a/app/pages/rsvp.vue
+++ b/app/pages/rsvp.vue
@@ -42,7 +42,7 @@ async function rsvp(status: RsvpStatus): Promise<void> {
 }
 
 /** Update the guest count and re-save (only while going). */
-async function setGuests(count: number): Promise<void> {
+    <GuestStepper :model-value="guests" :disabled="phase === 'saving'" @update:model-value="setGuests" />
   guests.value = count
   if (current.value === 'going') await rsvp('going')
 }

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -24,9 +24,9 @@ export interface Database {
         Relationships: []
       }
       event_invites: {
-        Row: { id: string, event_id: string, email: string, display_name: string | null, token: string, rsvp: string | null, rsvp_at: string | null, invited_by: string | null, resend_id: string | null, sent_at: string | null, delivered_at: string | null, opened_at: string | null, clicked_at: string | null, bounced_at: string | null, created_at: string }
-        Insert: { id?: string, event_id: string, email: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, created_at?: string }
-        Update: { id?: string, event_id?: string, email?: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, created_at?: string }
+        Row: { id: string, event_id: string, email: string, display_name: string | null, token: string, rsvp: string | null, rsvp_at: string | null, plus_ones: number, invited_by: string | null, resend_id: string | null, sent_at: string | null, delivered_at: string | null, opened_at: string | null, clicked_at: string | null, bounced_at: string | null, created_at: string }
+        Insert: { id?: string, event_id: string, email: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, plus_ones?: number, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, created_at?: string }
+        Update: { id?: string, event_id?: string, email?: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, plus_ones?: number, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, created_at?: string }
         Relationships: []
       }
       events: {
@@ -36,9 +36,9 @@ export interface Database {
         Relationships: []
       }
       rsvps: {
-        Row: { event_id: string, user_id: string, status: string, updated_at: string }
-        Insert: { event_id: string, user_id?: string, status: string, updated_at?: string }
-        Update: { event_id?: string, user_id?: string, status?: string, updated_at?: string }
+        Row: { event_id: string, user_id: string, status: string, plus_ones: number, updated_at: string }
+        Insert: { event_id: string, user_id?: string, status: string, plus_ones?: number, updated_at?: string }
+        Update: { event_id?: string, user_id?: string, status?: string, plus_ones?: number, updated_at?: string }
         Relationships: []
       }
       bring_items: {

--- a/server/api/rsvp.post.ts
+++ b/server/api/rsvp.post.ts
@@ -1,10 +1,14 @@
 import { serverSupabaseServiceRole } from '#supabase/server'
 import { z } from 'zod'
+import { MAX_PLUS_ONES } from '#shared/types/rsvp'
 import type { Database } from '~/types/database.types'
 
 const bodySchema = z.object({
   token: z.string().min(8).max(128),
-  status: z.enum(['going', 'maybe', 'no'])
+  status: z.enum(['going', 'maybe', 'no']),
+  // Additional guests the invitee is bringing. Only meaningful when going; clamped
+  // to the shared cap (mirrors the CHECK constraint) so a crafted body can't inflate.
+  plusOnes: z.number().int().min(0).max(MAX_PLUS_ONES).optional().default(0)
 })
 
 /**
@@ -17,6 +21,8 @@ export default defineEventHandler(async (event) => {
   const parsed = bodySchema.safeParse(await readBody(event))
   if (!parsed.success) throw createError({ statusCode: 400, statusMessage: 'Invalid RSVP' })
   const { token, status } = parsed.data
+  // Guests only count when going.
+  const plusOnes = status === 'going' ? parsed.data.plusOnes : 0
 
   const admin = serverSupabaseServiceRole<Database>(event)
   const { data: invite } = await admin
@@ -29,7 +35,7 @@ export default defineEventHandler(async (event) => {
   const now = new Date().toISOString()
   await admin
     .from('event_invites')
-    .update({ rsvp: status, rsvp_at: now, clicked_at: now })
+    .update({ rsvp: status, rsvp_at: now, clicked_at: now, plus_ones: plusOnes })
     .eq('id', invite.id)
 
   // Mirror into the app RSVP if this invitee is also a member (case-insensitive).
@@ -37,8 +43,8 @@ export default defineEventHandler(async (event) => {
   if (profile) {
     await admin
       .from('rsvps')
-      .upsert({ event_id: invite.event_id, user_id: profile.id, status, updated_at: now }, { onConflict: 'event_id,user_id' })
+      .upsert({ event_id: invite.event_id, user_id: profile.id, status, plus_ones: plusOnes, updated_at: now }, { onConflict: 'event_id,user_id' })
   }
 
-  return { ok: true, status }
+  return { ok: true, status, plusOnes }
 })

--- a/shared/types/rsvp.ts
+++ b/shared/types/rsvp.ts
@@ -2,6 +2,18 @@ export const RSVP_STATUSES = ['going', 'maybe', 'no'] as const
 
 export type RsvpStatus = (typeof RSVP_STATUSES)[number]
 
+/** Max additional guests ("+1"s) an attendee can bring. Mirrored by the CHECK
+ *  constraint on rsvps.plus_ones / event_invites.plus_ones — keep the two in sync. */
+export const MAX_PLUS_ONES = 10
+
+/** Clamp an arbitrary guest count into [0, MAX_PLUS_ONES] (floored). Guests only
+ *  count when going, so callers pass 0 for maybe/no. */
+export function clampPlusOnes(value: number | null | undefined): number {
+  const n = Math.floor(Number(value))
+  if (!Number.isFinite(n) || n <= 0) return 0
+  return Math.min(n, MAX_PLUS_ONES)
+}
+
 export function isRsvpStatus(value: string): value is RsvpStatus {
   return RSVP_STATUSES.some(s => s === value)
 }

--- a/supabase/migrations/20260627000000_rsvp_plus_ones.sql
+++ b/supabase/migrations/20260627000000_rsvp_plus_ones.sql
@@ -1,0 +1,17 @@
+-- "+1" / guest count — let an attendee say how many additional guests they're
+-- bringing when they RSVP "going". Stored on BOTH RSVP stores so the merged
+-- headcount (useEventRsvps) is accurate whether someone replied in-app or by e-vite:
+--   public.rsvps.plus_ones         — in-app member RSVPs
+--   public.event_invites.plus_ones — tokenized e-vite replies
+--
+-- Additive and safe (default 0 = today's behavior). The CHECK is the server-side
+-- source of truth, capped so a typo can't inflate the count; the UI mirrors the cap
+-- via MAX_PLUS_ONES in shared/types/rsvp.ts (keep the two in sync).
+
+alter table public.rsvps
+  add column if not exists plus_ones int not null default 0
+  constraint rsvps_plus_ones_range check (plus_ones >= 0 and plus_ones <= 10);
+
+alter table public.event_invites
+  add column if not exists plus_ones int not null default 0
+  constraint event_invites_plus_ones_range check (plus_ones >= 0 and plus_ones <= 10);

--- a/test/EventInviteManager.nuxt.test.ts
+++ b/test/EventInviteManager.nuxt.test.ts
@@ -47,11 +47,12 @@ mockNuxtImport('useToast', () => () => ({ add: (t: Toast) => toasts.push(t) }))
 mockNuxtImport('useInviteOptions', () => () => ({ save: saveOptionsFn }))
 mockNuxtImport('useEventRsvps', () => () => ({
   roster: ref({
-    going: [{ key: 'u1', name: 'Ada', email: 'ada@x.com', avatar: null, status: 'going', viaEmail: false }],
+    going: [{ key: 'u1', name: 'Ada', email: 'ada@x.com', avatar: null, status: 'going', plusOnes: 0, viaEmail: false }],
     maybe: [],
     no: [],
     noReply: [{ key: 'b@x.com', name: 'Bo', email: 'b@x.com' }],
-    total: 1
+    total: 1,
+    headcount: 1
   }),
   error: ref(null),
   refresh: async () => {}

--- a/test/GuestStepper.nuxt.test.ts
+++ b/test/GuestStepper.nuxt.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import GuestStepper from '../app/components/GuestStepper.vue'
+
+const minus = '[aria-label="One fewer guest"]'
+const plus = '[aria-label="One more guest"]'
+
+describe('GuestStepper', () => {
+  it('reads "just me" at zero and "+N guests" above', async () => {
+    const atZero = await mountSuspended(GuestStepper, { props: { modelValue: 0 } })
+    expect(atZero.text()).toContain('just me')
+    const atTwo = await mountSuspended(GuestStepper, { props: { modelValue: 2 } })
+    expect(atTwo.text()).toContain('+2 guests')
+    const atOne = await mountSuspended(GuestStepper, { props: { modelValue: 1 } })
+    expect(atOne.text()).toContain('+1 guest')
+  })
+
+  it('increments toward the next value', async () => {
+    const w = await mountSuspended(GuestStepper, { props: { modelValue: 1 } })
+    await w.find(plus).trigger('click')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual([2])
+  })
+
+  it('decrements toward the previous value', async () => {
+    const w = await mountSuspended(GuestStepper, { props: { modelValue: 1 } })
+    await w.find(minus).trigger('click')
+    expect(w.emitted('update:modelValue')?.[0]).toEqual([0])
+  })
+
+  it('disables minus at 0 and plus at the max', async () => {
+    const atZero = await mountSuspended(GuestStepper, { props: { modelValue: 0, max: 3 } })
+    expect(atZero.find(minus).attributes('disabled')).toBeDefined()
+    const atMax = await mountSuspended(GuestStepper, { props: { modelValue: 3, max: 3 } })
+    expect(atMax.find(plus).attributes('disabled')).toBeDefined()
+  })
+})

--- a/test/RsvpControl.nuxt.test.ts
+++ b/test/RsvpControl.nuxt.test.ts
@@ -18,4 +18,18 @@ describe('RsvpControl', () => {
     await maybeBtn?.trigger('click')
     expect(w.emitted('set')?.[0]).toEqual(['maybe'])
   })
+
+  it('surfaces guests in the headcount line when someone is bringing a +1', async () => {
+    const w = await mountSuspended(RsvpControl, { props: { myStatus: 'going', counts: { ...counts, guests: 2 } } })
+    expect(w.text()).toContain('+2 guests')
+  })
+
+  it('shows the guest stepper only while going, and emits guests on change', async () => {
+    const notGoing = await mountSuspended(RsvpControl, { props: { myStatus: 'maybe', counts } })
+    expect(notGoing.find('[aria-label="One more guest"]').exists()).toBe(false)
+
+    const going = await mountSuspended(RsvpControl, { props: { myStatus: 'going', myPlusOnes: 0, counts } })
+    await going.find('[aria-label="One more guest"]').trigger('click')
+    expect(going.emitted('guests')?.[0]).toEqual([1])
+  })
 })

--- a/test/RsvpRoster.nuxt.test.ts
+++ b/test/RsvpRoster.nuxt.test.ts
@@ -6,13 +6,14 @@ import type { EventRsvpRoster } from '../app/composables/useEventRsvps'
 
 const roster: EventRsvpRoster = {
   going: [
-    { key: 'u1', name: 'Ada', email: 'ada@x.com', avatar: null, status: 'going', viaEmail: false },
-    { key: 'g@x.com', name: 'Guest', email: 'g@x.com', avatar: null, status: 'going', viaEmail: true }
+    { key: 'u1', name: 'Ada', email: 'ada@x.com', avatar: null, status: 'going', plusOnes: 1, viaEmail: false },
+    { key: 'g@x.com', name: 'Guest', email: 'g@x.com', avatar: null, status: 'going', plusOnes: 2, viaEmail: true }
   ],
-  maybe: [{ key: 'u2', name: 'Bo', email: 'bo@x.com', avatar: null, status: 'maybe', viaEmail: false }],
+  maybe: [{ key: 'u2', name: 'Bo', email: 'bo@x.com', avatar: null, status: 'maybe', plusOnes: 0, viaEmail: false }],
   no: [],
   noReply: [{ key: 's@x.com', name: 'Silent', email: 's@x.com' }],
-  total: 3
+  total: 3,
+  headcount: 5 // 2 going + 3 guests
 }
 
 describe('RsvpRoster', () => {
@@ -23,6 +24,14 @@ describe('RsvpRoster', () => {
     expect(w.text()).toContain('Ada')
     expect(w.text()).toContain('Guest')
     expect(w.text()).toContain('Bo')
+  })
+
+  it('shows the headcount and per-person +N when guests are coming', async () => {
+    const w = await mountSuspended(RsvpRoster, { props: { roster } })
+    expect(w.text()).toContain('5 expected')
+    expect(w.text()).toContain('2 going + 3 guests')
+    expect(w.text()).toContain('+1') // Ada's guest badge
+    expect(w.text()).toContain('+2') // Guest's badge
   })
 
   it('hides the no-reply section unless asked (admin-only)', async () => {

--- a/test/useEventRsvps.nuxt.test.ts
+++ b/test/useEventRsvps.nuxt.test.ts
@@ -7,8 +7,8 @@ import type { EventRsvpRoster } from '../app/composables/useEventRsvps'
 // Controllable Supabase reads for the three tables the merge touches. Each test
 // sets the fixtures, then we wait for the immediate-watch load to settle.
 interface ProfileRow { id: string, display_name: string | null, email: string | null, avatar_url: string | null }
-interface InviteRow { email: string, display_name: string | null, rsvp: string | null }
-let rsvpRows: { user_id: string, status: string }[] = []
+interface InviteRow { email: string, display_name: string | null, rsvp: string | null, plus_ones?: number }
+let rsvpRows: { user_id: string, status: string, plus_ones?: number }[] = []
 let profileRows: ProfileRow[] = []
 let inviteRows: InviteRow[] = []
 
@@ -64,6 +64,26 @@ describe('useEventRsvps', () => {
     expect(roster.value.going[0]!.avatar).toBe('ada.jpg')
     expect(roster.value.maybe.map(p => p.name)).toEqual(['Bo'])
     expect(roster.value.total).toBe(2)
+  })
+
+  it('adds guests (plus_ones) into the headcount, going only', async () => {
+    rsvpRows = [
+      { user_id: 'u1', status: 'going', plus_ones: 2 },
+      { user_id: 'u2', status: 'going', plus_ones: 0 },
+      { user_id: 'u3', status: 'maybe', plus_ones: 5 } // ignored — not going
+    ]
+    profileRows = [
+      { id: 'u1', display_name: 'Ada', email: 'ada@x.com', avatar_url: null },
+      { id: 'u2', display_name: 'Bo', email: 'bo@x.com', avatar_url: null },
+      { id: 'u3', display_name: 'Cy', email: 'cy@x.com', avatar_url: null }
+    ]
+    inviteRows = []
+    const { roster } = useEventRsvps(ref('e1'))
+    await settle(roster)
+    // 2 going people + 2 guests = 4 expected; maybe's plus_ones is zeroed.
+    expect(roster.value.headcount).toBe(4)
+    expect(roster.value.going.find(p => p.name === 'Ada')!.plusOnes).toBe(2)
+    expect(roster.value.maybe.find(p => p.name === 'Cy')!.plusOnes).toBe(0)
   })
 
   it('folds email-only guests in and flags them viaEmail', async () => {

--- a/test/useRsvp.nuxt.test.ts
+++ b/test/useRsvp.nuxt.test.ts
@@ -6,7 +6,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 interface UpsertCall { payload: Record<string, unknown>, opts: unknown }
 interface DeleteCall { filters: Record<string, unknown> }
 const calls: { upserts: UpsertCall[], deletes: DeleteCall[] } = { upserts: [], deletes: [] }
-let rows: { user_id: string, status: string }[] = []
+let rows: { user_id: string, status: string, plus_ones?: number }[] = []
 
 // Minimal Supabase stub that records upserts/deletes and feeds refresh()/realtime.
 const supabase = {
@@ -57,8 +57,45 @@ describe('useRsvp', () => {
     rows = [{ user_id: 'me', status: 'going' }, { user_id: 'a', status: 'going' }, { user_id: 'b', status: 'maybe' }]
     const { counts, myStatus } = useRsvp(ref('e1'))
     await tick()
-    expect(counts.value).toEqual({ going: 2, maybe: 1, no: 0 })
+    expect(counts.value).toEqual({ going: 2, maybe: 1, no: 0, guests: 0 })
     expect(myStatus.value).toBe('going')
+  })
+
+  it('sums guests (plus_ones) across those going and resolves my own count', async () => {
+    rows = [
+      { user_id: 'me', status: 'going', plus_ones: 2 },
+      { user_id: 'a', status: 'going', plus_ones: 1 },
+      { user_id: 'b', status: 'maybe', plus_ones: 0 }
+    ]
+    const { counts, myPlusOnes } = useRsvp(ref('e1'))
+    await tick()
+    expect(counts.value.guests).toBe(3)
+    expect(myPlusOnes.value).toBe(2)
+  })
+
+  it('setGuests upserts going with the clamped guest count', async () => {
+    rows = [{ user_id: 'me', status: 'going', plus_ones: 0 }]
+    const { setGuests } = useRsvp(ref('e1'))
+    await tick()
+    await setGuests(3)
+    expect(calls.upserts).toHaveLength(1)
+    expect(calls.upserts[0]!.payload).toMatchObject({ status: 'going', plus_ones: 3 })
+  })
+
+  it('setGuests is a no-op when I am not going (guests only count for going)', async () => {
+    rows = [{ user_id: 'me', status: 'maybe', plus_ones: 0 }]
+    const { setGuests } = useRsvp(ref('e1'))
+    await tick()
+    await setGuests(2)
+    expect(calls.upserts).toHaveLength(0)
+  })
+
+  it('switching to maybe zeroes any guest count', async () => {
+    rows = [{ user_id: 'me', status: 'going', plus_ones: 4 }]
+    const { setStatus } = useRsvp(ref('e1'))
+    await tick()
+    await setStatus('maybe')
+    expect(calls.upserts[0]!.payload).toMatchObject({ status: 'maybe', plus_ones: 0 })
   })
 
   it('setStatus upserts the new status with the composite conflict target', async () => {


### PR DESCRIPTION
## Scope

Invitees can now say **how many additional guests** they're bringing when they RSVP *Going* — a guest count (0–10), on **both** RSVP paths — and the merged roster/headcount reflects it. Also folds in a small requested EventHero tweak (address on its own line, weather beneath).

## Implementation

- **Schema** (`20260627000000_rsvp_plus_ones.sql`): `plus_ones int not null default 0` with a `CHECK (0..10)` on **both** `rsvps` and `event_invites`. Additive and safe (default 0 = today's behavior). The cap mirrors `MAX_PLUS_ONES` in `shared/types/rsvp.ts`.
- **`GuestStepper.vue`**: a reusable "− N +" control ("just me" / "+N guests"), clamped to `[0, max]`, used by both surfaces.
- **In-app**: `useRsvp` exposes `myPlusOnes` + `setGuests` + `counts.guests`; guests only count while going (switching to maybe/no zeroes them). `RsvpControl` shows the stepper while going and the guest tally in the headcount line — wired in the overview and the event modal.
- **E-vite**: `/api/rsvp` accepts `plusOnes` (zod-clamped, going-only), stores it on `event_invites`, and mirrors it into `rsvps` for members. The `/rsvp` landing page shows the stepper after you reply *going* and re-saves on change.
- **Roster**: `useEventRsvps` carries `plusOnes` per entry and a `headcount` (going people + their guests); `RsvpRoster` renders a `+N` badge per person and an "N expected (X going + Y guests)" line — so the admin's "Who's RSVP'd" and the event modal both show the real headcount.

## How to Test

**Automated** (Node 22; full suite 356 passed / 9 skipped, typecheck clean, 0 lint errors):
- `useRsvp` — sums guests across those going, resolves `myPlusOnes`, `setGuests` upserts going+count, no-ops when not going, switching to maybe zeroes guests.
- `GuestStepper` — labels, increment/decrement, disabled at bounds.
- `RsvpControl` — stepper only while going, emits `guests`, headcount line shows guests.
- `useEventRsvps` — guests roll into `headcount` (going only).
- `RsvpRoster` — `+N` badge + "N expected" line.

**Manual:** RSVP *Going* in-app → "Bringing guests?" stepper appears → bump to +2 → the count line and the roster's headcount update live. Reply *Going* from an e-vite email link → same stepper on the confirmation page; the admin roster shows your name with a `+2` badge and a ✉️ glyph.

## Invariants & Risk

- No authorization changes — reads/writes ride the existing RLS (own RSVP; admin-only `event_invites`). The guest count is clamped both client- and server-side (zod + DB `CHECK`).
- ⚠️ **Migration must be applied to prod.** The `db-migrate` workflow is still failing on missing secrets, so apply `20260627000000_rsvp_plus_ones.sql` via the Supabase SQL editor (or fix the workflow secrets first). Until applied, `plus_ones` selects will error — same class of issue as the #107 incident, so don't deploy the app ahead of the migration.