### PR TITLE
feat: admin suggestions dashboard (movies / people / gaps + summary)

### DIFF
--- a/app/components/AdminSuggestionDashboard.vue
+++ b/app/components/AdminSuggestionDashboard.vue
@@ -148,9 +148,9 @@ function voterNames(s: AdminSuggestion): string[] {
               <UIcon name="i-lucide-heart" class="text-error align-text-bottom" />
               {{ s.voteCount ?? 0 }} votes
             </p>
-            <div v-if="voterNames(s).length" class="flex flex-wrap gap-1 mt-2">
+            <div v-if="voterNames(s) as names" class="flex flex-wrap gap-1 mt-2">
               <UBadge
-                v-for="(name, i) in voterNames(s)"
+                v-for="(name, i) in names"
                 :key="`${s.id}-${i}`"
                 :label="name"
                 color="neutral"

--- a/app/components/AdminSuggestionDashboard.vue
+++ b/app/components/AdminSuggestionDashboard.vue
@@ -108,7 +108,6 @@ function voterNames(s: AdminSuggestion): string[] {
 
     <!-- View switch -->
     <div class="flex flex-wrap items-center justify-between gap-2">
-      <div class="flex gap-1">
         <UButton
           v-for="v in views"
           :key="v.value"
@@ -117,6 +116,7 @@ function voterNames(s: AdminSuggestion): string[] {
           size="sm"
           :color="view === v.value ? 'primary' : 'neutral'"
           :variant="view === v.value ? 'solid' : 'outline'"
+          :aria-pressed="view === v.value"
           @click="view = v.value"
         />
       </div>

--- a/app/components/AdminSuggestionDashboard.vue
+++ b/app/components/AdminSuggestionDashboard.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import type { AdminSuggestion } from '#shared/types/suggestion'
+
+const props = defineProps<{
+  suggestions: AdminSuggestion[]
+  /** People who RSVP'd (going/maybe) — to surface who hasn't suggested/voted. */
+  expected?: { userId: string, name: string }[]
+  winnerIds?: string[]
+  votingLocked?: boolean
+}>()
+const emit = defineEmits<{ toggle: [id: string, deleted: boolean] }>()
+
+type View = 'movies' | 'people' | 'gaps'
+type Sort = 'votes' | 'newest' | 'title'
+type Filter = 'all' | 'visible' | 'hidden'
+
+const view = ref<View>('movies')
+const sort = ref<Sort>('votes')
+const filter = ref<Filter>('all')
+
+const views = [
+  { value: 'movies' as const, label: 'Movies', icon: 'i-lucide-clapperboard' },
+  { value: 'people' as const, label: 'People', icon: 'i-lucide-users' },
+  { value: 'gaps' as const, label: 'Gaps', icon: 'i-lucide-user-x' }
+]
+const sorts = [
+  { value: 'votes' as const, label: 'Most votes' },
+  { value: 'newest' as const, label: 'Newest' },
+  { value: 'title' as const, label: 'Title' }
+]
+const filters = [
+  { value: 'all' as const, label: 'All' },
+  { value: 'visible' as const, label: 'Visible' },
+  { value: 'hidden' as const, label: 'Hidden' }
+]
+
+const dashboard = computed(() =>
+  computeSuggestionDashboard({ suggestions: props.suggestions, winnerIds: props.winnerIds, expected: props.expected })
+)
+
+const movies = computed(() => {
+  const filtered = props.suggestions.filter((s) => {
+    if (filter.value === 'visible') return !s.deleted
+    if (filter.value === 'hidden') return s.deleted
+    return true
+  })
+  return [...filtered].sort((a, b) => {
+    if (sort.value === 'title') return a.tmdb_movie.title.localeCompare(b.tmdb_movie.title)
+    if (sort.value === 'newest') return (b.created_at ?? '').localeCompare(a.created_at ?? '')
+    return (b.voteCount ?? 0) - (a.voteCount ?? 0)
+  })
+})
+
+function voterNames(s: AdminSuggestion): string[] {
+  return (s.votes ?? []).map(v => v.voter?.display_name ?? 'Unknown')
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- Headline stats -->
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 text-center">
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold">
+          {{ dashboard.summary.suggestions }}
+        </p>
+        <p class="text-xs text-muted">
+          movies
+        </p>
+      </UCard>
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold">
+          {{ dashboard.summary.votes }}
+        </p>
+        <p class="text-xs text-muted">
+          votes
+        </p>
+      </UCard>
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold">
+          {{ dashboard.summary.submitters }}
+        </p>
+        <p class="text-xs text-muted">
+          submitters
+        </p>
+      </UCard>
+      <UCard variant="subtle" :ui="{ body: 'p-3' }">
+        <p class="text-xl font-bold">
+          {{ dashboard.summary.voters }}
+        </p>
+        <p class="text-xs text-muted">
+          voters
+        </p>
+      </UCard>
+    </div>
+
+    <div v-if="dashboard.summary.mostVoted || dashboard.summary.topVoters.length" class="flex flex-wrap gap-x-6 gap-y-1 text-sm">
+      <p v-if="dashboard.summary.mostVoted && dashboard.summary.mostVoted.votes > 0">
+        <span class="text-muted">Leading:</span>
+        <span class="font-medium">{{ dashboard.summary.mostVoted.title }}</span>
+        <span class="text-muted">({{ dashboard.summary.mostVoted.votes }})</span>
+      </p>
+      <p v-if="dashboard.summary.topVoters.length">
+        <span class="text-muted">Top voters:</span>
+        <span class="font-medium">{{ dashboard.summary.topVoters.map(v => `${v.name} (${v.votes})`).join(', ') }}</span>
+      </p>
+    </div>
+
+    <!-- View switch -->
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <div class="flex gap-1">
+        <UButton
+          v-for="v in views"
+          :key="v.value"
+          :label="v.label"
+          :icon="v.icon"
+          size="sm"
+          :color="view === v.value ? 'primary' : 'neutral'"
+          :variant="view === v.value ? 'solid' : 'outline'"
+          @click="view = v.value"
+        />
+      </div>
+      <div v-if="view === 'movies'" class="flex flex-wrap gap-1">
+        <USelectMenu v-model="sort" :items="sorts" value-key="value" :search-input="false" size="sm" class="w-36" />
+        <USelectMenu v-model="filter" :items="filters" value-key="value" :search-input="false" size="sm" class="w-28" />
+      </div>
+    </div>
+
+    <!-- MOVIES -->
+    <div v-if="view === 'movies'" class="space-y-3">
+      <UCard
+        v-for="s in movies"
+        :key="s.id"
+        variant="subtle"
+        :class="s.deleted ? 'opacity-60' : ''"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <h3 class="font-semibold">
+              {{ s.tmdb_movie.title }}
+              <UBadge v-if="s.deleted" label="Hidden" color="neutral" variant="subtle" size="xs" />
+              <UBadge v-if="winnerIds?.includes(s.id)" label="Winner" color="primary" variant="subtle" size="xs" />
+            </h3>
+            <p class="text-sm text-muted truncate">
+              by {{ s.author?.display_name || s.author?.email || 'unknown' }}
+            </p>
+            <p class="text-sm mt-1">
+              <UIcon name="i-lucide-heart" class="text-error align-text-bottom" />
+              {{ s.voteCount ?? 0 }} votes
+            </p>
+            <div v-if="voterNames(s).length" class="flex flex-wrap gap-1 mt-2">
+              <UBadge
+                v-for="(name, i) in voterNames(s)"
+                :key="`${s.id}-${i}`"
+                :label="name"
+                color="neutral"
+                variant="outline"
+                size="xs"
+              />
+            </div>
+          </div>
+          <UButton
+            v-if="s.deleted"
+            label="Restore"
+            icon="i-lucide-rotate-ccw"
+            color="neutral"
+            variant="outline"
+            size="sm"
+            class="shrink-0"
+            @click="emit('toggle', s.id, false)"
+          />
+          <UButton
+            v-else
+            label="Hide"
+            icon="i-lucide-eye-off"
+            color="error"
+            variant="outline"
+            size="sm"
+            class="shrink-0"
+            @click="emit('toggle', s.id, true)"
+          />
+        </div>
+      </UCard>
+      <UCard v-if="!movies.length" variant="subtle" class="text-center text-muted">
+        No suggestions for this filter.
+      </UCard>
+    </div>
+
+    <!-- PEOPLE -->
+    <div v-else-if="view === 'people'" class="space-y-3">
+      <UCard v-for="p in dashboard.byPerson" :key="p.userId" variant="subtle">
+        <p class="font-semibold mb-2">
+          {{ p.name }}
+        </p>
+        <div class="grid sm:grid-cols-2 gap-3">
+          <div>
+            <p class="text-xs font-semibold text-muted mb-1.5 flex items-center gap-1">
+              <UIcon name="i-lucide-clapperboard" /> Suggested · {{ p.suggested.length }}
+            </p>
+            <ul v-if="p.suggested.length" class="space-y-1">
+              <li v-for="m in p.suggested" :key="m.id" class="text-sm flex items-center gap-1.5">
+                <span class="truncate">{{ m.title }}</span>
+                <UBadge :label="`${m.votes}`" icon="i-lucide-heart" color="neutral" variant="subtle" size="xs" class="shrink-0" />
+                <UBadge v-if="m.won" label="Winner" color="primary" variant="subtle" size="xs" class="shrink-0" />
+              </li>
+            </ul>
+            <p v-else class="text-sm text-muted">
+              —
+            </p>
+          </div>
+          <div>
+            <p class="text-xs font-semibold text-muted mb-1.5 flex items-center gap-1">
+              <UIcon name="i-lucide-heart" /> Voted for · {{ p.votedFor.length }}
+            </p>
+            <ul v-if="p.votedFor.length" class="space-y-1">
+              <li v-for="m in p.votedFor" :key="m.id" class="text-sm truncate">
+                {{ m.title }}
+              </li>
+            </ul>
+            <p v-else class="text-sm text-muted">
+              —
+            </p>
+          </div>
+        </div>
+      </UCard>
+      <UCard v-if="!dashboard.byPerson.length" variant="subtle" class="text-center text-muted">
+        No participation yet.
+      </UCard>
+    </div>
+
+    <!-- GAPS -->
+    <div v-else class="space-y-2">
+      <p class="text-sm text-muted">
+        Coming (RSVP'd going/maybe) but haven't fully joined in — nudge them.
+      </p>
+      <UCard v-for="g in dashboard.gaps" :key="g.userId" variant="subtle" :ui="{ body: 'p-3' }">
+        <div class="flex items-center justify-between gap-2">
+          <span class="font-medium truncate">{{ g.name }}</span>
+          <div class="flex gap-1 shrink-0">
+            <UBadge v-if="!g.suggested" label="No suggestion" icon="i-lucide-clapperboard" color="warning" variant="subtle" size="xs" />
+            <UBadge v-if="!g.voted" label="No vote" icon="i-lucide-heart" color="warning" variant="subtle" size="xs" />
+          </div>
+        </div>
+      </UCard>
+      <UCard v-if="!dashboard.gaps.length" variant="subtle" class="text-center text-muted">
+        Everyone who RSVP'd has suggested and voted. 🎉
+      </UCard>
+    </div>
+  </div>
+</template>

--- a/app/components/GuestStepper.vue
+++ b/app/components/GuestStepper.vue
@@ -4,12 +4,13 @@ import { MAX_PLUS_ONES } from '#shared/types/rsvp'
 // A compact "− N +" stepper for the number of additional guests an attendee is
 // bringing (their "+1"s). Clamps to [0, max]; emits on every change.
 const model = defineModel<number>({ default: 0 })
-const props = withDefaults(defineProps<{ max?: number }>(), { max: MAX_PLUS_ONES })
+const props = withDefaults(defineProps<{ max?: number, disabled?: boolean }>(), { max: MAX_PLUS_ONES, disabled: false })
 
-const atMin = computed(() => model.value <= 0)
-const atMax = computed(() => model.value >= props.max)
+const atMin = computed(() => props.disabled || model.value <= 0)
+const atMax = computed(() => props.disabled || model.value >= props.max)
 
 function step(delta: number): void {
+  if (props.disabled) return
   model.value = Math.min(props.max, Math.max(0, model.value + delta))
 }
 </script>

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -28,7 +28,7 @@ const statsEvent = ref<MovieEvent | null>(null)
 const eventStatsOpen = ref(false)
 
 const selectedEventId = ref<string>()
-const { suggestions, setDeleted, voterNames } = useAdminSuggestions(selectedEventId)
+const { suggestions, setDeleted } = useAdminSuggestions(selectedEventId)
 
 // Bring list + headcount for the selected event (admins curate; people claim on the event page).
 const { items: bringItems, addItem: addBringItem, updateItem: updateBringItem, remove: removeBringItem } = useBringList(selectedEventId)
@@ -129,6 +129,16 @@ async function onRemoveBring(item: BringItem): Promise<void> {
 
 const votingLocked = computed(() => Boolean(selectedEvent.value?.voting_locked_at))
 const winners = computed(() => topWinners(suggestions.value))
+const winnerIds = computed(() => winners.value.map(w => w.id))
+
+// Who RSVP'd (going/maybe) — feeds the dashboard's "engagement gaps" view. Members
+// only (email-only guests can't suggest/vote in-app); keyed by user id.
+const { roster: rsvpRoster } = useEventRsvps(selectedEventId)
+const expectedParticipants = computed(() =>
+  [...rsvpRoster.value.going, ...rsvpRoster.value.maybe]
+    .filter(e => !e.viaEmail)
+    .map(e => ({ userId: e.key, name: e.name }))
+)
 
 async function onLockVoting(): Promise<void> {
   const ev = selectedEvent.value
@@ -417,60 +427,14 @@ function onSelectEvent(event: MovieEvent): void {
           <WinnersBanner v-if="votingLocked && winners.length" :winners="winners" />
         </div>
 
-        <div v-if="suggestions.length" class="space-y-3">
-          <UCard
-            v-for="suggestion in suggestions"
-            :key="suggestion.id"
-            variant="subtle"
-            :class="suggestion.deleted ? 'opacity-60' : ''"
-          >
-            <div class="flex items-start justify-between gap-3">
-              <div class="min-w-0">
-                <h3 class="font-semibold">
-                  {{ suggestion.tmdb_movie.title }}
-                  <UBadge v-if="suggestion.deleted" label="Hidden" color="neutral" variant="subtle" size="xs" />
-                </h3>
-                <p class="text-sm text-muted truncate">
-                  by {{ suggestion.author?.email || 'unknown' }}
-                </p>
-                <p class="text-sm mt-1">
-                  <UIcon name="i-lucide-heart" class="text-error align-text-bottom" />
-                  {{ suggestion.votes?.length ?? 0 }} votes
-                </p>
-                <div v-if="voterNames(suggestion).length" class="flex flex-wrap gap-1 mt-2">
-                  <UBadge
-                    v-for="(name, i) in voterNames(suggestion)"
-                    :key="`${suggestion.id}-${i}`"
-                    :label="name"
-                    color="neutral"
-                    variant="outline"
-                    size="xs"
-                  />
-                </div>
-              </div>
-              <UButton
-                v-if="suggestion.deleted"
-                label="Restore"
-                icon="i-lucide-rotate-ccw"
-                color="neutral"
-                variant="outline"
-                size="sm"
-                class="shrink-0"
-                @click="toggleSuggestion(suggestion.id, false)"
-              />
-              <UButton
-                v-else
-                label="Hide"
-                icon="i-lucide-eye-off"
-                color="error"
-                variant="outline"
-                size="sm"
-                class="shrink-0"
-                @click="toggleSuggestion(suggestion.id, true)"
-              />
-            </div>
-          </UCard>
-        </div>
+        <AdminSuggestionDashboard
+          v-if="suggestions.length"
+          :suggestions="suggestions"
+          :expected="expectedParticipants"
+          :winner-ids="winnerIds"
+          :voting-locked="votingLocked"
+          @toggle="toggleSuggestion"
+        />
         <UCard v-else variant="subtle" class="text-center text-muted">
           No suggestions for this event.
         </UCard>

--- a/app/pages/rsvp.vue
+++ b/app/pages/rsvp.vue
@@ -13,6 +13,9 @@ const token = computed(() => (route.query.token ?? '').toString())
 const phase = ref<'saving' | 'done' | 'error'>('saving')
 const current = ref<RsvpStatus | null>(null)
 const guests = ref(0)
+// Updating the guest count re-saves in the background (no full-screen spinner) —
+// this flag just disables the stepper for the in-flight request.
+const savingGuests = ref(false)
 
 const HEADLINE: Record<RsvpStatus, string> = {
   going: 'You\'re going! 🎉',
@@ -41,10 +44,20 @@ async function rsvp(status: RsvpStatus): Promise<void> {
   }
 }
 
-/** Update the guest count and re-save (only while going). */
-    <GuestStepper :model-value="guests" :disabled="phase === 'saving'" @update:model-value="setGuests" />
+/** Update the guest count and re-save in the background (only while going). Keeps
+ *  the "done" view up (no spinner flicker on every tap) and disables the stepper for
+ *  the in-flight request. */
+async function setGuests(count: number): Promise<void> {
   guests.value = count
-  if (current.value === 'going') await rsvp('going')
+  if (current.value !== 'going' || !token.value) return
+  savingGuests.value = true
+  try {
+    await $fetch('/api/rsvp', { method: 'POST', body: { token: token.value, status: 'going', plusOnes: count } })
+  } catch {
+    phase.value = 'error'
+  } finally {
+    savingGuests.value = false
+  }
 }
 
 onMounted(() => {
@@ -79,7 +92,7 @@ onMounted(() => {
           <!-- Bringing guests? Only while going. -->
           <div v-if="current === 'going'" class="flex flex-col items-center gap-2 pt-1">
             <span class="text-sm text-muted">Bringing guests?</span>
-            <GuestStepper :model-value="guests" @update:model-value="setGuests" />
+            <GuestStepper :model-value="guests" :disabled="savingGuests" @update:model-value="setGuests" />
           </div>
         </template>
 

--- a/shared/utils/suggestionDashboard.ts
+++ b/shared/utils/suggestionDashboard.ts
@@ -1,0 +1,120 @@
+import type { AdminSuggestion } from '#shared/types/suggestion'
+
+/** What one person did for an event: the movies they suggested + the ones they voted for. */
+export interface PersonActivity {
+  userId: string
+  name: string
+  suggested: { id: string, title: string, votes: number, won: boolean }[]
+  votedFor: { id: string, title: string }[]
+}
+
+export interface TopVoter { userId: string, name: string, votes: number }
+
+export interface DashboardSummary {
+  suggestions: number
+  votes: number
+  submitters: number
+  voters: number
+  mostVoted: { title: string, votes: number } | null
+  topVoters: TopVoter[]
+}
+
+/** Someone expected at the event (RSVP'd) who hasn't fully engaged. */
+export interface EngagementGap { userId: string, name: string, suggested: boolean, voted: boolean }
+
+export interface SuggestionDashboard {
+  byPerson: PersonActivity[]
+  summary: DashboardSummary
+  gaps: EngagementGap[]
+}
+
+const TOP_VOTERS = 5
+
+/**
+ * Pivots an event's admin suggestions (each carrying its author + named voters) into
+ * the per-event dashboard: a per-person breakdown of what each person suggested and
+ * voted for, headline summary stats, and engagement gaps. Pure — the composable does
+ * the I/O and hands the rows in, so the pivots are unit-testable.
+ *
+ * Hidden (soft-deleted) suggestions are excluded from every figure. `winnerIds` marks
+ * a person's suggestion as a win (top-2 once voting locked); `expected` is the people
+ * who RSVP'd (going/maybe) — anyone there who hasn't suggested AND voted is a gap.
+ */
+export function computeSuggestionDashboard(input: {
+  suggestions: ReadonlyArray<AdminSuggestion>
+  winnerIds?: ReadonlyArray<string>
+  expected?: ReadonlyArray<{ userId: string, name: string }>
+}): SuggestionDashboard {
+  const live = input.suggestions.filter(s => !s.deleted)
+  const winners = new Set(input.winnerIds ?? [])
+  const nameById = new Map<string, string>()
+  const people = new Map<string, PersonActivity>()
+
+  const ensure = (userId: string, name: string): PersonActivity => {
+    if (name && name !== 'Unknown') nameById.set(userId, name)
+    let person = people.get(userId)
+    if (!person) {
+      person = { userId, name, suggested: [], votedFor: [] }
+      people.set(userId, person)
+    }
+    return person
+  }
+
+  let totalVotes = 0
+  let mostVoted: { title: string, votes: number } | null = null
+  const voteCountByUser = new Map<string, number>()
+  const voters = new Set<string>()
+
+  for (const s of live) {
+    const votes = s.voteCount ?? s.votes?.length ?? 0
+    totalVotes += votes
+    if (!mostVoted || votes > mostVoted.votes) mostVoted = { title: s.tmdb_movie.title, votes }
+
+    const authorName = s.author?.display_name ?? s.author?.email ?? 'Unknown'
+    ensure(s.user_id, authorName).suggested.push({
+      id: s.id,
+      title: s.tmdb_movie.title,
+      votes,
+      won: winners.has(s.id)
+    })
+
+    for (const vote of s.votes ?? []) {
+      voters.add(vote.user_id)
+      voteCountByUser.set(vote.user_id, (voteCountByUser.get(vote.user_id) ?? 0) + 1)
+      ensure(vote.user_id, vote.voter?.display_name ?? 'Unknown')
+        .votedFor.push({ id: s.id, title: s.tmdb_movie.title })
+    }
+  }
+
+  // A voter we first met as 'Unknown' may be named elsewhere (as an author or another
+  // suggestion's voter) — backfill the best name we learned.
+  for (const person of people.values()) person.name = nameById.get(person.userId) ?? person.name
+
+  const byPerson = [...people.values()].sort((a, b) =>
+    (b.suggested.length + b.votedFor.length) - (a.suggested.length + a.votedFor.length)
+    || a.name.localeCompare(b.name)
+  )
+
+  const topVoters: TopVoter[] = [...voteCountByUser.entries()]
+    .map(([userId, votes]) => ({ userId, name: nameById.get(userId) ?? 'Unknown', votes }))
+    .sort((a, b) => b.votes - a.votes || a.name.localeCompare(b.name))
+    .slice(0, TOP_VOTERS)
+
+  const gaps: EngagementGap[] = (input.expected ?? [])
+    .map(e => ({ userId: e.userId, name: e.name, suggested: people.get(e.userId)?.suggested.length ? true : false, voted: voters.has(e.userId) }))
+    .filter(g => !g.suggested || !g.voted)
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  return {
+    byPerson,
+    summary: {
+      suggestions: live.length,
+      votes: totalVotes,
+      submitters: new Set(live.map(s => s.user_id)).size,
+      voters: voters.size,
+      mostVoted,
+      topVoters
+    },
+    gaps
+  }
+}

--- a/shared/utils/suggestionDashboard.ts
+++ b/shared/utils/suggestionDashboard.ts
@@ -101,7 +101,7 @@ export function computeSuggestionDashboard(input: {
     .slice(0, TOP_VOTERS)
 
   const gaps: EngagementGap[] = (input.expected ?? [])
-    .map(e => ({ userId: e.userId, name: e.name, suggested: people.get(e.userId)?.suggested.length ? true : false, voted: voters.has(e.userId) }))
+    .map(e => ({ userId: e.userId, name: e.name, suggested: !!people.get(e.userId)?.suggested.length, voted: voters.has(e.userId) }))
     .filter(g => !g.suggested || !g.voted)
     .sort((a, b) => a.name.localeCompare(b.name))
 

--- a/test/AdminSuggestionDashboard.nuxt.test.ts
+++ b/test/AdminSuggestionDashboard.nuxt.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import AdminSuggestionDashboard from '../app/components/AdminSuggestionDashboard.vue'
+import type { AdminSuggestion } from '../shared/types/suggestion'
+
+function sug(id: string, authorName: string, authorId: string, voters: Array<[string, string]>, title: string, deleted = false): AdminSuggestion {
+  return {
+    id,
+    event_id: 'e1',
+    user_id: authorId,
+    tmdb_movie: { id: 1, title },
+    deleted,
+    created_at: '2026-01-01T00:00:00Z',
+    voteCount: voters.length,
+    author: { display_name: authorName, email: `${authorId}@x.com` },
+    votes: voters.map(([uid, name]) => ({ user_id: uid, voter: { display_name: name } }))
+  }
+}
+
+const suggestions = [
+  sug('s1', 'Ada', 'ada', [['bo', 'Bo'], ['cy', 'Cy']], 'Heat'),
+  sug('s2', 'Bo', 'bo', [['ada', 'Ada']], 'Casino')
+]
+const expected = [{ userId: 'ada', name: 'Ada' }, { userId: 'dee', name: 'Dee' }]
+
+const clickView = async (w: Awaited<ReturnType<typeof mountSuspended>>, label: string): Promise<void> => {
+  await w.findAll('button').find(b => b.text().trim() === label)!.trigger('click')
+}
+
+describe('AdminSuggestionDashboard', () => {
+  it('shows summary stats and the movie list by default', async () => {
+    const w = await mountSuspended(AdminSuggestionDashboard, { props: { suggestions, expected } })
+    expect(w.text()).toContain('submitters')
+    expect(w.text()).toContain('Heat')
+    expect(w.text()).toContain('Casino')
+    expect(w.text()).toContain('Leading:') // most-voted summary
+  })
+
+  it('pivots to a per-person view of suggested + voted', async () => {
+    const w = await mountSuspended(AdminSuggestionDashboard, { props: { suggestions, expected } })
+    await clickView(w, 'People')
+    expect(w.text()).toContain('Suggested')
+    expect(w.text()).toContain('Voted for')
+    expect(w.text()).toContain('Ada')
+    expect(w.text()).toContain('Bo')
+  })
+
+  it('lists engagement gaps (RSVPd but inactive)', async () => {
+    const w = await mountSuspended(AdminSuggestionDashboard, { props: { suggestions, expected } })
+    await clickView(w, 'Gaps')
+    // Dee RSVP'd but never suggested or voted.
+    expect(w.text()).toContain('Dee')
+    expect(w.text()).toContain('No suggestion')
+  })
+
+  it('emits toggle when hiding a suggestion', async () => {
+    const w = await mountSuspended(AdminSuggestionDashboard, { props: { suggestions, expected } })
+    await w.findAll('button').find(b => b.text().includes('Hide'))!.trigger('click')
+    expect(w.emitted('toggle')?.[0]).toEqual(['s1', true])
+  })
+})

--- a/test/suggestionDashboard.test.ts
+++ b/test/suggestionDashboard.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import type { AdminSuggestion } from '../shared/types/suggestion'
+import { computeSuggestionDashboard } from '../shared/utils/suggestionDashboard'
+
+// Build an admin suggestion: author + named voters, vote count derived from voters.
+function sug(
+  id: string,
+  author: { id: string, name: string },
+  voters: Array<{ id: string, name: string }>,
+  opts: { title?: string, deleted?: boolean } = {}
+): AdminSuggestion {
+  return {
+    id,
+    event_id: 'e1',
+    user_id: author.id,
+    tmdb_movie: { id: Number(id.replace(/\D/g, '')) || 1, title: opts.title ?? id },
+    deleted: opts.deleted ?? false,
+    created_at: '2026-01-01T00:00:00Z',
+    voteCount: voters.length,
+    author: { display_name: author.name, email: `${author.id}@x.com` },
+    votes: voters.map(v => ({ user_id: v.id, voter: { display_name: v.name } }))
+  }
+}
+
+describe('computeSuggestionDashboard', () => {
+  it('pivots per person: what each suggested and voted for', () => {
+    const { byPerson } = computeSuggestionDashboard({
+      suggestions: [
+        sug('s1', { id: 'ada', name: 'Ada' }, [{ id: 'bo', name: 'Bo' }, { id: 'ada', name: 'Ada' }], { title: 'Heat' }),
+        sug('s2', { id: 'bo', name: 'Bo' }, [{ id: 'ada', name: 'Ada' }], { title: 'Casino' })
+      ]
+    })
+    const ada = byPerson.find(p => p.userId === 'ada')!
+    expect(ada.suggested.map(m => m.title)).toEqual(['Heat'])
+    expect(ada.votedFor.map(m => m.title).sort()).toEqual(['Casino', 'Heat'])
+    const bo = byPerson.find(p => p.userId === 'bo')!
+    expect(bo.suggested.map(m => m.title)).toEqual(['Casino'])
+    expect(bo.votedFor.map(m => m.title)).toEqual(['Heat'])
+  })
+
+  it('summarizes totals, most-voted, and top voters', () => {
+    const { summary } = computeSuggestionDashboard({
+      suggestions: [
+        sug('s1', { id: 'ada', name: 'Ada' }, [{ id: 'bo', name: 'Bo' }, { id: 'cy', name: 'Cy' }], { title: 'Heat' }),
+        sug('s2', { id: 'bo', name: 'Bo' }, [{ id: 'bo', name: 'Bo' }], { title: 'Casino' })
+      ]
+    })
+    expect(summary.suggestions).toBe(2)
+    expect(summary.votes).toBe(3)
+    expect(summary.submitters).toBe(2) // ada, bo
+    expect(summary.voters).toBe(2) // distinct voters: bo, cy
+    expect(summary.mostVoted).toEqual({ title: 'Heat', votes: 2 })
+    expect(summary.topVoters[0]).toMatchObject({ name: 'Bo', votes: 2 })
+  })
+
+  it('excludes hidden suggestions from every figure', () => {
+    const { summary, byPerson } = computeSuggestionDashboard({
+      suggestions: [
+        sug('s1', { id: 'ada', name: 'Ada' }, [{ id: 'bo', name: 'Bo' }], { title: 'Live' }),
+        sug('gone', { id: 'cy', name: 'Cy' }, [{ id: 'ada', name: 'Ada' }], { title: 'Gone', deleted: true })
+      ]
+    })
+    expect(summary.suggestions).toBe(1)
+    expect(summary.votes).toBe(1)
+    expect(byPerson.some(p => p.userId === 'cy')).toBe(false)
+  })
+
+  it('marks winners on the suggester', () => {
+    const { byPerson } = computeSuggestionDashboard({
+      suggestions: [sug('s1', { id: 'ada', name: 'Ada' }, [{ id: 'bo', name: 'Bo' }], { title: 'Heat' })],
+      winnerIds: ['s1']
+    })
+    expect(byPerson.find(p => p.userId === 'ada')!.suggested[0]!.won).toBe(true)
+  })
+
+  it('flags expected people who have not suggested and/or voted', () => {
+    const { gaps } = computeSuggestionDashboard({
+      suggestions: [sug('s1', { id: 'ada', name: 'Ada' }, [{ id: 'ada', name: 'Ada' }], { title: 'Heat' })],
+      expected: [
+        { userId: 'ada', name: 'Ada' }, // suggested + voted → not a gap
+        { userId: 'bo', name: 'Bo' }, // did nothing → gap (both false)
+        { userId: 'cy', name: 'Cy' }
+      ]
+    })
+    expect(gaps.map(g => g.userId).sort()).toEqual(['bo', 'cy'])
+    expect(gaps.find(g => g.userId === 'bo')).toMatchObject({ suggested: false, voted: false })
+    expect(gaps.find(g => g.userId === 'ada')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Scope

Turns the flat admin **Suggestions** tab into a per-event **dashboard** with multiple views and sort/filter — including your example: pick a person and see what they *suggested* **and** *voted for* in one place. Everything is derived from data `useAdminSuggestions` already loads (each suggestion carries its author + named voters), so the per-person/summary views need **no new queries**.

## Views (selected event)

- **Summary strip** — movies, votes, distinct submitters/voters, the leading movie, and top voters.
- **Movies** — the suggestion list, now **sortable** (most votes / newest / title) and **filterable** (all / visible / hidden), with author, vote count, voter badges, a winner badge, and hide/restore.
- **People** — per person: the movies they **suggested** (vote tally + won badge) and the movies they **voted for**, side by side.
- **Gaps** — people who RSVP'd going/maybe but haven't suggested and/or voted yet, so you can nudge them (fed by `useEventRsvps`; members only, since email-only guests can't suggest/vote in-app).

## Implementation

- `shared/utils/suggestionDashboard.ts` — `computeSuggestionDashboard({ suggestions, winnerIds, expected })` is a **pure** pivot → `{ byPerson, summary, gaps }`. Hidden suggestions are excluded from every figure. Unit-tested.
- `AdminSuggestionDashboard.vue` — owns the view/sort/filter UI; emits `toggle(id, deleted)` for hide/restore.
- `admin.vue` — keeps the end/reopen-voting controls + `WinnersBanner`, adds `useEventRsvps` for the gaps base + `winnerIds`, and replaces the old inline list with the dashboard.

## Note on the diff

This branch also carries the **identical** `rsvp.vue` / `GuestStepper` build-fix from **#120** — `main` (1.7.0) currently fails to build (the `rsvp.vue` mangle), so the fix is needed for this branch to be green. The change is byte-identical to #120, so the two merge cleanly in any order. (If #120 lands first, that part of this diff disappears on rebase.)

## How to Test

**Automated** (Node 22; full suite 365 passed / 9 skipped, typecheck clean, 0 lint errors):
- `suggestionDashboard.test.ts` — per-person pivot (suggested + votedFor), summary (totals/most-voted/top-voters), hidden excluded, winner marking, engagement gaps.
- `AdminSuggestionDashboard.nuxt.test.ts` — summary renders, People pivot, Gaps list, Hide emits `toggle`.

**Manual:** Admin → Suggestions → pick an event. Toggle **Movies / People / Gaps**; sort/filter the movie list; in **People** confirm a person's suggested + voted-for; in **Gaps** confirm someone who RSVP'd but hasn't participated shows up.

## Invariants & Risk

- No auth/schema/key changes — reads ride existing admin RLS (`useAdminSuggestions`, `useEventRsvps`). Presentational/derivational only.