### PR TITLE
feat: un-RSVP hides your suggestions and votes; re-RSVP restores them

### DIFF
--- a/app/composables/useAdminSuggestions.ts
+++ b/app/composables/useAdminSuggestions.ts
@@ -5,12 +5,14 @@ import type { AdminSuggestion } from '#shared/types/suggestion'
 const SELECT = `
   id, event_id, user_id, tmdb_movie, deleted, created_at,
   author:profiles!suggestions_user_id_fkey(display_name, email),
-  votes(user_id, voter:profiles!votes_user_id_fkey(display_name))
+  votes(user_id, hidden_at, voter:profiles!votes_user_id_fkey(display_name))
 `
 
 /**
- * Admin view of an event's suggestions — includes soft-deleted rows, and joins
- * the author + each voter's display name. Realtime keeps it live.
+ * Admin view of an event's suggestions — includes admin-deleted rows (for the
+ * moderation toggle) but excludes rsvp-hidden ones (off the ballot, auto-restore
+ * when the author returns), so admin sees the same contention set members do.
+ * Joins the author + each voter's display name. Realtime keeps it live.
  */
 export function useAdminSuggestions(eventId: MaybeRefOrGetter<string | null | undefined>) {
   const supabase = useSupabaseClient<Database>()
@@ -26,11 +28,13 @@ export function useAdminSuggestions(eventId: MaybeRefOrGetter<string | null | un
         .from('suggestions')
         .select(SELECT)
         .eq('event_id', id)
+        // Off the ballot while the author isn't "going" (admin-deleted rows still load).
+        .is('rsvp_hidden_at', null)
       if (error) throw error
-      // Admins read every vote row (RLS), so the count is just votes.length here —
-      // mirror it into voteCount to satisfy the shared Suggestion shape.
+      // Admins read every vote row (RLS); count only the live (non-soft-deleted)
+      // ones so the admin count matches the public tally.
       return ((data ?? []) as unknown as AdminSuggestion[])
-        .map(s => ({ ...s, voteCount: s.votes?.length ?? 0 }))
+        .map(s => ({ ...s, voteCount: liveVoteCount(s.votes) }))
     }
   })
 
@@ -46,7 +50,10 @@ export function useAdminSuggestions(eventId: MaybeRefOrGetter<string | null | un
   }
 
   function voterNames(suggestion: AdminSuggestion): string[] {
-    return (suggestion.votes ?? []).map(vote => vote.voter?.display_name ?? 'Unknown')
+    // Only live voters — someone who left "going" no longer counts.
+    return (suggestion.votes ?? [])
+      .filter(vote => vote.hidden_at == null)
+      .map(vote => vote.voter?.display_name ?? 'Unknown')
   }
 
   return { suggestions, error, setDeleted, voterNames }

--- a/app/composables/useEventStats.ts
+++ b/app/composables/useEventStats.ts
@@ -15,8 +15,10 @@ export function useEventStats(eventId: MaybeRefOrGetter<string | null>) {
     const [suggestions, rsvps, bring] = await Promise.all([
       supabase
         .from('suggestions')
-        .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
-        .eq('event_id', id),
+        .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id, hidden_at)')
+        .eq('event_id', id)
+        // rsvp-hidden suggestions are off the ballot (admin-deleted still load).
+        .is('rsvp_hidden_at', null),
       supabase.from('rsvps').select('status').eq('event_id', id),
       supabase.from('bring_items').select('user_id').eq('event_id', id)
     ])
@@ -26,9 +28,9 @@ export function useEventStats(eventId: MaybeRefOrGetter<string | null>) {
     return computeEventStats({
       // The votes embed isn't declared in the generated types, so cast as
       // useSuggestions does (the inferred shape doesn't match). Admins read every
-      // vote (RLS), so the count is votes.length — populate voteCount to match the
-      // shared Suggestion shape (the tally RPC is only needed where reads are scoped).
-      suggestions: ((suggestions.data ?? []) as unknown as Suggestion[]).map(s => ({ ...s, voteCount: s.votes?.length ?? 0 })),
+      // vote (RLS); count only live (non-soft-deleted) votes so totals match the
+      // public tally.
+      suggestions: ((suggestions.data ?? []) as unknown as Suggestion[]).map(s => ({ ...s, voteCount: liveVoteCount(s.votes) })),
       rsvps: rsvps.data ?? [],
       bringItems: bring.data ?? []
     })

--- a/app/composables/useSuggestions.ts
+++ b/app/composables/useSuggestions.ts
@@ -4,9 +4,11 @@ import type { Database } from '~/types/database.types'
 import type { Suggestion } from '#shared/types/suggestion'
 import type { TmdbMovie } from '#shared/types/movie'
 
-// Rows as they come back from the suggestions query (votes = only those the viewer
-// may read; the public count is merged in from the tally RPC below).
-type RawSuggestion = Omit<Suggestion, 'voteCount'>
+// Rows as they come back from the suggestions query: votes carry `hidden_at` so we
+// can drop the viewer's own soft-deleted (un-RSVP'd) votes before exposing them; the
+// public count is merged in from the tally RPC below.
+type RawVoteRow = { user_id: string, hidden_at: string | null }
+type RawSuggestionRow = Omit<Suggestion, 'voteCount' | 'votes'> & { votes: RawVoteRow[] }
 
 /**
  * Realtime suggestions for an event + the write actions. Vote *counts* come from
@@ -30,16 +32,24 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
       const [rows, counts] = await Promise.all([
         supabase
           .from('suggestions')
-          .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
+          .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id, hidden_at)')
           .eq('event_id', id)
-          .eq('deleted', false),
+          .eq('deleted', false)
+          // Hidden because the author left "going" — off the ballot until they return.
+          .is('rsvp_hidden_at', null),
         supabase.rpc('suggestion_vote_counts', { p_event_id: id })
       ])
       if (rows.error) throw rows.error
       if (counts.error) throw counts.error
       const countById = new Map((counts.data ?? []).map(c => [c.suggestion_id, Number(c.votes)]))
-      return ((rows.data ?? []) as unknown as RawSuggestion[])
-        .map(s => ({ ...s, voteCount: countById.get(s.id) ?? 0 }))
+      return ((rows.data ?? []) as unknown as RawSuggestionRow[])
+        .map(s => ({
+          ...s,
+          // Drop the viewer's own soft-deleted votes so "did I vote" and my budget
+          // reflect live votes only (counts come from the tally, which also excludes them).
+          votes: (s.votes ?? []).filter(v => v.hidden_at == null).map(v => ({ user_id: v.user_id })),
+          voteCount: countById.get(s.id) ?? 0
+        }))
         .sort((a, b) => {
           const diff = b.voteCount - a.voteCount
           return diff !== 0 ? diff : new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
@@ -108,5 +118,5 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
     await refresh()
   }
 
-  return { suggestions, error, alreadySuggested, suggest, vote, unvote, removeSuggestion }
+  return { suggestions, error, refresh, alreadySuggested, suggest, vote, unvote, removeSuggestion }
 }

--- a/app/composables/useUserStats.ts
+++ b/app/composables/useUserStats.ts
@@ -35,15 +35,17 @@ export function useUserStats(userId: MaybeRefOrGetter<string | null>) {
 
     const { data: pool } = await supabase
       .from('suggestions')
-      .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id)')
+      .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id, hidden_at)')
       .in('event_id', lockedIds)
+      // rsvp-hidden suggestions are off the ballot, so they can't be winners.
+      .is('rsvp_hidden_at', null)
     // The votes embed isn't declared in the generated types (no FK relationship
     // row), so PostgREST's inferred shape doesn't match — cast as useSuggestions does.
-    // Admin drill-down reads every vote (RLS), so the winner count is votes.length —
-    // populate voteCount so topWinners (which counts by voteCount) lines up.
+    // Admin drill-down reads every vote (RLS); count only live votes so the winner
+    // set matches the overview's double-feature.
     const byEvent = new Map<string, Suggestion[]>()
     for (const row of (pool ?? []) as unknown as Suggestion[]) {
-      const s = { ...row, voteCount: row.votes?.length ?? 0 }
+      const s = { ...row, voteCount: liveVoteCount(row.votes) }
       const list = byEvent.get(s.event_id) ?? []
       list.push(s)
       byEvent.set(s.event_id, list)

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -23,7 +23,7 @@ const trailerMovie = ref<TmdbMovie | null>(null)
 const currentEvent = computed(() => events.value[eventIndex.value] ?? null)
 const currentEventId = computed(() => currentEvent.value?.id ?? null)
 
-const { suggestions, alreadySuggested, suggest, vote, unvote, removeSuggestion } = useSuggestions(currentEventId)
+const { suggestions, refresh: refreshSuggestions, alreadySuggested, suggest, vote, unvote, removeSuggestion } = useSuggestions(currentEventId)
 const { myStatus, myPlusOnes, counts, setStatus, setGuests } = useRsvp(currentEventId)
 // Who else is looking at this movie night right now (Realtime Presence).
 const { online } = usePresence(currentEventId)
@@ -44,6 +44,20 @@ const winners = computed(() => topWinners(suggestions.value))
 // You must RSVP "going" to suggest or vote. RLS is the real gate (mirrors
 // public.is_going() in the migration); this just drives the UI.
 const isGoing = computed(() => myStatus.value === 'going')
+
+// Leaving "going" hides this user's suggestions + soft-deletes their votes (a
+// server-side trigger). Confirm first when they actually have something to lose.
+const pendingRsvp = ref<RsvpStatus | null>(null)
+const confirmLeaveOpen = ref(false)
+const leaveSummary = computed(() => {
+  const parts: string[] = []
+  if (mySuggestionCount.value > 0) parts.push(`${mySuggestionCount.value} suggestion${mySuggestionCount.value === 1 ? '' : 's'}`)
+  if (myVoteCount.value > 0) parts.push(`${myVoteCount.value} vote${myVoteCount.value === 1 ? '' : 's'}`)
+  return parts.join(' and ')
+})
+watch(confirmLeaveOpen, (open) => {
+  if (!open) pendingRsvp.value = null
+})
 
 // Per-event participation caps (mirrors the DB triggers — see shared/utils/limits).
 // Effective limit = admin-configured (app_settings) or the default in limits.ts.
@@ -123,8 +137,25 @@ async function onRemove(suggestion: Suggestion): Promise<void> {
     toast.add({ title: 'Suggestion removed', color: 'neutral' })
   }
 }
+async function applyRsvp(status: RsvpStatus): Promise<void> {
+  if (await run(() => setStatus(status), 'Could not update RSVP')) {
+    // The hide/restore happens in a DB trigger; re-pull so the list reflects it now.
+    await refreshSuggestions()
+  }
+}
 async function onRsvp(status: RsvpStatus): Promise<void> {
-  await run(() => setStatus(status), 'Could not update RSVP')
+  // Any status tap while "going" leaves "going" (tapping it again clears it).
+  if (myStatus.value === 'going' && (mySuggestionCount.value > 0 || myVoteCount.value > 0)) {
+    pendingRsvp.value = status
+    confirmLeaveOpen.value = true
+    return
+  }
+  await applyRsvp(status)
+}
+async function confirmLeave(): Promise<void> {
+  const status = pendingRsvp.value
+  confirmLeaveOpen.value = false
+  if (status) await applyRsvp(status)
 }
 async function onGuests(count: number): Promise<void> {
   await run(() => setGuests(count), 'Could not update guest count')
@@ -354,6 +385,22 @@ async function onGuests(count: number): Promise<void> {
 
     <EventInfoModal v-model:open="eventInfoOpen" :event="currentEvent" />
     <TrailerModal v-model:open="trailerOpen" :movie="trailerMovie" />
+
+    <!-- Warn before leaving "going" hides this user's suggestions + votes. -->
+    <UModal v-model:open="confirmLeaveOpen" title="Leave “Going”?">
+      <template #body>
+        <p class="text-sm text-muted">
+          You won't be marked as going, so your <strong class="text-default">{{ leaveSummary }}</strong>
+          for this movie night will be hidden. RSVP “Going” again and they'll come right back.
+        </p>
+      </template>
+      <template #footer>
+        <div class="flex justify-end gap-2 w-full">
+          <UButton label="Stay going" color="neutral" variant="ghost" @click="confirmLeaveOpen = false" />
+          <UButton label="Hide my stuff" color="warning" icon="i-lucide-eye-off" @click="confirmLeave" />
+        </div>
+      </template>
+    </UModal>
   </UContainer>
 </template>
 

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -48,15 +48,15 @@ export interface Database {
         Relationships: []
       }
       suggestions: {
-        Row: { id: string, event_id: string, user_id: string, tmdb_movie: TmdbMovie, deleted: boolean, created_at: string }
-        Insert: { id?: string, event_id: string, user_id?: string, tmdb_movie: TmdbMovie, deleted?: boolean, created_at?: string }
-        Update: { id?: string, event_id?: string, user_id?: string, tmdb_movie?: TmdbMovie, deleted?: boolean, created_at?: string }
+        Row: { id: string, event_id: string, user_id: string, tmdb_movie: TmdbMovie, deleted: boolean, rsvp_hidden_at: string | null, created_at: string }
+        Insert: { id?: string, event_id: string, user_id?: string, tmdb_movie: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, created_at?: string }
+        Update: { id?: string, event_id?: string, user_id?: string, tmdb_movie?: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, created_at?: string }
         Relationships: []
       }
       votes: {
-        Row: { suggestion_id: string, user_id: string, created_at: string }
-        Insert: { suggestion_id: string, user_id?: string, created_at?: string }
-        Update: { suggestion_id?: string, user_id?: string, created_at?: string }
+        Row: { suggestion_id: string, user_id: string, hidden_at: string | null, created_at: string }
+        Insert: { suggestion_id: string, user_id?: string, hidden_at?: string | null, created_at?: string }
+        Update: { suggestion_id?: string, user_id?: string, hidden_at?: string | null, created_at?: string }
         Relationships: []
       }
       comms_log: {

--- a/shared/types/suggestion.ts
+++ b/shared/types/suggestion.ts
@@ -19,7 +19,9 @@ export interface Suggestion {
   deleted: boolean
   created_at: string
   voteCount: number
-  votes: { user_id: string }[]
+  // `hidden_at` is present on admin/stats reads (to drop soft-deleted votes from
+  // counts); the overview read strips it, so it's optional.
+  votes: { user_id: string, hidden_at?: string | null }[]
 }
 
 /**
@@ -29,5 +31,5 @@ export interface Suggestion {
  */
 export interface AdminSuggestion extends Suggestion {
   author: { display_name: string | null, email: string | null } | null
-  votes: { user_id: string, voter: { display_name: string | null } | null }[]
+  votes: { user_id: string, hidden_at?: string | null, voter: { display_name: string | null } | null }[]
 }

--- a/shared/utils/ballot.ts
+++ b/shared/utils/ballot.ts
@@ -1,0 +1,12 @@
+/**
+ * Ballot visibility helpers, mirroring the SQL read paths in the RSVP hide/restore
+ * migration so client-side counts match the server. A vote counts toward the ballot
+ * only while it isn't soft-deleted (`hidden_at` null — the voter left "going").
+ * Suggestions that are admin-deleted or rsvp-hidden are excluded at the query level
+ * by each read path, so this only has to handle the per-vote case.
+ */
+export function liveVoteCount(
+  votes: ReadonlyArray<{ hidden_at?: string | null }> | null | undefined
+): number {
+  return (votes ?? []).filter(v => v.hidden_at == null).length
+}

--- a/shared/utils/eventStats.ts
+++ b/shared/utils/eventStats.ts
@@ -26,7 +26,8 @@ export function computeEventStats(input: {
   const submitters = new Set(live.map(s => s.user_id))
   const voters = new Set<string>()
   for (const s of live) {
-    for (const v of s.votes ?? []) voters.add(v.user_id)
+    // Soft-deleted votes (voter left "going") don't count toward distinct voters.
+    for (const v of s.votes ?? []) if (v.hidden_at == null) voters.add(v.user_id)
   }
   const countStatus = (status: string): number => input.rsvps.filter(r => r.status === status).length
   return {

--- a/supabase/migrations/20260630000000_rsvp_unrsvp_hide_restore.sql
+++ b/supabase/migrations/20260630000000_rsvp_unrsvp_hide_restore.sql
@@ -1,0 +1,130 @@
+-- ============================================================================
+-- Un-RSVP hides your stuff; re-RSVP restores it.
+--
+-- When a user leaves "going" (→ maybe/no, or clears their RSVP entirely) their
+-- suggestions are hidden and their votes are soft-deleted for that event. When
+-- they return to "going", everything is restored to its prior state. Nothing is
+-- ever hard-deleted, so restore is exact.
+--
+-- The hide/restore is driven by a trigger on `rsvps` (Invariant 1 — enforcement
+-- lives in the database, not the client). Two NEW soft-hide flags, kept separate
+-- from admin moderation so the reasons compose instead of colliding:
+--   * suggestions.rsvp_hidden_at — distinct from `deleted` (admin moderation), so
+--     a re-RSVP can never un-delete a suggestion an admin removed.
+--   * votes.hidden_at — votes had no soft-delete at all (hard-delete only).
+--
+-- "Effectively visible" becomes `deleted = false AND rsvp_hidden_at is null` for a
+-- suggestion, and `hidden_at is null` for a vote. Every read path that decides the
+-- ballot is updated to honor it: the tally RPC, the participation-limit triggers
+-- (so a voter whose pick gets hidden gets their budget back — client and server
+-- agree), and the overview/winners reads in app code.
+-- ============================================================================
+
+alter table public.suggestions add column if not exists rsvp_hidden_at timestamptz;
+alter table public.votes       add column if not exists hidden_at      timestamptz;
+
+-- ---------- Hide / restore trigger ----------
+-- AFTER each rsvps change, reconcile the acting user's suggestions + votes for the
+-- event to match their new "going" state. SECURITY DEFINER so it can update rows a
+-- normal user has no UPDATE policy for (suggestions/votes); it only ever touches
+-- the rsvp row's own user_id, never anyone else's. Restores clear ONLY the
+-- rsvp-hide flags — admin `deleted` is left untouched.
+create function public.sync_rsvp_visibility() returns trigger
+  language plpgsql security definer set search_path = '' as $$
+declare
+  uid   uuid;
+  eid   uuid;
+  going boolean;
+begin
+  if tg_op = 'DELETE' then
+    uid := old.user_id; eid := old.event_id; going := false;
+  else
+    uid := new.user_id; eid := new.event_id; going := (new.status = 'going');
+  end if;
+
+  if going then
+    -- Restore: un-hide this user's suggestions + votes for the event.
+    update public.suggestions
+      set rsvp_hidden_at = null
+      where user_id = uid and event_id = eid and rsvp_hidden_at is not null;
+    update public.votes v
+      set hidden_at = null
+      from public.suggestions s
+      where v.suggestion_id = s.id and s.event_id = eid
+        and v.user_id = uid and v.hidden_at is not null;
+  else
+    -- Hide: soft-delete this user's suggestions + votes for the event.
+    update public.suggestions
+      set rsvp_hidden_at = now()
+      where user_id = uid and event_id = eid and rsvp_hidden_at is null;
+    update public.votes v
+      set hidden_at = now()
+      from public.suggestions s
+      where v.suggestion_id = s.id and s.event_id = eid
+        and v.user_id = uid and v.hidden_at is null;
+  end if;
+
+  return null; -- AFTER trigger: return value is ignored.
+end;
+$$;
+
+create trigger rsvps_sync_visibility
+  after insert or update or delete on public.rsvps
+  for each row execute function public.sync_rsvp_visibility();
+
+-- ---------- Read paths: exclude hidden from the ballot ----------
+
+-- Tally: count only live votes on live suggestions (drop soft-deleted votes and
+-- rsvp-hidden / admin-deleted suggestions).
+create or replace function public.suggestion_vote_counts(p_event_id uuid)
+  returns table (suggestion_id uuid, votes bigint)
+  language sql security definer stable set search_path = public as $$
+  select v.suggestion_id, count(*)::bigint
+  from public.votes v
+  join public.suggestions s on s.id = v.suggestion_id
+  where s.event_id = p_event_id and s.deleted = false and s.rsvp_hidden_at is null
+    and v.hidden_at is null
+    and public.is_allowed()
+  group by v.suggestion_id
+$$;
+revoke all on function public.suggestion_vote_counts(uuid) from public;
+grant execute on function public.suggestion_vote_counts(uuid) to authenticated;
+
+-- ---------- Participation limits: count only live participation ----------
+-- A suggestion/vote that's hidden (rsvp) or admin-deleted no longer occupies a
+-- slot, so the cap math must ignore it — otherwise a voter whose pick gets hidden
+-- would see freed budget in the UI but be rejected by the server (mismatch).
+
+create or replace function public.enforce_suggestion_limit() returns trigger
+  language plpgsql security definer set search_path = public as $$
+begin
+  if auth.uid() is not null and (
+    select count(*) from public.suggestions
+    where event_id = new.event_id and user_id = auth.uid()
+      and deleted = false and rsvp_hidden_at is null
+  ) >= public.suggestion_limit() then
+    raise exception 'Suggestion limit (%) reached for this event', public.suggestion_limit()
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function public.enforce_vote_limit() returns trigger
+  language plpgsql security definer set search_path = public as $$
+declare
+  ev uuid;
+begin
+  select event_id into ev from public.suggestions where id = new.suggestion_id;
+  if auth.uid() is not null and (
+    select count(*) from public.votes v
+    join public.suggestions s on s.id = v.suggestion_id
+    where v.user_id = auth.uid() and s.event_id = ev
+      and s.deleted = false and s.rsvp_hidden_at is null and v.hidden_at is null
+  ) >= public.vote_limit() then
+    raise exception 'Vote limit (%) reached for this event', public.vote_limit()
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;

--- a/test/ballot.test.ts
+++ b/test/ballot.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { liveVoteCount } from '../shared/utils/ballot'
+
+describe('liveVoteCount', () => {
+  it('counts only votes without a hidden_at timestamp', () => {
+    expect(liveVoteCount([{ hidden_at: null }, { hidden_at: '2026-06-01T00:00:00Z' }, {}])).toBe(2)
+  })
+
+  it('treats a missing hidden_at as live', () => {
+    expect(liveVoteCount([{}, {}])).toBe(2)
+  })
+
+  it('returns 0 for empty / null / undefined', () => {
+    expect(liveVoteCount([])).toBe(0)
+    expect(liveVoteCount(null)).toBe(0)
+    expect(liveVoteCount(undefined)).toBe(0)
+  })
+})

--- a/test/eventStats.test.ts
+++ b/test/eventStats.test.ts
@@ -41,6 +41,21 @@ describe('computeEventStats', () => {
     expect(stats.submitterCount).toBe(1)
   })
 
+  it('excludes soft-deleted (un-RSVP) votes from the distinct voter count', () => {
+    const withHidden: Suggestion = {
+      id: 's1',
+      event_id: 'e1',
+      user_id: 'alice',
+      tmdb_movie: { id: 1, title: 'Heat' },
+      deleted: false,
+      created_at: '2026-01-01T00:00:00Z',
+      voteCount: 1,
+      votes: [{ user_id: 'live' }, { user_id: 'left', hidden_at: '2026-06-01T00:00:00Z' }]
+    }
+    const stats = computeEventStats({ suggestions: [withHidden], rsvps: [], bringItems: [] })
+    expect(stats.voterCount).toBe(1) // only 'live' — 'left' soft-deleted their vote on un-RSVP
+  })
+
   it('splits RSVPs into going / maybe / declined', () => {
     const stats = computeEventStats({
       suggestions: [],

--- a/test/overview.nuxt.test.ts
+++ b/test/overview.nuxt.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment nuxt
-import { beforeEach, describe, expect, it } from 'vitest'
-import { ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import OverviewPage from '../app/pages/overview.vue'
 
@@ -21,6 +22,7 @@ const event = {
 const isAdmin = ref(false)
 const myId = ref<string | null>(null)
 const myStatus = ref<string | null>(null)
+const setStatus = vi.fn(async () => {})
 const suggestionList = ref<Array<Record<string, unknown>>>([])
 // Admin-configured caps (null = fall back to the limits.ts defaults).
 const cfgMaxSuggestions = ref<number | null>(null)
@@ -31,6 +33,7 @@ mockNuxtImport('useEvents', () => () => ({ events: ref([event]) }))
 mockNuxtImport('useTmdb', () => () => ({ posterUrl: () => null }))
 mockNuxtImport('useSuggestions', () => () => ({
   suggestions: suggestionList,
+  refresh: async () => {},
   alreadySuggested: () => false,
   suggest: async () => {},
   vote: async () => {},
@@ -41,7 +44,7 @@ mockNuxtImport('useRsvp', () => () => ({
   myStatus,
   myPlusOnes: ref(0),
   counts: ref({ going: 0, maybe: 0, no: 0, guests: 0 }),
-  setStatus: async () => {},
+  setStatus,
   setGuests: async () => {}
 }))
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
@@ -69,12 +72,17 @@ beforeEach(() => {
   isAdmin.value = false
   myId.value = null
   myStatus.value = 'going'
+  setStatus.mockClear()
   suggestionList.value = []
   cfgMaxSuggestions.value = null
   cfgMaxVotes.value = null
   // Some tests flip the date to the past; reset to upcoming each time.
   event.event_date = UPCOMING
 })
+
+// Use the real RsvpControl so we can click a status button to trigger the leave
+// flow; GuestStepper stays stubbed (it pulls its own bits).
+const rsvpStubs = { ...stubs, RsvpControl: false as const, GuestStepper: true }
 
 function mineSuggestion(i: number): Record<string, unknown> {
   return { id: `s${i}`, event_id: 'e1', user_id: 'me', tmdb_movie: { id: i, title: `M${i}` }, deleted: false, created_at: '2026-01-01', votes: [] }
@@ -146,5 +154,40 @@ describe('overview page', () => {
     myStatus.value = null
     const w = await mountSuspended(OverviewPage, { global: { stubs } })
     expect(w.text()).not.toContain('RSVP to join in')
+  })
+
+  it('warns before leaving “going” when I have suggestions or votes', async () => {
+    myId.value = 'me'
+    myStatus.value = 'going'
+    suggestionList.value = [mineSuggestion(1)] // mySuggestionCount = 1
+    const w = await mountSuspended(OverviewPage, { global: { stubs: rsvpStubs } })
+    await w.findAll('button').find(b => b.text().includes('Maybe'))?.trigger('click')
+    await nextTick()
+    // Doesn't leave yet — a confirmation appears instead.
+    expect(setStatus).not.toHaveBeenCalled()
+    expect(document.body.textContent).toContain('Hide my stuff')
+  })
+
+  it('leaves immediately when there is nothing to hide', async () => {
+    myId.value = 'me'
+    myStatus.value = 'going'
+    suggestionList.value = [] // no suggestions, no votes
+    const w = await mountSuspended(OverviewPage, { global: { stubs: rsvpStubs } })
+    await w.findAll('button').find(b => b.text().includes('Maybe'))?.trigger('click')
+    await flushPromises()
+    expect(setStatus).toHaveBeenCalledWith('maybe')
+  })
+
+  it('hides my stuff once I confirm leaving', async () => {
+    myId.value = 'me'
+    myStatus.value = 'going'
+    suggestionList.value = [mineSuggestion(1)]
+    const w = await mountSuspended(OverviewPage, { global: { stubs: rsvpStubs } })
+    await w.findAll('button').find(b => b.text().includes('Maybe'))?.trigger('click')
+    await nextTick()
+    const confirm = [...document.body.querySelectorAll('button')].find(b => b.textContent?.includes('Hide my stuff'))
+    confirm?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+    expect(setStatus).toHaveBeenCalledWith('maybe')
   })
 })

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -240,4 +240,57 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('rsvps').delete().eq('user_id', gateId)
     await admin!.from('invites').delete().eq('email', gateEmail)
   })
+
+  it('un-RSVP hides the user’s suggestions + votes; re-RSVP restores them', async () => {
+    const email = `rls_hide_${stamp}@example.com`
+    const uid = await makeUser(email)
+    await admin!.from('invites').insert({ email })
+    const client = await signInAs(email)
+
+    // Another member's suggestion (service role) for our user to vote on, plus our
+    // own suggestion B. Both happen while "going" (the participation gate).
+    const { data: a } = await admin!
+      .from('suggestions')
+      .insert({ event_id: eventId, user_id: memberId, tmdb_movie: { id: 800, title: 'Voted' } })
+      .select('id').single()
+    const aId = a!.id
+
+    await client.from('rsvps').insert({ event_id: eventId, user_id: uid, status: 'going' })
+    const { data: b } = await client
+      .from('suggestions').insert({ event_id: eventId, tmdb_movie: { id: 801, title: 'Mine' } })
+      .select('id').single()
+    const bId = b!.id
+    await client.from('votes').insert({ suggestion_id: aId })
+
+    // Baseline (going): B visible, vote live, tally counts A.
+    const beforeB = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', bId).single()
+    expect(beforeB.data!.rsvp_hidden_at, 'B starts visible').toBeNull()
+    const beforeVote = await admin!.from('votes').select('hidden_at').eq('suggestion_id', aId).eq('user_id', uid).single()
+    expect(beforeVote.data!.hidden_at, 'the vote starts live').toBeNull()
+    const tallyBefore = await client.rpc('suggestion_vote_counts', { p_event_id: eventId })
+    expect(Number((tallyBefore.data ?? []).find(r => r.suggestion_id === aId)?.votes), 'A counts the vote').toBe(1)
+
+    // Leave "going" → suggestions hidden, votes soft-deleted.
+    await client.from('rsvps').update({ status: 'maybe' }).eq('event_id', eventId).eq('user_id', uid)
+    const hiddenB = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', bId).single()
+    expect(hiddenB.data!.rsvp_hidden_at, 'B is rsvp-hidden after leaving going').not.toBeNull()
+    const hiddenVote = await admin!.from('votes').select('hidden_at').eq('suggestion_id', aId).eq('user_id', uid).single()
+    expect(hiddenVote.data!.hidden_at, 'the vote is soft-deleted after leaving going').not.toBeNull()
+    const tallyHidden = await client.rpc('suggestion_vote_counts', { p_event_id: eventId })
+    expect((tallyHidden.data ?? []).find(r => r.suggestion_id === aId), 'the hidden vote no longer counts').toBeUndefined()
+
+    // Return to "going" → restored to the exact prior state.
+    await client.from('rsvps').update({ status: 'going' }).eq('event_id', eventId).eq('user_id', uid)
+    const restoredB = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', bId).single()
+    expect(restoredB.data!.rsvp_hidden_at, 'B is restored on re-RSVP').toBeNull()
+    const restoredVote = await admin!.from('votes').select('hidden_at').eq('suggestion_id', aId).eq('user_id', uid).single()
+    expect(restoredVote.data!.hidden_at, 'the vote is restored on re-RSVP').toBeNull()
+    const tallyRestored = await client.rpc('suggestion_vote_counts', { p_event_id: eventId })
+    expect(Number((tallyRestored.data ?? []).find(r => r.suggestion_id === aId)?.votes), 'the vote counts again').toBe(1)
+
+    await admin!.from('votes').delete().eq('user_id', uid)
+    await admin!.from('suggestions').delete().in('id', [aId, bId])
+    await admin!.from('rsvps').delete().eq('user_id', uid)
+    await admin!.from('invites').delete().eq('email', email)
+  })
 })

--- a/test/useEventStats.nuxt.test.ts
+++ b/test/useEventStats.nuxt.test.ts
@@ -16,6 +16,7 @@ function builder(table: string) {
   const c: Record<string, unknown> = {
     select: () => c,
     eq: () => c,
+    is: () => c,
     then: (resolve: (v: unknown) => void) => {
       if (table === 'suggestions') return resolve({ data: data.suggestions, error: data.error })
       if (table === 'rsvps') return resolve({ data: data.rsvps, error: null })

--- a/test/useSuggestions-race.nuxt.test.ts
+++ b/test/useSuggestions-race.nuxt.test.ts
@@ -15,6 +15,7 @@ const supabase = {
         if (col === 'event_id') eventId = val
         return chain
       },
+      is: () => chain,
       // `await`-ing the query registers a resolver for its event id.
       then: (onFulfilled: (r: { data: unknown[] }) => unknown) =>
         new Promise<{ data: unknown[] }>((resolve) => {

--- a/test/useSuggestions-rsvp-hidden.nuxt.test.ts
+++ b/test/useSuggestions-rsvp-hidden.nuxt.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment nuxt
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+// A suggestion whose embedded votes include the viewer's own *soft-deleted* vote
+// (hidden_at set, because they left "going"). useSuggestions must drop it so
+// "did I vote" and the vote budget reflect only live votes — counts come from the
+// tally, which excludes hidden votes server-side too.
+const rowWithHiddenVote = {
+  id: 's1',
+  event_id: 'e1',
+  user_id: 'author',
+  tmdb_movie: { id: 1, title: 'Heat' },
+  deleted: false,
+  created_at: '2026-01-01T00:00:00Z',
+  votes: [{ user_id: 'me', hidden_at: '2026-06-01T00:00:00Z' }]
+}
+
+const supabase = {
+  from() {
+    return {
+      select: () => {
+        const chain = {
+          eq: () => chain,
+          is: () => chain,
+          then: (onFulfilled: (r: { data: unknown[], error: null }) => unknown) =>
+            Promise.resolve({ data: [rowWithHiddenVote], error: null }).then(onFulfilled)
+        }
+        return chain
+      }
+    }
+  },
+  rpc: () => Promise.resolve({ data: [{ suggestion_id: 's1', votes: 0 }], error: null }),
+  channel() {
+    const ch = { on: () => ch, subscribe: () => ch, send: () => Promise.resolve('ok') }
+    return ch
+  },
+  removeChannel() {}
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+mockNuxtImport('useState', () => () => ref('me'))
+
+async function loaded(suggestions: { value: { votes: unknown[] }[] }): Promise<void> {
+  await vi.waitFor(() => {
+    if (!suggestions.value.length) throw new Error('not loaded yet')
+  })
+}
+
+describe('useSuggestions — soft-deleted (un-RSVP) votes', () => {
+  it('drops the viewer’s own hidden_at vote from the votes array', async () => {
+    const { suggestions } = useSuggestions(ref('e1'))
+    await loaded(suggestions)
+    // The only embedded vote is soft-deleted, so the live votes array is empty.
+    expect(suggestions.value[0]!.votes).toHaveLength(0)
+  })
+})

--- a/test/useSuggestions-tally.nuxt.test.ts
+++ b/test/useSuggestions-tally.nuxt.test.ts
@@ -23,7 +23,16 @@ const ownVoteRow = {
 const supabase = {
   from() {
     return {
-      select: () => ({ eq: () => ({ eq: () => Promise.resolve({ data: [ownVoteRow], error: null }) }) }),
+      select: () => {
+        // Load chains .eq('event_id').eq('deleted').is('rsvp_hidden_at', null).
+        const chain = {
+          eq: () => chain,
+          is: () => chain,
+          then: (onFulfilled: (r: { data: unknown[], error: null }) => unknown) =>
+            Promise.resolve({ data: [ownVoteRow], error: null }).then(onFulfilled)
+        }
+        return chain
+      },
       insert: () => Promise.resolve({ error: null }),
       delete: () => ({ eq: () => Promise.resolve({ error: null }) })
     }

--- a/test/useSuggestions.nuxt.test.ts
+++ b/test/useSuggestions.nuxt.test.ts
@@ -29,7 +29,16 @@ const supabase = {
         }
         return chain
       },
-      select: () => ({ eq: () => ({ eq: () => Promise.resolve({ data: [] }) }) })
+      select: () => {
+        // Load chains .eq('event_id').eq('deleted').is('rsvp_hidden_at', null).
+        const chain = {
+          eq: () => chain,
+          is: () => chain,
+          then: (onFulfilled: (r: { data: unknown[], error: null }) => unknown) =>
+            Promise.resolve({ data: [], error: null }).then(onFulfilled)
+        }
+        return chain
+      }
     }
   },
   rpc: () => Promise.resolve({ data: [], error: null }),

--- a/test/useUserStats.nuxt.test.ts
+++ b/test/useUserStats.nuxt.test.ts
@@ -30,6 +30,7 @@ function builder(table: string) {
       usedIn = true
       return c
     },
+    is: () => c,
     not: () => c,
     then: (resolve: (v: unknown) => void) => {
       if (table === 'rsvps') return resolve({ data: data.rsvps, error: null })


### PR DESCRIPTION
## Scope

Second of the RSVP-participation PRs (follows #127). When a member **leaves "going"**
(→ maybe/no, or clears their RSVP), their suggestions are **hidden** and their votes are
**soft-deleted** for that event — off the ballot, uncounted. When they **return to "going"**,
everything is **restored to its exact prior state**. Nothing is ever hard-deleted.

Next: PR #3 (ballot pruning / phased runoff) builds on this hide/restore plumbing.

## Implementation

Six focused commits, each green on its own:

1. **`feat(db)` migration** — two new soft-hide flags, deliberately separate from admin
   moderation so the reasons compose: `suggestions.rsvp_hidden_at` (distinct from `deleted`,
   so a re-RSVP can never un-delete a moderated suggestion) and `votes.hidden_at` (votes had
   no soft-delete at all). An **AFTER trigger on `rsvps`** reconciles the acting user's rows
   for the event on every change — hide on leave, restore on return. Enforcement is in the DB
   (Invariant 1), not the client; the trigger only ever touches its own `user_id`'s rows.
   The tally RPC and **both participation-limit triggers** now exclude hidden rows, so a voter
   whose pick gets hidden gets their budget back — **client and server budgets stay in sync**.
2. **`test(rls)`** — integration coverage: going member's suggestion + vote are live and
   counted; leaving "going" flips the flags and drops the vote from the tally; returning
   restores both exactly.
3. **Overview read path** — `useSuggestions` drops rsvp-hidden suggestions server-side and
   strips the viewer's own soft-deleted votes from each embed (so "did I vote"/budget reflect
   live votes only); exposes `refresh()`.
4. **`liveVoteCount` helper** — shared ballot helper + the optional `hidden_at` on the votes
   types.
5. **Admin + stats consistency** — admin winners drive the lock-voting decision, so they must
   match what members see. `useAdminSuggestions`, `useEventStats`, and `useUserStats` now
   exclude rsvp-hidden suggestions (admin-deleted still load for moderation) and count only
   live votes, so a backed-out nominee can't appear as a winner and soft-deleted votes don't
   inflate counts.
6. **Confirmation UI** — leaving "going" with something to lose opens a confirm
   ("your N suggestions and M votes will be hidden — RSVP Going again to restore"); with
   nothing to lose it proceeds straight through. The overview re-pulls on any RSVP change so
   the hide/restore shows immediately.

## Screenshots

UI surface is the `/overview` left panel: a confirmation modal now appears when you tap
Maybe/Can't (or un-toggle Going) while you have suggestions/votes.

|         | leaving "going" (new)                              |
| ------- | -------------------------------------------------- |
| desktop | "Leave Going?" modal → Stay going / Hide my stuff  |
| mobile  | same modal                                         |

_(Static screenshots to follow before merge.)_

## How to Test

**Automated**
- Integration (`test/rls.integration.test.ts`, Supabase-local, skipped otherwise): hide on
  leave + restore on return, with tally assertions.
- Unit: `useSuggestions` strips soft-deleted votes; `liveVoteCount`; `computeEventStats`
  excludes hidden voters; overview confirmation (warns when there's stuff to lose, proceeds
  when there isn't, hides on confirm). `npm run typecheck`, `npm run lint` (0 errors),
  `npx vitest run` (386 passing) all green.

**Manual**
1. RSVP **Going**, suggest a movie and vote on a couple.
2. Tap **Maybe** → confirm dialog; confirm. Your suggestion disappears from the list and
   the vote totals drop for everyone; your vote budget frees up.
3. Tap **Going** again → your suggestion and votes come right back, counts restored.

## Invariants & Risk

- **Authorization / Invariant 1:** hide/restore is a SECURITY DEFINER trigger on `rsvps`
  (a normal user has no UPDATE policy on suggestions/votes — the trigger is the only writer,
  and only for the rsvp row's own user).
- **Vote integrity / Invariant 3:** still no stored counter — counts are derived; the tally
  and limit triggers just exclude `hidden_at`/`rsvp_hidden_at`. The dedup unique index is
  unchanged, so a hidden suggestion keeps its title slot reserved for a clean restore.
- **Migration must reach prod.** Realtime liveness note: a *vote-only* un-RSVP (user voted
  but never suggested) updates other viewers' counts on the next load rather than instantly
  (the overview subscribes to the suggestions table, not the privacy-restricted votes stream);
  the un-RSVPing user themselves refreshes immediately. Standalone e-vite RSVP changes
  (`/rsvp`) still hide/restore correctly via the trigger, without the in-app confirmation.