### PR TITLE
feat: communications log in the admin Comms tab

### DIFF
--- a/app/components/AdminSuggestionDashboard.vue
+++ b/app/components/AdminSuggestionDashboard.vue
@@ -11,12 +11,14 @@ const props = defineProps<{
 const emit = defineEmits<{ toggle: [id: string, deleted: boolean] }>()
 
 type View = 'movies' | 'people' | 'gaps'
-type Sort = 'votes' | 'newest' | 'title'
+type Sort = 'votes' | 'newest' | 'title' | 'submitter'
 type Filter = 'all' | 'visible' | 'hidden'
 
 const view = ref<View>('movies')
 const sort = ref<Sort>('votes')
 const filter = ref<Filter>('all')
+const submitter = ref<string>('all')
+const query = ref('')
 
 const views = [
   { value: 'movies' as const, label: 'Movies', icon: 'i-lucide-clapperboard' },
@@ -26,7 +28,8 @@ const views = [
 const sorts = [
   { value: 'votes' as const, label: 'Most votes' },
   { value: 'newest' as const, label: 'Newest' },
-  { value: 'title' as const, label: 'Title' }
+  { value: 'title' as const, label: 'Title' },
+  { value: 'submitter' as const, label: 'Submitter' }
 ]
 const filters = [
   { value: 'all' as const, label: 'All' },
@@ -38,21 +41,48 @@ const dashboard = computed(() =>
   computeSuggestionDashboard({ suggestions: props.suggestions, winnerIds: props.winnerIds, expected: props.expected })
 )
 
+function authorName(s: AdminSuggestion): string {
+  return s.author?.display_name || s.author?.email || 'unknown'
+}
+
+// Distinct submitters for the filter dropdown (live suggestions only).
+const submitterOptions = computed(() => {
+  const byId = new Map<string, string>()
+  for (const s of props.suggestions) if (!s.deleted) byId.set(s.user_id, authorName(s))
+  return [
+    { value: 'all', label: 'All submitters' },
+    ...[...byId].map(([value, label]) => ({ value, label })).sort((a, b) => a.label.localeCompare(b.label))
+  ]
+})
+
+// The widest vote bar scales to the most-voted movie (min 1 so it never divides by 0).
+const maxVotes = computed(() => Math.max(1, ...props.suggestions.map(s => s.voteCount ?? 0)))
+
+function matches(text: string): boolean {
+  const q = query.value.trim().toLowerCase()
+  return !q || text.toLowerCase().includes(q)
+}
+
 const movies = computed(() => {
   const filtered = props.suggestions.filter((s) => {
-    if (filter.value === 'visible') return !s.deleted
-    if (filter.value === 'hidden') return s.deleted
-    return true
+    if (filter.value === 'visible' && s.deleted) return false
+    if (filter.value === 'hidden' && !s.deleted) return false
+    if (submitter.value !== 'all' && s.user_id !== submitter.value) return false
+    return matches(s.tmdb_movie.title)
   })
   return [...filtered].sort((a, b) => {
     if (sort.value === 'title') return a.tmdb_movie.title.localeCompare(b.tmdb_movie.title)
     if (sort.value === 'newest') return (b.created_at ?? '').localeCompare(a.created_at ?? '')
+    if (sort.value === 'submitter') return authorName(a).localeCompare(authorName(b))
     return (b.voteCount ?? 0) - (a.voteCount ?? 0)
   })
 })
 
-function voterNames(s: AdminSuggestion): string[] {
-  return (s.votes ?? []).map(v => v.voter?.display_name ?? 'Unknown')
+const people = computed(() => dashboard.value.byPerson.filter(p => matches(p.name)))
+const gaps = computed(() => dashboard.value.gaps.filter(g => matches(g.name)))
+
+function barPct(votes: number): number {
+  return Math.round((votes / maxVotes.value) * 100)
 }
 </script>
 
@@ -94,7 +124,10 @@ function voterNames(s: AdminSuggestion): string[] {
       </UCard>
     </div>
 
-    <div v-if="dashboard.summary.mostVoted || dashboard.summary.topVoters.length" class="flex flex-wrap gap-x-6 gap-y-1 text-sm">
+    <div
+      v-if="(dashboard.summary.mostVoted && dashboard.summary.mostVoted.votes > 0) || dashboard.summary.topVoters.length"
+      class="flex flex-wrap gap-x-6 gap-y-1 text-sm"
+    >
       <p v-if="dashboard.summary.mostVoted && dashboard.summary.mostVoted.votes > 0">
         <span class="text-muted">Leading:</span>
         <span class="font-medium">{{ dashboard.summary.mostVoted.title }}</span>
@@ -106,8 +139,9 @@ function voterNames(s: AdminSuggestion): string[] {
       </p>
     </div>
 
-    <!-- View switch -->
+    <!-- View switch + search -->
     <div class="flex flex-wrap items-center justify-between gap-2">
+      <div class="flex gap-1">
         <UButton
           v-for="v in views"
           :key="v.value"
@@ -120,10 +154,20 @@ function voterNames(s: AdminSuggestion): string[] {
           @click="view = v.value"
         />
       </div>
-      <div v-if="view === 'movies'" class="flex flex-wrap gap-1">
-        <USelectMenu v-model="sort" :items="sorts" value-key="value" :search-input="false" size="sm" class="w-36" />
-        <USelectMenu v-model="filter" :items="filters" value-key="value" :search-input="false" size="sm" class="w-28" />
-      </div>
+      <UInput
+        v-model="query"
+        icon="i-lucide-search"
+        :placeholder="view === 'movies' ? 'Search movies…' : 'Search people…'"
+        size="sm"
+        class="w-full sm:w-56"
+      />
+    </div>
+
+    <!-- Movies controls -->
+    <div v-if="view === 'movies'" class="flex flex-wrap gap-1">
+      <USelectMenu v-model="sort" :items="sorts" value-key="value" :search-input="false" size="sm" class="w-40" />
+      <USelectMenu v-model="filter" :items="filters" value-key="value" :search-input="false" size="sm" class="w-28" />
+      <USelectMenu v-model="submitter" :items="submitterOptions" value-key="value" :search-input="false" size="sm" class="w-44" />
     </div>
 
     <!-- MOVIES -->
@@ -135,24 +179,28 @@ function voterNames(s: AdminSuggestion): string[] {
         :class="s.deleted ? 'opacity-60' : ''"
       >
         <div class="flex items-start justify-between gap-3">
-          <div class="min-w-0">
+          <div class="min-w-0 flex-1">
             <h3 class="font-semibold">
               {{ s.tmdb_movie.title }}
               <UBadge v-if="s.deleted" label="Hidden" color="neutral" variant="subtle" size="xs" />
               <UBadge v-if="winnerIds?.includes(s.id)" label="Winner" color="primary" variant="subtle" size="xs" />
             </h3>
             <p class="text-sm text-muted truncate">
-              by {{ s.author?.display_name || s.author?.email || 'unknown' }}
+              by {{ authorName(s) }}
             </p>
-            <p class="text-sm mt-1">
-              <UIcon name="i-lucide-heart" class="text-error align-text-bottom" />
-              {{ s.voteCount ?? 0 }} votes
+            <p class="text-sm mt-1 inline-flex items-center gap-1">
+              <UIcon name="i-lucide-heart" class="text-error" />
+              {{ s.voteCount ?? 0 }} {{ (s.voteCount ?? 0) === 1 ? 'vote' : 'votes' }}
             </p>
-            <div v-if="voterNames(s) as names" class="flex flex-wrap gap-1 mt-2">
+            <!-- Vote-share bar -->
+            <div class="mt-1.5 h-1.5 max-w-xs rounded-full bg-elevated overflow-hidden">
+              <div class="h-full rounded-full bg-primary transition-all" :style="{ width: `${barPct(s.voteCount ?? 0)}%` }" />
+            </div>
+            <div v-if="(s.votes ?? []).length" class="flex flex-wrap gap-1 mt-2">
               <UBadge
-                v-for="(name, i) in names"
+                v-for="(v, i) in (s.votes ?? [])"
                 :key="`${s.id}-${i}`"
-                :label="name"
+                :label="v.voter?.display_name ?? 'Unknown'"
                 color="neutral"
                 variant="outline"
                 size="xs"
@@ -182,20 +230,26 @@ function voterNames(s: AdminSuggestion): string[] {
         </div>
       </UCard>
       <UCard v-if="!movies.length" variant="subtle" class="text-center text-muted">
-        No suggestions for this filter.
+        No suggestions match.
       </UCard>
     </div>
 
     <!-- PEOPLE -->
     <div v-else-if="view === 'people'" class="space-y-3">
-      <UCard v-for="p in dashboard.byPerson" :key="p.userId" variant="subtle">
-        <p class="font-semibold mb-2">
-          {{ p.name }}
-        </p>
+      <UCard v-for="p in people" :key="p.userId" variant="subtle">
+        <div class="flex items-center justify-between gap-2 mb-2">
+          <p class="font-semibold truncate">
+            {{ p.name }}
+          </p>
+          <div class="flex gap-1 shrink-0">
+            <UBadge :label="`${p.suggested.length} suggested`" icon="i-lucide-clapperboard" color="neutral" variant="subtle" size="xs" />
+            <UBadge :label="`${p.votedFor.length} voted`" icon="i-lucide-heart" color="neutral" variant="subtle" size="xs" />
+          </div>
+        </div>
         <div class="grid sm:grid-cols-2 gap-3">
           <div>
-            <p class="text-xs font-semibold text-muted mb-1.5 flex items-center gap-1">
-              <UIcon name="i-lucide-clapperboard" /> Suggested · {{ p.suggested.length }}
+            <p class="text-xs font-semibold text-muted mb-1.5">
+              Suggested
             </p>
             <ul v-if="p.suggested.length" class="space-y-1">
               <li v-for="m in p.suggested" :key="m.id" class="text-sm flex items-center gap-1.5">
@@ -209,8 +263,8 @@ function voterNames(s: AdminSuggestion): string[] {
             </p>
           </div>
           <div>
-            <p class="text-xs font-semibold text-muted mb-1.5 flex items-center gap-1">
-              <UIcon name="i-lucide-heart" /> Voted for · {{ p.votedFor.length }}
+            <p class="text-xs font-semibold text-muted mb-1.5">
+              Voted for
             </p>
             <ul v-if="p.votedFor.length" class="space-y-1">
               <li v-for="m in p.votedFor" :key="m.id" class="text-sm truncate">
@@ -223,8 +277,8 @@ function voterNames(s: AdminSuggestion): string[] {
           </div>
         </div>
       </UCard>
-      <UCard v-if="!dashboard.byPerson.length" variant="subtle" class="text-center text-muted">
-        No participation yet.
+      <UCard v-if="!people.length" variant="subtle" class="text-center text-muted">
+        No one matches.
       </UCard>
     </div>
 
@@ -233,7 +287,7 @@ function voterNames(s: AdminSuggestion): string[] {
       <p class="text-sm text-muted">
         Coming (RSVP'd going/maybe) but haven't fully joined in — nudge them.
       </p>
-      <UCard v-for="g in dashboard.gaps" :key="g.userId" variant="subtle" :ui="{ body: 'p-3' }">
+      <UCard v-for="g in gaps" :key="g.userId" variant="subtle" :ui="{ body: 'p-3' }">
         <div class="flex items-center justify-between gap-2">
           <span class="font-medium truncate">{{ g.name }}</span>
           <div class="flex gap-1 shrink-0">
@@ -242,8 +296,8 @@ function voterNames(s: AdminSuggestion): string[] {
           </div>
         </div>
       </UCard>
-      <UCard v-if="!dashboard.gaps.length" variant="subtle" class="text-center text-muted">
-        Everyone who RSVP'd has suggested and voted. 🎉
+      <UCard v-if="!gaps.length" variant="subtle" class="text-center text-muted">
+        {{ dashboard.gaps.length ? 'No one matches.' : 'Everyone who RSVP\'d has suggested and voted. 🎉' }}
       </UCard>
     </div>
   </div>

--- a/app/components/CommsLog.vue
+++ b/app/components/CommsLog.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import type { CommsLogEntry } from '~/composables/useCommsLog'
+
+defineProps<{ entries: CommsLogEntry[] }>()
+
+const KIND = {
+  announcement: { icon: 'i-lucide-megaphone', label: 'Announcement' },
+  invite: { icon: 'i-lucide-mail-plus', label: 'E-vite' }
+} as const
+</script>
+
+<template>
+  <div>
+    <h3 class="text-sm font-semibold text-muted mb-2">
+      Sent communications
+    </h3>
+    <div v-if="entries.length" class="space-y-2">
+      <UCard v-for="e in entries" :key="e.id" variant="subtle" :ui="{ body: 'p-3' }">
+        <div class="flex items-start gap-3">
+          <UIcon :name="KIND[e.kind].icon" class="size-4 mt-0.5 text-muted shrink-0" />
+          <div class="min-w-0 flex-1">
+            <p class="text-sm font-medium truncate">
+              {{ e.subject || KIND[e.kind].label }}
+            </p>
+            <p class="text-xs text-muted">
+              {{ KIND[e.kind].label }}<span v-if="e.scope"> · {{ e.scope }}</span>
+              · {{ e.recipientCount }} recipient{{ e.recipientCount === 1 ? '' : 's' }}
+              <span v-if="e.sentByName"> · by {{ e.sentByName }}</span>
+            </p>
+          </div>
+          <time class="text-xs text-muted shrink-0">{{ formatDateTime(e.createdAt) }}</time>
+        </div>
+      </UCard>
+    </div>
+    <UCard v-else variant="subtle" class="text-center text-muted text-sm">
+      Nothing sent yet for this event.
+    </UCard>
+  </div>
+</template>

--- a/app/composables/useCommsLog.ts
+++ b/app/composables/useCommsLog.ts
@@ -1,0 +1,62 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Database } from '~/types/database.types'
+
+/** One sent communication (announcement or invite blast) for an event. */
+export interface CommsLogEntry {
+  id: string
+  kind: 'announcement' | 'invite'
+  scope: string | null
+  subject: string | null
+  recipientCount: number
+  sentByName: string | null
+  createdAt: string
+}
+
+/**
+ * Admin-only log of communications sent for an event — announcements and e-vite
+ * blasts, newest first. Admin-gated by RLS (the comms_log policies); a non-admin
+ * reads nothing. Live via realtime, so a fresh send appears without a manual refresh.
+ */
+export function useCommsLog(eventId: MaybeRefOrGetter<string | null | undefined>): {
+  entries: Ref<CommsLogEntry[]>
+  error: Ref<string | null>
+  refresh: () => Promise<void>
+} {
+  const supabase = useSupabaseClient<Database>()
+
+  const { data: entries, error, refresh } = useRealtimeQuery<CommsLogEntry[]>({
+    key: eventId,
+    channel: 'comms-log',
+    tables: [{ table: 'comms_log' }],
+    empty: [],
+    errorFallback: 'Failed to load the comms log',
+    load: async (id) => {
+      const { data, error } = await supabase
+        .from('comms_log')
+        .select('id, kind, scope, subject, recipient_count, sent_by, created_at')
+        .eq('event_id', id)
+        .order('created_at', { ascending: false })
+      if (error) throw error
+      const rows = data ?? []
+
+      const senderIds = [...new Set(rows.map(r => r.sent_by).filter((x): x is string => Boolean(x)))]
+      const { data: senders } = senderIds.length
+        ? await supabase.from('profiles').select('id, display_name').in('id', senderIds)
+        : { data: [] }
+      const nameById = new Map((senders ?? []).map(s => [s.id, s.display_name]))
+
+      return rows.map(r => ({
+        id: r.id,
+        // DB CHECK constrains kind to this set; narrow at the boundary.
+        kind: r.kind === 'invite' ? 'invite' : 'announcement',
+        scope: r.scope,
+        subject: r.subject,
+        recipientCount: r.recipient_count,
+        sentByName: r.sent_by ? nameById.get(r.sent_by) ?? null : null,
+        createdAt: r.created_at
+      }))
+    }
+  })
+
+  return { entries, error, refresh }
+}

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -33,6 +33,8 @@ const { suggestions, setDeleted } = useAdminSuggestions(selectedEventId)
 // Bring list + headcount for the selected event (admins curate; people claim on the event page).
 const { items: bringItems, addItem: addBringItem, updateItem: updateBringItem, remove: removeBringItem } = useBringList(selectedEventId)
 const { counts: rsvpCounts } = useRsvp(selectedEventId)
+// Log of communications sent for the selected event (announcements + e-vite blasts).
+const { entries: commsLog } = useCommsLog(selectedEventId)
 
 // Upcoming events first (soonest first), then past events descending (oldest last).
 const sortedEvents = computed(() => sortEventsForAdmin(events.value))
@@ -479,7 +481,10 @@ function onSelectEvent(event: MovieEvent): void {
           Email an announcement or reminder about an event. Recipients are BCC'd.
         </p>
         <EventPicker v-model="selectedEventId" :items="eventOptions" />
-        <EventAnnounceComposer v-if="selectedEventId" :event-id="selectedEventId" class="max-w-xl" />
+        <template v-if="selectedEventId">
+          <EventAnnounceComposer :event-id="selectedEventId" class="max-w-xl" />
+          <CommsLog :entries="commsLog" class="max-w-xl mt-6" />
+        </template>
         <UCard v-else variant="subtle" class="text-center text-muted">
           Select an event to send a blast.
         </UCard>

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -59,6 +59,12 @@ export interface Database {
         Update: { suggestion_id?: string, user_id?: string, created_at?: string }
         Relationships: []
       }
+      comms_log: {
+        Row: { id: string, event_id: string | null, kind: string, scope: string | null, subject: string | null, recipient_count: number, sent_by: string | null, created_at: string }
+        Insert: { id?: string, event_id?: string | null, kind: string, scope?: string | null, subject?: string | null, recipient_count?: number, sent_by?: string | null, created_at?: string }
+        Update: { id?: string, event_id?: string | null, kind?: string, scope?: string | null, subject?: string | null, recipient_count?: number, sent_by?: string | null, created_at?: string }
+        Relationships: []
+      }
     }
     Views: { [_ in never]: never }
     Functions: {

--- a/app/utils/datetime.ts
+++ b/app/utils/datetime.ts
@@ -12,6 +12,12 @@ export function formatDate(value: DateInput, options: Intl.DateTimeFormatOptions
   return date ? date.toLocaleDateString(undefined, options) : ''
 }
 
+/** Date + time (uses toLocaleString, which supports timeStyle — formatDate does not). */
+export function formatDateTime(value: DateInput, options: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeStyle: 'short' }): string {
+  const date = toDate(value)
+  return date ? date.toLocaleString(undefined, options) : ''
+}
+
 export function isSameDay(a: Date, b: Date): boolean {
   return (
     a.getFullYear() === b.getFullYear()

--- a/server/api/events/[id]/invites/send.post.ts
+++ b/server/api/events/[id]/invites/send.post.ts
@@ -71,15 +71,27 @@ export default defineEventHandler(async (event) => {
     }
   })
 
-  return {
-    ok: true,
-    ...(await sendEventInvites(db, {
-      apiKey: resendApiKey,
-      from: resendFrom,
-      replyTo: user.email ?? undefined,
-      eventId,
-      invitedBy: userId,
-      recipients
-    }))
+  const result = await sendEventInvites(db, {
+    apiKey: resendApiKey,
+    from: resendFrom,
+    replyTo: user.email ?? undefined,
+    eventId,
+    invitedBy: userId,
+    recipients
+  })
+
+  // Record the blast in the comms log when at least one e-vite went out (best-effort —
+  // a logging failure must not fail the send).
+  if (result.sent > 0) {
+    const { error: logError } = await db.from('comms_log').insert({
+      event_id: eventId,
+      kind: 'invite',
+      subject: `E-vite — ${ev.title}`,
+      recipient_count: result.sent,
+      sent_by: userId
+    })
+    if (logError) console.error('[events/invites/send] comms_log insert failed -', logError.message)
   }
+
+  return { ok: true, ...result }
 })

--- a/server/api/events/announce.post.ts
+++ b/server/api/events/announce.post.ts
@@ -76,5 +76,17 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 502, statusMessage: error instanceof Error ? error.message : 'Send failed' })
   }
 
+  // Record the send in the comms log (best-effort — the email already went out, so a
+  // logging failure must not fail the request; surface it in logs instead).
+  const { error: logError } = await admin.from('comms_log').insert({
+    event_id: eventId,
+    kind: 'announcement',
+    scope,
+    subject: mail.subject,
+    recipient_count: emails.length,
+    sent_by: userId
+  })
+  if (logError) console.error('[events/announce] comms_log insert failed -', logError.message)
+
   return { ok: true, count: emails.length }
 })

--- a/supabase/migrations/20260628000000_comms_log.sql
+++ b/supabase/migrations/20260628000000_comms_log.sql
@@ -1,0 +1,34 @@
+-- Communications log — an admin-visible record of every blast sent from the app, so
+-- the Comms tab can show "what went out, to whom, when". Today announcements vanish
+-- after sending (the route just returns a count); this persists them, plus invite
+-- blasts, as a lightweight audit trail.
+--
+-- One row per send (not per recipient — per-recipient delivery/opens already live on
+-- event_invites). Written by the announce + invite routes, which run under the admin's
+-- own session, so the admin-only RLS insert policy covers them (no service role).
+
+create table public.comms_log (
+  id              uuid primary key default gen_random_uuid(),
+  event_id        uuid references public.events (id) on delete cascade,
+  kind            text not null check (kind in ('announcement', 'invite')),
+  -- Announcement audience (members | going | invited); null for invite blasts.
+  scope           text,
+  subject         text,
+  recipient_count int not null default 0,
+  sent_by         uuid references public.profiles (id) on delete set null,
+  created_at      timestamptz not null default now()
+);
+
+create index comms_log_event_id_idx on public.comms_log (event_id, created_at desc);
+
+alter table public.comms_log enable row level security;
+grant select, insert on public.comms_log to authenticated;
+
+-- Admin-only: the log can reveal the audience/subject of every blast.
+create policy "comms_log: admin read" on public.comms_log
+  for select to authenticated using (public.is_admin());
+create policy "comms_log: admin insert" on public.comms_log
+  for insert to authenticated with check (public.is_admin());
+
+-- Stream new entries to the admin Comms tab live.
+alter publication supabase_realtime add table public.comms_log;

--- a/test/AdminSuggestionDashboard.nuxt.test.ts
+++ b/test/AdminSuggestionDashboard.nuxt.test.ts
@@ -37,6 +37,19 @@ describe('AdminSuggestionDashboard', () => {
     expect(w.text()).toContain('Leading:') // most-voted summary
   })
 
+  it('filters the movie list by the search box', async () => {
+    const w = await mountSuspended(AdminSuggestionDashboard, { props: { suggestions, expected } })
+    await w.get('input[placeholder*="Search"]').setValue('heat')
+    expect(w.text()).toContain('Heat')
+    expect(w.text()).not.toContain('Casino')
+  })
+
+  it('shows a vote-share bar per movie', async () => {
+    const w = await mountSuspended(AdminSuggestionDashboard, { props: { suggestions, expected } })
+    // Heat has 2 of max 2 votes → a full-width bar.
+    expect(w.html()).toContain('width: 100%')
+  })
+
   it('pivots to a per-person view of suggested + voted', async () => {
     const w = await mountSuspended(AdminSuggestionDashboard, { props: { suggestions, expected } })
     await clickView(w, 'People')

--- a/test/CommsLog.nuxt.test.ts
+++ b/test/CommsLog.nuxt.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import CommsLog from '../app/components/CommsLog.vue'
+import type { CommsLogEntry } from '../app/composables/useCommsLog'
+
+const entries: CommsLogEntry[] = [
+  { id: 'c1', kind: 'announcement', scope: 'going', subject: 'See you Friday', recipientCount: 12, sentByName: 'Pat', createdAt: '2026-06-20T18:00:00Z' },
+  { id: 'c2', kind: 'invite', scope: null, subject: 'E-vite — Movie Night', recipientCount: 30, sentByName: null, createdAt: '2026-06-19T18:00:00Z' }
+]
+
+describe('CommsLog', () => {
+  it('lists each sent communication with kind, scope, recipients, and sender', async () => {
+    const w = await mountSuspended(CommsLog, { props: { entries } })
+    expect(w.text()).toContain('See you Friday')
+    expect(w.text()).toContain('Announcement')
+    expect(w.text()).toContain('going')
+    expect(w.text()).toContain('12 recipients')
+    expect(w.text()).toContain('by Pat')
+    expect(w.text()).toContain('E-vite — Movie Night')
+    expect(w.text()).toContain('30 recipients')
+  })
+
+  it('singularizes one recipient', async () => {
+    const one: CommsLogEntry[] = [{ ...entries[0]!, recipientCount: 1 }]
+    const w = await mountSuspended(CommsLog, { props: { entries: one } })
+    expect(w.text()).toContain('1 recipient')
+    expect(w.text()).not.toContain('1 recipients')
+  })
+
+  it('shows an empty state when nothing has been sent', async () => {
+    const w = await mountSuspended(CommsLog, { props: { entries: [] } })
+    expect(w.text()).toContain('Nothing sent yet')
+  })
+})

--- a/test/useCommsLog.nuxt.test.ts
+++ b/test/useCommsLog.nuxt.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment nuxt
+import { describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import type { CommsLogEntry } from '../app/composables/useCommsLog'
+
+interface LogRow { id: string, kind: string, scope: string | null, subject: string | null, recipient_count: number, sent_by: string | null, created_at: string }
+let logRows: LogRow[] = []
+const profiles = [{ id: 'pat', display_name: 'Pat' }]
+
+const supabase = {
+  from(table: string) {
+    if (table === 'comms_log') {
+      return { select: () => ({ eq: () => ({ order: () => Promise.resolve({ data: logRows, error: null }) }) }) }
+    }
+    // profiles
+    return { select: () => ({ in: () => Promise.resolve({ data: profiles, error: null }) }) }
+  },
+  channel() {
+    const ch = { on: () => ch, subscribe: () => ch }
+    return ch
+  },
+  removeChannel() {}
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+async function settle(entries: { value: CommsLogEntry[] }): Promise<void> {
+  await vi.waitFor(() => {
+    if (logRows.length > 0 && entries.value.length === 0) throw new Error('not loaded')
+  })
+  await nextTick()
+}
+
+describe('useCommsLog', () => {
+  it('maps rows newest-first with kind narrowed and sender name resolved', async () => {
+    logRows = [
+      { id: 'c1', kind: 'announcement', scope: 'going', subject: 'Hi', recipient_count: 5, sent_by: 'pat', created_at: '2026-06-20T00:00:00Z' },
+      { id: 'c2', kind: 'invite', scope: null, subject: 'E-vite', recipient_count: 9, sent_by: null, created_at: '2026-06-19T00:00:00Z' }
+    ]
+    const { entries } = useCommsLog(ref('e1'))
+    await settle(entries)
+    expect(entries.value).toHaveLength(2)
+    expect(entries.value[0]).toMatchObject({ kind: 'announcement', recipientCount: 5, sentByName: 'Pat', scope: 'going' })
+    expect(entries.value[1]).toMatchObject({ kind: 'invite', sentByName: null })
+  })
+
+  it('coerces an unexpected kind to announcement at the boundary', async () => {
+    logRows = [{ id: 'c3', kind: 'weird', scope: null, subject: null, recipient_count: 0, sent_by: null, created_at: '2026-06-20T00:00:00Z' }]
+    const { entries } = useCommsLog(ref('e1'))
+    await settle(entries)
+    expect(entries.value[0]!.kind).toBe('announcement')
+  })
+})


### PR DESCRIPTION
## Scope

The Comms tab could *send* announcements but kept no record — once sent, a blast vanished (the route just returned a count). This adds a **log of communications sent** per event, shown right under the composer.

## Implementation

- **Migration `20260628000000_comms_log.sql`** — `comms_log(event_id, kind ['announcement'|'invite'], scope, subject, recipient_count, sent_by, created_at)`. **Admin-only** RLS (read + insert), added to the realtime publication. The announce + invite routes run under the admin's own session, so the insert is covered by the admin policy — no service role.
- **Routes write the log** — `announce.post.ts` and `events/[id]/invites/send.post.ts` insert a row after a successful send. Best-effort: a logging failure never fails the send (the email already went out), it's just logged. (This also captures the auto-winners announcement fired when voting locks.)
- **`useCommsLog(eventId)`** — admin-only, realtime, newest-first; resolves sender display names.
- **`CommsLog.vue`** — per entry: kind + scope + recipient count + sender + timestamp, with an empty state. Wired beneath `EventAnnounceComposer` in the Comms tab.
- Added `formatDateTime()` (the existing `formatDate` uses `toLocaleDateString`, which can't render a time).

## How to Test

**Automated** (Node 22; full suite 361 passed / 9 skipped, typecheck clean, 0 lint errors):
- `useCommsLog.nuxt.test.ts` — newest-first mapping, sender-name resolution, kind boundary-narrowing.
- `CommsLog.nuxt.test.ts` — renders entries (kind/scope/recipients/sender), singularizes one recipient, empty state.

**Manual:** Admin → Comms → pick an event → send an announcement → it appears in "Sent communications" immediately (realtime), with audience + recipient count. Send an e-vite blast from Invites → shows as an "E-vite" entry too.

## Notes / Risk

- Admin-only by RLS; no change to auth model, keys, or vote integrity. Logging is best-effort and never blocks a send.
- ⚠️ **Migration must be applied to prod** (`20260628000000_comms_log.sql`) — the `db-migrate` workflow is still failing on missing secrets, so apply via the Supabase SQL editor (or fix the secrets). Until applied, the comms log reads/writes will error; the send itself still works (logging is best-effort).
- Also carries the identical **#120** `rsvp.vue`/`GuestStepper` build-fix so this branch compiles on the currently-broken `main`; merges cleanly with #120.