### PR TITLE
docs: require many small commits per PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,7 +301,12 @@ covering that behavior.
 
 - **Always work from a feature branch.** Never commit directly to `main`. Use descriptive
   names: `feat/vote-limits`, `fix/admin-voters-race`.
-- **Commit often.** Small, frequent, logical commits. Don't batch unrelated changes.
+- **Commit often — many small commits per PR.** A PR should land as a sequence of small,
+  logical commits, never one big squashed blob. Each commit is one coherent step (a schema
+  migration, a composable, the UI wiring, the tests for it) that builds and is independently
+  reviewable, so the PR can be **analyzed and unwound bit by bit** — read commit-by-commit,
+  `git bisect`, or revert a single step without losing the rest. If a commit needs "and" to
+  describe it, split it. Don't batch unrelated changes into one commit.
 - **Conventional commit messages.** Prefixes:
   - `feat:` — New feature or capability
   - `fix:` — Bug fix


### PR DESCRIPTION
## Scope

Per request: make the **many-small-commits-per-PR** expectation explicit in CLAUDE.md so it
applies to all future work. A PR should land as a sequence of small, logical, independently
reviewable commits — never one squashed blob — so it can be analyzed and unwound bit by bit
(read commit-by-commit, `git bisect`, or revert a single step without losing the rest).

## Implementation

Strengthens the existing "Commit often" bullet in the Git Workflow section. No code changes.

## How to Test

Docs only — n/a.

## Invariants & Risk

None — documentation/process only.