### PR TITLE
fix: hearts above everything + animated vote reordering (+ repair broken rsvp.vue)

### DIFF
--- a/app/components/FloatingHearts.vue
+++ b/app/components/FloatingHearts.vue
@@ -1,17 +1,22 @@
 <script setup lang="ts">
-// A tiny flourish: spawn a heart that floats up and fades when the user (un)votes.
-// 'vote' → a red heart rising; 'unvote' → a grayscale broken heart. Self-cleaning:
-// each heart removes itself on animationend so the list never grows unbounded.
+// A tiny flourish: spawn a heart that floats up the screen and fades when the user
+// (un)votes. 'vote' → a red heart; 'unvote' → a grayscale broken heart.
+//
+// Rendered in a fixed, teleported-to-<body> overlay so it sits above everything and
+// is never clipped by a card's rounded `overflow-hidden` (the old in-card version got
+// trapped behind the cards above it). Each heart is positioned at the click's screen
+// coords and removes itself on animationend so the list never grows unbounded.
 type HeartKind = 'vote' | 'unvote'
-interface Heart { id: number, kind: HeartKind, drift: number }
+interface Heart { id: number, kind: HeartKind, x: number, y: number, drift: number }
 
 const hearts = ref<Heart[]>([])
 let seq = 0
 
-function spawn(kind: HeartKind): void {
+/** Spawn a heart at viewport coords (x, y) — the center of the tapped vote button. */
+function spawn(kind: HeartKind, x: number, y: number): void {
   // A little horizontal drift so repeated taps don't stack in a single column.
-  const drift = Math.round((Math.random() - 0.5) * 22)
-  hearts.value = [...hearts.value, { id: seq++, kind, drift }]
+  const drift = Math.round((Math.random() - 0.5) * 48)
+  hearts.value = [...hearts.value, { id: seq++, kind, x, y, drift }]
 }
 
 function remove(id: number): void {
@@ -22,19 +27,21 @@ defineExpose({ spawn })
 </script>
 
 <template>
-  <div class="floating-hearts pointer-events-none absolute inset-0 overflow-visible">
-    <UIcon
-      v-for="h in hearts"
-      :key="h.id"
-      :name="h.kind === 'vote' ? 'i-lucide-heart' : 'i-lucide-heart-crack'"
-      :class="[
-        'floating-heart absolute left-1/2 top-1/2 size-5',
-        h.kind === 'vote' ? 'text-red-500' : 'text-neutral-400 grayscale'
-      ]"
-      :style="{ '--drift': `${h.drift}px` }"
-      @animationend="remove(h.id)"
-    />
-  </div>
+  <Teleport to="body">
+    <div class="floating-hearts pointer-events-none fixed inset-0 z-[100] overflow-hidden">
+      <UIcon
+        v-for="h in hearts"
+        :key="h.id"
+        :name="h.kind === 'vote' ? 'i-lucide-heart' : 'i-lucide-heart-crack'"
+        :class="[
+          'floating-heart fixed size-7 drop-shadow',
+          h.kind === 'vote' ? 'text-red-500' : 'text-neutral-400 grayscale'
+        ]"
+        :style="{ 'left': `${h.x}px`, 'top': `${h.y}px`, '--drift': `${h.drift}px` }"
+        @animationend="remove(h.id)"
+      />
+    </div>
+  </Teleport>
 </template>
 
 <style scoped>
@@ -43,18 +50,20 @@ defineExpose({ spawn })
     opacity: 0;
     transform: translate(-50%, -50%) scale(0.4);
   }
-  25% {
+  12% {
     opacity: 1;
-    transform: translate(calc(-50% + var(--drift) * 0.4), -120%) scale(1);
+    transform: translate(-50%, -50%) scale(1.1);
   }
+  /* Rise about half the viewport, fading out over the back half of the trip. */
   100% {
     opacity: 0;
-    transform: translate(calc(-50% + var(--drift)), -260%) scale(1.15);
+    transform: translate(calc(-50% + var(--drift)), calc(-50% - 48vh)) scale(1.25);
   }
 }
 
 .floating-heart {
-  animation: floating-heart 0.9s ease-out forwards;
+  animation: floating-heart 1.8s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+  will-change: transform, opacity;
 }
 
 /* Respect users who prefer no motion — show nothing rather than a jump. */

--- a/app/components/GuestStepper.vue
+++ b/app/components/GuestStepper.vue
@@ -4,12 +4,13 @@ import { MAX_PLUS_ONES } from '#shared/types/rsvp'
 // A compact "− N +" stepper for the number of additional guests an attendee is
 // bringing (their "+1"s). Clamps to [0, max]; emits on every change.
 const model = defineModel<number>({ default: 0 })
-const props = withDefaults(defineProps<{ max?: number }>(), { max: MAX_PLUS_ONES })
+const props = withDefaults(defineProps<{ max?: number, disabled?: boolean }>(), { max: MAX_PLUS_ONES, disabled: false })
 
-const atMin = computed(() => model.value <= 0)
-const atMax = computed(() => model.value >= props.max)
+const atMin = computed(() => props.disabled || model.value <= 0)
+const atMax = computed(() => props.disabled || model.value >= props.max)
 
 function step(delta: number): void {
+  if (props.disabled) return
   model.value = Math.min(props.max, Math.max(0, model.value + delta))
 }
 </script>

--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -33,15 +33,19 @@ const rankClass = computed(() => {
 })
 const highlight = computed(() => props.rank === 1 && voteCount.value > 0)
 
-// The floating-heart flourish lives over the vote button; spawn it optimistically
-// on click (it's a flourish, not a state indicator) then emit the actual action.
-const hearts = useTemplateRef<{ spawn: (kind: 'vote' | 'unvote') => void }>('hearts')
-function onHeartClick(): void {
+// The floating-heart flourish is a teleported overlay; spawn it at the tapped
+// button's center (works for mouse + keyboard) optimistically on click — it's a
+// flourish, not a state indicator — then emit the actual action.
+const hearts = useTemplateRef<{ spawn: (kind: 'vote' | 'unvote', x: number, y: number) => void }>('hearts')
+function onHeartClick(e: MouseEvent): void {
+  const rect = (e.currentTarget as HTMLElement | null)?.getBoundingClientRect()
+  const x = rect ? rect.left + rect.width / 2 : e.clientX
+  const y = rect ? rect.top + rect.height / 2 : e.clientY
   if (hasVoted.value) {
-    hearts.value?.spawn('unvote')
+    hearts.value?.spawn('unvote', x, y)
     emit('unvote')
   } else {
-    hearts.value?.spawn('vote')
+    hearts.value?.spawn('vote', x, y)
     emit('vote')
   }
 }

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -274,7 +274,8 @@ async function onGuests(count: number): Promise<void> {
             />
           </div>
 
-          <div v-if="suggestions.length" class="space-y-3">
+          <!-- TransitionGroup animates the FLIP reorder when votes change the ranking. -->
+          <TransitionGroup v-if="suggestions.length" tag="div" name="rank" class="relative space-y-3">
             <SuggestionCard
               v-for="(suggestion, index) in suggestions"
               :key="suggestion.id"
@@ -288,7 +289,7 @@ async function onGuests(count: number): Promise<void> {
               @remove="onRemove(suggestion)"
               @trailer="openTrailer(suggestion)"
             />
-          </div>
+          </TransitionGroup>
           <UCard v-else variant="subtle" class="text-center py-10">
             <UIcon name="i-lucide-film" class="size-8 text-muted mx-auto" />
             <p class="text-muted mt-2">
@@ -328,3 +329,31 @@ async function onGuests(count: number): Promise<void> {
     <TrailerModal v-model:open="trailerOpen" :movie="trailerMovie" />
   </UContainer>
 </template>
+
+<style scoped>
+/* Smoothly slide cards to their new rank when votes reorder the list (FLIP), and
+   fade suggestions in/out as they're added/removed. */
+.rank-move,
+.rank-enter-active,
+.rank-leave-active {
+  transition: transform 0.45s cubic-bezier(0.22, 0.61, 0.36, 1), opacity 0.35s ease;
+}
+.rank-enter-from,
+.rank-leave-to {
+  opacity: 0;
+  transform: scale(0.97);
+}
+/* Take a leaving card out of flow so the others FLIP up into its place. */
+.rank-leave-active {
+  position: absolute;
+  width: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rank-move,
+  .rank-enter-active,
+  .rank-leave-active {
+    transition: none;
+  }
+}
+</style>

--- a/app/pages/rsvp.vue
+++ b/app/pages/rsvp.vue
@@ -13,6 +13,9 @@ const token = computed(() => (route.query.token ?? '').toString())
 const phase = ref<'saving' | 'done' | 'error'>('saving')
 const current = ref<RsvpStatus | null>(null)
 const guests = ref(0)
+// Updating the guest count re-saves in the background (no full-screen spinner) —
+// this flag just disables the stepper for the in-flight request.
+const savingGuests = ref(false)
 
 const HEADLINE: Record<RsvpStatus, string> = {
   going: 'You\'re going! 🎉',
@@ -41,10 +44,20 @@ async function rsvp(status: RsvpStatus): Promise<void> {
   }
 }
 
-/** Update the guest count and re-save (only while going). */
-    <GuestStepper :model-value="guests" :disabled="phase === 'saving'" @update:model-value="setGuests" />
+/** Update the guest count and re-save in the background (only while going). Keeps
+ *  the "done" view up (no spinner flicker on every tap) and disables the stepper for
+ *  the in-flight request. */
+async function setGuests(count: number): Promise<void> {
   guests.value = count
-  if (current.value === 'going') await rsvp('going')
+  if (current.value !== 'going' || !token.value) return
+  savingGuests.value = true
+  try {
+    await $fetch('/api/rsvp', { method: 'POST', body: { token: token.value, status: 'going', plusOnes: count } })
+  } catch {
+    phase.value = 'error'
+  } finally {
+    savingGuests.value = false
+  }
 }
 
 onMounted(() => {
@@ -79,7 +92,7 @@ onMounted(() => {
           <!-- Bringing guests? Only while going. -->
           <div v-if="current === 'going'" class="flex flex-col items-center gap-2 pt-1">
             <span class="text-sm text-muted">Bringing guests?</span>
-            <GuestStepper :model-value="guests" @update:model-value="setGuests" />
+            <GuestStepper :model-value="guests" :disabled="savingGuests" @update:model-value="setGuests" />
           </div>
         </template>
 

--- a/test/FloatingHearts.nuxt.test.ts
+++ b/test/FloatingHearts.nuxt.test.ts
@@ -1,40 +1,50 @@
 // @vitest-environment nuxt
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { nextTick } from 'vue'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import FloatingHearts from '../app/components/FloatingHearts.vue'
 
-interface Spawner { spawn: (kind: 'vote' | 'unvote') => void }
+// Hearts teleport to <body>, so query the document rather than the wrapper.
+interface Spawner { spawn: (kind: 'vote' | 'unvote', x: number, y: number) => void }
+const inBody = (): Element[] => Array.from(document.body.querySelectorAll('.floating-heart'))
+
+afterEach(() => {
+  document.body.querySelectorAll('.floating-heart').forEach(el => el.remove())
+})
 
 describe('FloatingHearts', () => {
   it('starts empty', async () => {
-    const w = await mountSuspended(FloatingHearts)
-    expect(w.findAll('.floating-heart')).toHaveLength(0)
+    await mountSuspended(FloatingHearts)
+    expect(inBody()).toHaveLength(0)
   })
 
-  it('spawns a red heart for a vote and a grayscale one for an unvote', async () => {
+  it('spawns a red heart for a vote and a grayscale one for an unvote, at the given coords', async () => {
     const w = await mountSuspended(FloatingHearts)
     const vm = w.vm as unknown as Spawner
-    vm.spawn('vote')
+    vm.spawn('vote', 40, 60)
     await nextTick()
-    expect(w.find('.floating-heart').classes()).toContain('text-red-500')
+    const first = inBody()[0]!
+    expect(first.className).toContain('text-red-500')
+    // Positioned at the click's screen coords (fixed overlay).
+    expect((first as HTMLElement).style.left).toBe('40px')
+    expect((first as HTMLElement).style.top).toBe('60px')
 
-    vm.spawn('unvote')
+    vm.spawn('unvote', 0, 0)
     await nextTick()
-    const all = w.findAll('.floating-heart')
+    const all = inBody()
     expect(all).toHaveLength(2)
-    expect(all[1]!.classes()).toContain('grayscale')
+    expect(all[1]!.className).toContain('grayscale')
   })
 
   it('removes each heart when its float animation ends', async () => {
     const w = await mountSuspended(FloatingHearts)
     const vm = w.vm as unknown as Spawner
-    vm.spawn('vote')
+    vm.spawn('vote', 10, 10)
     await nextTick()
-    expect(w.findAll('.floating-heart')).toHaveLength(1)
+    expect(inBody()).toHaveLength(1)
 
-    await w.find('.floating-heart').trigger('animationend')
+    inBody()[0]!.dispatchEvent(new Event('animationend', { bubbles: true }))
     await nextTick()
-    expect(w.findAll('.floating-heart')).toHaveLength(0)
+    expect(inBody()).toHaveLength(0)
   })
 })

--- a/test/GuestStepper.nuxt.test.ts
+++ b/test/GuestStepper.nuxt.test.ts
@@ -34,4 +34,12 @@ describe('GuestStepper', () => {
     const atMax = await mountSuspended(GuestStepper, { props: { modelValue: 3, max: 3 } })
     expect(atMax.find(plus).attributes('disabled')).toBeDefined()
   })
+
+  it('disabled freezes both buttons and ignores clicks', async () => {
+    const w = await mountSuspended(GuestStepper, { props: { modelValue: 1, disabled: true } })
+    expect(w.find(minus).attributes('disabled')).toBeDefined()
+    expect(w.find(plus).attributes('disabled')).toBeDefined()
+    await w.find(plus).trigger('click')
+    expect(w.emitted('update:modelValue')).toBeFalsy()
+  })
 })

--- a/test/SuggestionCard.nuxt.test.ts
+++ b/test/SuggestionCard.nuxt.test.ts
@@ -1,8 +1,13 @@
 // @vitest-environment nuxt
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { ref } from 'vue'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import SuggestionCard from '../app/components/SuggestionCard.vue'
+
+// Hearts teleport to <body> and persist across mounts — clear them between tests.
+afterEach(() => {
+  document.body.querySelectorAll('.floating-heart').forEach(el => el.remove())
+})
 
 mockNuxtImport('useAuth', () => () => ({ myId: ref('me') }))
 mockNuxtImport('useTmdb', () => () => ({ posterUrl: () => null }))
@@ -33,23 +38,26 @@ describe('SuggestionCard', () => {
     expect(w.emitted('vote')).toBeFalsy()
   })
 
+  // The heart overlay teleports to <body>, so assert against the document.
+  const bodyHeart = (): HTMLElement | null => document.body.querySelector('.floating-heart')
+
   it('floats a red heart up when I cast a vote', async () => {
     const notVoted = { ...suggestion, votes: [{ user_id: 'bob' }] }
     const w = await mountSuspended(SuggestionCard, { props: { suggestion: notVoted, rank: 1, maxVotes: 2 } })
     await w.get('[aria-label="Vote"]').trigger('click')
-    const heart = w.find('.floating-heart')
-    expect(heart.exists()).toBe(true)
-    expect(heart.classes()).toContain('text-red-500')
+    const heart = bodyHeart()
+    expect(heart?.className).toContain('text-red-500')
     expect(w.emitted('vote')).toBeTruthy()
+    heart?.remove()
   })
 
   it('floats a grayscale broken heart up when I remove my vote', async () => {
     const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2 } })
     await w.get('[aria-label="Remove vote"]').trigger('click')
-    const heart = w.find('.floating-heart')
-    expect(heart.exists()).toBe(true)
-    expect(heart.classes()).toContain('grayscale')
+    const heart = bodyHeart()
+    expect(heart?.className).toContain('grayscale')
     expect(w.emitted('unvote')).toBeTruthy()
+    heart?.remove()
   })
 
   it('emits trailer from the Trailer button', async () => {


### PR DESCRIPTION
## Scope

Two vote-feedback polish items you asked for — plus an urgent repair: **`main` (1.7.0) currently has a broken `app/pages/rsvp.vue`** that fails the SFC build.

## 1. Floating hearts — above everything, slower

The hearts were anchored *inside* the suggestion card, so they got clipped by the card's rounded `overflow-hidden` and painted behind the cards above — and at 0.9s / −260% they were gone too fast.

- Now rendered in a **fixed, teleported-to-`<body>` overlay** (`z-[100]`, `pointer-events-none`) → always on top, never clipped. Each heart spawns at the **tapped button's screen coords** (works for mouse and keyboard).
- **Slower, longer flight**: rises ~48vh and fades over **1.8s** with an ease-out curve. Honors `prefers-reduced-motion`.

## 2. Animated vote reordering

Wrapped the suggestion list in `<TransitionGroup name="rank">`, so when votes change the ranking the cards **FLIP-slide** to their new positions (and fade in/out on add/remove) — restoring the old animated reshuffle. Disabled under `prefers-reduced-motion`.

## 3. Hotfix: repair broken `rsvp.vue`

`1.7.0` shipped `rsvp.vue` with a `GuestStepper` template line pasted over the `setGuests()` function declaration — an SFC parse error (`Unexpected token`) that **fails `nuxt build`/typecheck**. This:
- Restores `setGuests()`.
- Implements the intended "disable the stepper while saving" *correctly*: changing the guest count now re-saves **in the background** (a `savingGuests` flag) instead of flipping the whole page to the loading spinner — so the stepper no longer flickers away on every ± tap.
- `GuestStepper` gains a `disabled` prop (freezes both buttons, ignores clicks).

> ⚠️ Worth fast-tracking #3 — until this merges, a fresh deploy of main can fail to build / the `/rsvp` page is broken.

## How to Test

**Automated** (Node 22; full suite 357 passed / 9 skipped, typecheck clean, 0 lint errors):
- `FloatingHearts` — asserts the teleported `<body>` nodes, spawn coords, kind→color, and self-removal on `animationend`.
- `SuggestionCard` — red heart on vote / grayscale on unvote (now reads from `document.body`), clears hearts between tests.
- `GuestStepper` — `disabled` freezes both buttons and emits nothing.

**Manual:** vote on a lower-ranked movie → a red heart floats up past the cards above and off toward the top; the cards smoothly slide into their new order. Unvote → grayscale broken heart. On the e-vite `/rsvp` page, reply *Going* and tap the guest stepper → it updates without the page flashing to the spinner.

## Invariants & Risk

- Presentational only; no auth/schema/key changes. The `rsvp.vue` fix restores intended behavior and unbreaks the build.