### PR TITLE
feat: require a "going" RSVP to suggest or vote

### DIFF
--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
 import type { Suggestion } from '#shared/types/suggestion'
 
-const props = defineProps<{ suggestion: Suggestion, rank: number, maxVotes: number, locked?: boolean, voteCapReached?: boolean }>()
+// canVote defaults to true via withDefaults: a *typed* boolean prop that's absent
+// is cast to `false` by Vue, which would wrongly disable voting wherever the prop
+// isn't passed — the default makes "voting allowed" the explicit fallback.
+const props = withDefaults(
+  defineProps<{ suggestion: Suggestion, rank: number, maxVotes: number, locked?: boolean, voteCapReached?: boolean, canVote?: boolean }>(),
+  { canVote: true }
+)
 const emit = defineEmits<{ vote: [], unvote: [], remove: [], trailer: [] }>()
 
 const { myId } = useAuth()
@@ -13,8 +19,15 @@ const voteCount = computed(() => props.suggestion.voteCount ?? 0)
 const hasVoted = computed(() =>
   Boolean(myId.value) && (props.suggestion.votes ?? []).some(v => v.user_id === myId.value)
 )
-// At the vote cap you can't add a new vote, but you can still remove one to switch.
-const voteDisabled = computed(() => Boolean(props.voteCapReached) && !hasVoted.value)
+// Can't add a *new* vote at the cap or when you're not RSVP'd "going" — but you
+// can always remove a vote you've already cast (to switch your pick / back out).
+const voteDisabled = computed(() => !hasVoted.value && (Boolean(props.voteCapReached) || !props.canVote))
+const voteDisabledTitle = computed(() => {
+  if (!voteDisabled.value) return undefined
+  return !props.canVote
+    ? 'RSVP "Going" to vote on movies'
+    : 'Vote limit reached — remove a vote to switch your pick'
+})
 const isOwner = computed(() =>
   Boolean(myId.value) && props.suggestion.user_id === myId.value
 )
@@ -86,7 +99,7 @@ function onHeartClick(e: MouseEvent): void {
               :label="String(voteCount)"
               size="sm"
               :disabled="voteDisabled"
-              :title="voteDisabled ? 'Vote limit reached — remove a vote to switch your pick' : undefined"
+              :title="voteDisabledTitle"
               :aria-label="hasVoted ? 'Remove vote' : 'Vote'"
               @click="onHeartClick"
             />

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -41,6 +41,10 @@ const cardBackdrop = computed(() => currentEvent.value?.poster_url || leadPoster
 const votingLocked = computed(() => Boolean(currentEvent.value?.voting_locked_at))
 const winners = computed(() => topWinners(suggestions.value))
 
+// You must RSVP "going" to suggest or vote. RLS is the real gate (mirrors
+// public.is_going() in the migration); this just drives the UI.
+const isGoing = computed(() => myStatus.value === 'going')
+
 // Per-event participation caps (mirrors the DB triggers — see shared/utils/limits).
 // Effective limit = admin-configured (app_settings) or the default in limits.ts.
 const { maxSuggestions: cfgMaxSuggestions, maxVotes: cfgMaxVotes } = useAppSettings()
@@ -84,6 +88,10 @@ function openTrailer(suggestion: Suggestion): void {
 
 async function onSuggest(movie: TmdbMovie): Promise<void> {
   suggestOpen.value = false
+  if (!isGoing.value) {
+    toast.add({ title: 'RSVP first', description: 'Mark yourself “Going” to suggest a movie.', color: 'warning' })
+    return
+  }
   if (alreadySuggested(movie.id)) {
     toast.add({ title: 'Already suggested', description: `${movie.title} is already on the list.`, color: 'warning' })
     return
@@ -97,6 +105,10 @@ async function onSuggest(movie: TmdbMovie): Promise<void> {
   }
 }
 async function onVote(suggestion: Suggestion): Promise<void> {
+  if (!isGoing.value) {
+    toast.add({ title: 'RSVP first', description: 'Mark yourself “Going” to vote.', color: 'warning' })
+    return
+  }
   if (atVoteCap.value) {
     toast.add({ title: `You've used all ${voteLimit.value} votes`, description: 'Remove a vote to switch your pick.', color: 'warning' })
     return
@@ -212,45 +224,56 @@ async function onGuests(count: number): Promise<void> {
 
           <!-- Suggest + finder (hidden once voting is locked) -->
           <template v-if="!votingLocked">
-            <p class="text-xs text-muted text-center">
-              {{ mySuggestionCount }} of {{ suggestionLimit }} suggestions used
-            </p>
-            <template v-if="!atSuggestionCap">
-              <!-- Suggest (desktop inline) -->
-              <div class="hidden lg:block">
-                <h2 class="text-sm font-semibold text-muted mb-2">
-                  Suggest a movie
-                </h2>
-                <SuggestSection :suggested-movie-ids="suggestedMovieIds" @suggest="onSuggest" />
-              </div>
+            <!-- Gate: you must RSVP "going" before you can suggest or vote. -->
+            <template v-if="isGoing">
+              <p class="text-xs text-muted text-center">
+                {{ mySuggestionCount }} of {{ suggestionLimit }} suggestions used
+              </p>
+              <template v-if="!atSuggestionCap">
+                <!-- Suggest (desktop inline) -->
+                <div class="hidden lg:block">
+                  <h2 class="text-sm font-semibold text-muted mb-2">
+                    Suggest a movie
+                  </h2>
+                  <SuggestSection :suggested-movie-ids="suggestedMovieIds" @suggest="onSuggest" />
+                </div>
 
-              <!-- Suggest (mobile) -->
-              <UButton
-                class="lg:hidden justify-center"
-                block
-                label="Suggest a movie"
-                icon="i-lucide-plus"
-                @click="suggestOpen = true"
-              />
+                <!-- Suggest (mobile) -->
+                <UButton
+                  class="lg:hidden justify-center"
+                  block
+                  label="Suggest a movie"
+                  icon="i-lucide-plus"
+                  @click="suggestOpen = true"
+                />
 
-              <!-- Movie finder (all sizes) -->
-              <UButton
-                class="justify-center"
-                block
+                <!-- Movie finder (all sizes) -->
+                <UButton
+                  class="justify-center"
+                  block
+                  color="neutral"
+                  variant="outline"
+                  label="Help me find a movie"
+                  icon="i-lucide-clapperboard"
+                  @click="finderOpen = true"
+                />
+              </template>
+              <UAlert
+                v-else
+                icon="i-lucide-circle-check"
                 color="neutral"
-                variant="outline"
-                label="Help me find a movie"
-                icon="i-lucide-clapperboard"
-                @click="finderOpen = true"
+                variant="subtle"
+                :title="`You've used all ${suggestionLimit} suggestions`"
+                description="Remove one from the list to free up a slot."
               />
             </template>
             <UAlert
               v-else
-              icon="i-lucide-circle-check"
-              color="neutral"
+              icon="i-lucide-calendar-check"
+              color="primary"
               variant="subtle"
-              :title="`You've used all ${suggestionLimit} suggestions`"
-              description="Remove one from the list to free up a slot."
+              title="RSVP to join in"
+              description="Mark yourself “Going” to suggest movies and vote on the lineup."
             />
           </template>
           <p v-else class="text-sm text-muted text-center inline-flex items-center justify-center gap-1.5">
@@ -283,6 +306,7 @@ async function onGuests(count: number): Promise<void> {
               :rank="index + 1"
               :max-votes="maxVotes"
               :locked="votingLocked"
+              :can-vote="isGoing"
               :vote-cap-reached="atVoteCap"
               @vote="onVote(suggestion)"
               @unvote="onUnvote(suggestion)"

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -267,8 +267,11 @@ async function onGuests(count: number): Promise<void> {
                 description="Remove one from the list to free up a slot."
               />
             </template>
+            <!-- Only prompt to RSVP when there's actually an RSVP control to act on
+                 (the RsvpControl card is upcoming-only). For a past-but-unlocked event
+                 we just hide the suggest controls silently. -->
             <UAlert
-              v-else
+              v-else-if="isUpcoming(currentEvent.event_date)"
               icon="i-lucide-calendar-check"
               color="primary"
               variant="subtle"

--- a/supabase/migrations/20260629000000_rsvp_required_to_participate.sql
+++ b/supabase/migrations/20260629000000_rsvp_required_to_participate.sql
@@ -1,0 +1,58 @@
+-- ============================================================================
+-- RSVP-gated participation. You must be RSVP'd "going" to an event before you
+-- can suggest a movie or cast a vote for it. RLS is the boundary (Invariant 1) —
+-- the gate is enforced in the policies, the overview UI only mirrors it.
+--
+-- "going" specifically: "maybe" and "no" are not commitments, so they don't get
+-- to shape the ballot. Unvoting/removing your own rows stays open (you can always
+-- back out); only *creating* a suggestion or vote requires the going RSVP.
+-- ============================================================================
+
+-- Am I (auth.uid()) RSVP'd "going" to this event? SECURITY DEFINER (search_path
+-- = '') so it can read rsvps from inside another table's policy without tripping
+-- RLS or recursing — mirrors public.is_allowed() / public.is_voting_locked().
+create function public.is_going(eid uuid) returns boolean
+  language sql security definer set search_path = '' stable as $$
+  select exists (
+    select 1 from public.rsvps r
+    where r.event_id = eid and r.user_id = auth.uid() and r.status = 'going'
+  );
+$$;
+revoke all on function public.is_going(uuid) from public;
+grant execute on function public.is_going(uuid) to authenticated;
+
+-- Same check, resolved through a suggestion (votes carry no event_id — same shape
+-- as is_voting_locked(suggestion_id)).
+create function public.is_going_for_suggestion(sid uuid) returns boolean
+  language sql security definer set search_path = '' stable as $$
+  select exists (
+    select 1
+    from public.suggestions s
+    join public.rsvps r on r.event_id = s.event_id
+    where s.id = sid and r.user_id = auth.uid() and r.status = 'going'
+  );
+$$;
+revoke all on function public.is_going_for_suggestion(uuid) from public;
+grant execute on function public.is_going_for_suggestion(uuid) to authenticated;
+
+-- ---------- Gate the participation writes ----------
+-- AND the going check onto the existing insert policies (keep every prior clause:
+-- own row, not deleted, allowlisted, not blocked, voting not locked).
+
+drop policy "suggestions: create own" on public.suggestions;
+create policy "suggestions: create own" on public.suggestions
+  for insert to authenticated
+  with check (
+    user_id = auth.uid() and deleted = false and public.is_allowed() and not public.is_blocked()
+    and (select voting_locked_at from public.events where id = event_id) is null
+    and public.is_going(event_id)
+  );
+
+drop policy "votes: insert own" on public.votes;
+create policy "votes: insert own" on public.votes
+  for insert to authenticated
+  with check (
+    user_id = auth.uid() and public.is_allowed() and not public.is_blocked()
+    and not public.is_voting_locked(suggestion_id)
+    and public.is_going_for_suggestion(suggestion_id)
+  );

--- a/test/SuggestionCard.nuxt.test.ts
+++ b/test/SuggestionCard.nuxt.test.ts
@@ -94,4 +94,17 @@ describe('SuggestionCard', () => {
     const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2, voteCapReached: true } })
     expect(w.get('[aria-label="Remove vote"]').attributes('disabled')).toBeUndefined()
   })
+
+  it('disables a new vote when I am not RSVP’d going (canVote=false)', async () => {
+    const notMine = { ...suggestion, votes: [{ user_id: 'bob' }] }
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion: notMine, rank: 1, maxVotes: 2, canVote: false } })
+    const btn = w.get('[aria-label="Vote"]')
+    expect(btn.attributes('disabled')).toBeDefined()
+    expect(btn.attributes('title')).toContain('RSVP')
+  })
+
+  it('still lets me remove an existing vote when not going (canVote=false)', async () => {
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2, canVote: false } })
+    expect(w.get('[aria-label="Remove vote"]').attributes('disabled')).toBeUndefined()
+  })
 })

--- a/test/overview.nuxt.test.ts
+++ b/test/overview.nuxt.test.ts
@@ -20,6 +20,7 @@ const event = {
 // referencing module-scope values, same pattern as useAdminPeople.nuxt.test.ts).
 const isAdmin = ref(false)
 const myId = ref<string | null>(null)
+const myStatus = ref<string | null>(null)
 const suggestionList = ref<Array<Record<string, unknown>>>([])
 // Admin-configured caps (null = fall back to the limits.ts defaults).
 const cfgMaxSuggestions = ref<number | null>(null)
@@ -37,9 +38,11 @@ mockNuxtImport('useSuggestions', () => () => ({
   removeSuggestion: async () => {}
 }))
 mockNuxtImport('useRsvp', () => () => ({
-  myStatus: ref(null),
-  counts: ref({ going: 0, maybe: 0, no: 0 }),
-  setStatus: async () => {}
+  myStatus,
+  myPlusOnes: ref(0),
+  counts: ref({ going: 0, maybe: 0, no: 0, guests: 0 }),
+  setStatus: async () => {},
+  setGuests: async () => {}
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
 mockNuxtImport('useAppSettings', () => () => ({
@@ -63,6 +66,7 @@ const stubs = {
 beforeEach(() => {
   isAdmin.value = false
   myId.value = null
+  myStatus.value = 'going'
   suggestionList.value = []
   cfgMaxSuggestions.value = null
   cfgMaxVotes.value = null
@@ -112,5 +116,22 @@ describe('overview page', () => {
     // The cap notice fires at 2 (the configured value), not the default of 5.
     expect(w.text()).toContain('2 of 2 suggestions used')
     expect(w.text()).toContain('used all 2 suggestions')
+  })
+
+  it('prompts to RSVP and hides the suggest controls when not going', async () => {
+    myStatus.value = null
+    const w = await mountSuspended(OverviewPage, { global: { stubs } })
+    expect(w.text()).toContain('RSVP to join in')
+    // The suggestion-count line and suggest controls only appear once going.
+    expect(w.text()).not.toContain('suggestions used')
+    expect(w.text()).not.toContain('Suggest a movie')
+  })
+
+  it('shows the suggest controls once I am going', async () => {
+    myId.value = 'me'
+    myStatus.value = 'going'
+    const w = await mountSuspended(OverviewPage, { global: { stubs } })
+    expect(w.text()).toContain('0 of 5 suggestions used')
+    expect(w.text()).not.toContain('RSVP to join in')
   })
 })

--- a/test/overview.nuxt.test.ts
+++ b/test/overview.nuxt.test.ts
@@ -63,6 +63,8 @@ const stubs = {
   WhoOnline: true
 }
 
+const UPCOMING = '2999-07-15T19:00:00Z'
+
 beforeEach(() => {
   isAdmin.value = false
   myId.value = null
@@ -70,6 +72,8 @@ beforeEach(() => {
   suggestionList.value = []
   cfgMaxSuggestions.value = null
   cfgMaxVotes.value = null
+  // Some tests flip the date to the past; reset to upcoming each time.
+  event.event_date = UPCOMING
 })
 
 function mineSuggestion(i: number): Record<string, unknown> {
@@ -132,6 +136,15 @@ describe('overview page', () => {
     myStatus.value = 'going'
     const w = await mountSuspended(OverviewPage, { global: { stubs } })
     expect(w.text()).toContain('0 of 5 suggestions used')
+    expect(w.text()).not.toContain('RSVP to join in')
+  })
+
+  it('does not show the RSVP prompt for a past event (no RSVP control to act on)', async () => {
+    // RsvpControl is upcoming-only, so a dead-end "RSVP to join in" prompt would
+    // be misleading on a past-but-unlocked event — it must stay hidden.
+    event.event_date = '2000-01-01T19:00:00Z'
+    myStatus.value = null
+    const w = await mountSuspended(OverviewPage, { global: { stubs } })
     expect(w.text()).not.toContain('RSVP to join in')
   })
 })

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -218,10 +218,15 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     const noVote = await gateClient.from('votes').insert({ suggestion_id: seedId })
     expect(noVote.error, 'voting without a going RSVP should be rejected').toBeTruthy()
 
-    // A non-going RSVP ("maybe") is still not enough — going is the gate.
+    // A non-going RSVP is still not enough — going is the gate. Check both
+    // "maybe" and "no" explicitly so the going-only intent is airtight.
     await gateClient.from('rsvps').insert({ event_id: eventId, user_id: gateId, status: 'maybe' })
-    const stillNoVote = await gateClient.from('votes').insert({ suggestion_id: seedId })
-    expect(stillNoVote.error, '“maybe” must not unlock voting').toBeTruthy()
+    const noVoteMaybe = await gateClient.from('votes').insert({ suggestion_id: seedId })
+    expect(noVoteMaybe.error, '“maybe” must not unlock voting').toBeTruthy()
+
+    await gateClient.from('rsvps').update({ status: 'no' }).eq('event_id', eventId).eq('user_id', gateId)
+    const noVoteNo = await gateClient.from('votes').insert({ suggestion_id: seedId })
+    expect(noVoteNo.error, '“no” must not unlock voting').toBeTruthy()
 
     // Flip to going → both writes now succeed.
     await gateClient.from('rsvps').update({ status: 'going' }).eq('event_id', eventId).eq('user_id', gateId)

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -197,4 +197,42 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('suggestions').delete().eq('id', suggestionId)
     await admin!.from('invites').delete().eq('email', otherEmail)
   })
+
+  it('blocks suggesting/voting until you RSVP “going”, then allows it', async () => {
+    const gateEmail = `rls_gate_${stamp}@example.com`
+    const gateId = await makeUser(gateEmail)
+    await admin!.from('invites').insert({ email: gateEmail })
+    const gateClient = await signInAs(gateEmail)
+
+    // A suggestion seeded by the service role for the gate user to try to vote on.
+    const { data: seed } = await admin!
+      .from('suggestions')
+      .insert({ event_id: eventId, user_id: memberId, tmdb_movie: { id: 700, title: 'Gatekept' } })
+      .select('id')
+      .single()
+    const seedId = seed!.id
+
+    // Not RSVP'd → both participation writes are rejected by RLS.
+    const noSuggest = await gateClient.from('suggestions').insert({ event_id: eventId, tmdb_movie: { id: 701, title: 'Nope' } })
+    expect(noSuggest.error, 'suggesting without a going RSVP should be rejected').toBeTruthy()
+    const noVote = await gateClient.from('votes').insert({ suggestion_id: seedId })
+    expect(noVote.error, 'voting without a going RSVP should be rejected').toBeTruthy()
+
+    // A non-going RSVP ("maybe") is still not enough — going is the gate.
+    await gateClient.from('rsvps').insert({ event_id: eventId, user_id: gateId, status: 'maybe' })
+    const stillNoVote = await gateClient.from('votes').insert({ suggestion_id: seedId })
+    expect(stillNoVote.error, '“maybe” must not unlock voting').toBeTruthy()
+
+    // Flip to going → both writes now succeed.
+    await gateClient.from('rsvps').update({ status: 'going' }).eq('event_id', eventId).eq('user_id', gateId)
+    const okSuggest = await gateClient.from('suggestions').insert({ event_id: eventId, tmdb_movie: { id: 702, title: 'Yes' } })
+    expect(okSuggest.error, 'suggesting while going should be allowed').toBeNull()
+    const okVote = await gateClient.from('votes').insert({ suggestion_id: seedId })
+    expect(okVote.error, 'voting while going should be allowed').toBeNull()
+
+    await admin!.from('votes').delete().eq('user_id', gateId)
+    await admin!.from('suggestions').delete().eq('event_id', eventId)
+    await admin!.from('rsvps').delete().eq('user_id', gateId)
+    await admin!.from('invites').delete().eq('email', gateEmail)
+  })
 })


### PR DESCRIPTION
## Scope

First of three planned PRs for **RSVP-gated participation + ballot pruning**. This one
makes a **"going" RSVP a prerequisite for participating**: you can't suggest a movie or
cast a vote for an event unless you've marked yourself **Going**. "maybe"/"no" are not
commitments, so they don't get to shape the ballot.

Backing out stays open — you can always remove your own suggestion or un-vote; only
*creating* a suggestion or vote requires the going RSVP.

Part of the roadmap epic. Next: PR #2 (un-RSVP hides your stuff + restores on re-RSVP),
PR #3 (ballot pruning / phased runoff).

## Implementation

- **RLS is the real gate (Invariant 1).** New migration
  `20260629000000_rsvp_required_to_participate.sql` adds two `SECURITY DEFINER` predicates:
  - `is_going(event_id)` — am I RSVP'd "going" to this event?
  - `is_going_for_suggestion(suggestion_id)` — same, resolved through the suggestion
    (votes carry no `event_id`, same shape as the existing `is_voting_locked`).

  These are AND-ed onto the existing `suggestions: create own` and `votes: insert own`
  `with check` clauses, preserving every prior condition (own row, not deleted, allowlisted,
  not blocked, not voting-locked). Delete/un-vote policies are untouched.
- **UI mirrors the gate (it is not the gate).** `overview.vue` gains an `isGoing` computed.
  When you're not going, the suggest controls are replaced by an "RSVP to join in" prompt;
  `onSuggest`/`onVote` short-circuit with a "RSVP first" toast as a belt-and-suspenders.
- **`SuggestionCard`** gets a `canVote` prop: when false, the vote button is disabled for
  *new* votes only (you can still remove an existing vote) with an explanatory tooltip.
- **Bug fix caught by tests:** a *typed* `canVote?: boolean` prop that's absent is cast to
  `false` by Vue (not `undefined`), which would wrongly disable voting wherever the prop
  isn't passed. `canVote` now defaults to `true` via `withDefaults`.

## Screenshots

UI change is the left control panel on `/overview`:

|         | not going (new)                                  | going (unchanged)                  |
| ------- | ------------------------------------------------ | ---------------------------------- |
| desktop | "RSVP to join in" prompt; vote buttons disabled  | suggest controls + active voting   |
| mobile  | same prompt replaces the "Suggest a movie" button | same                              |

_(Static screenshots to follow — happy to attach before merge if you want them.)_

## How to Test

**Automated**
- Unit: `test/overview.nuxt.test.ts` — prompts to RSVP + hides suggest controls when not
  going; shows controls once going. `test/SuggestionCard.nuxt.test.ts` — `canVote=false`
  disables a new vote (with the RSVP tooltip) but still allows removing an existing vote.
- Integration: `test/rls.integration.test.ts` — a fresh allowlisted member can't suggest or
  vote with no RSVP (or with "maybe"), then both succeed once flipped to "going". Runs
  against local Supabase (`supabase start` + the `SUPABASE_TEST_*` env vars); skipped otherwise.
- `npm run typecheck`, `npm run lint` (0 errors), `npx vitest run` (377 passing) all green.

**Manual**
1. Sign in, open `/overview` on an upcoming event, and don't RSVP (or pick "Maybe"/"Can't").
2. The left panel shows "RSVP to join in"; there's no suggest box, and every card's heart
   button is disabled (tooltip: RSVP "Going" to vote).
3. Click **Going**. The suggest controls appear and voting is enabled.
4. Switch back to "Maybe": controls disappear again. (Hiding your already-cast votes is PR #2.)

## Invariants & Risk

- **Touches authorization (Invariant 1).** The enforcement is in the RLS policies; the
  middleware/UI are unchanged as gates. Both insert predicates keep all prior clauses.
- Vote integrity (Invariant 3), the TMDB key (2), admin role (4), and rendered HTML (5) are
  untouched. Service-role/historical imports bypass RLS as before, so seeding is unaffected.
- **Migration must reach prod** for the gate to take effect.