### PR TITLE
feat: ballot pruning — cut zero-vote titles + keep-top-N runoff

### DIFF
--- a/app/components/BallotPruneControls.vue
+++ b/app/components/BallotPruneControls.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+// Admin control to prune an event's ballot as the night nears: cut zero-vote
+// titles, or keep only the top N by votes. Cuts are permanent (a confirm guards
+// them); freed votes are refunded to voters server-side. Emits `pruned` with the
+// number cut so the parent can refresh its list.
+const props = defineProps<{ eventId: string }>()
+const emit = defineEmits<{ pruned: [cut: number] }>()
+
+const toast = useToast()
+const { cullZeroVotes, cullToTop } = useBallotPruning(() => props.eventId)
+
+// keepTop is a string: UInput type="number" writes a string back through v-model
+// (see ParticipationLimitsSetting). Parse + clamp to a sane keep count.
+const keepTop = ref('8')
+const keepTopNum = computed(() => Math.max(1, Math.floor(Number(keepTop.value)) || 1))
+
+const pending = ref<{ kind: 'zero' } | { kind: 'top', keep: number } | null>(null)
+const prompt = computed(() => {
+  const p = pending.value
+  if (!p) return ''
+  return p.kind === 'zero'
+    ? 'Permanently cut every title with no votes yet? This can’t be undone.'
+    : `Permanently cut everything except the top ${p.keep} by votes? Anyone who voted for a cut title gets that vote back. This can’t be undone.`
+})
+
+async function confirm(): Promise<void> {
+  const action = pending.value
+  pending.value = null
+  if (!action) return
+  try {
+    const cut = action.kind === 'zero' ? await cullZeroVotes() : await cullToTop(action.keep)
+    emit('pruned', cut)
+    toast.add({
+      title: cut ? `Cut ${cut} title${cut === 1 ? '' : 's'} from the ballot` : 'Nothing to cut',
+      icon: 'i-lucide-scissors',
+      color: cut ? 'success' : 'neutral'
+    })
+  } catch (error) {
+    toast.add({ title: 'Could not prune the ballot', description: error instanceof Error ? error.message : undefined, color: 'error' })
+  }
+}
+</script>
+
+<template>
+  <UCard variant="subtle">
+    <div class="flex flex-wrap items-center justify-between gap-3">
+      <div class="min-w-0">
+        <h3 class="text-sm font-semibold flex items-center gap-1.5">
+          <UIcon name="i-lucide-scissors" /> Prune the ballot
+        </h3>
+        <p class="text-xs text-muted mt-0.5">
+          Trim the lineup as the night nears. Cuts are permanent; freed votes go back to voters.
+        </p>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <UButton
+          label="Cut zero-vote titles"
+          icon="i-lucide-trash"
+          color="neutral"
+          variant="outline"
+          size="sm"
+          @click="pending = { kind: 'zero' }"
+        />
+        <div class="flex items-center gap-1.5">
+          <span class="text-xs text-muted whitespace-nowrap">keep top</span>
+          <UInput v-model="keepTop" type="number" min="1" size="sm" class="w-16" />
+          <UButton
+            label="Cut"
+            icon="i-lucide-scissors"
+            color="primary"
+            size="sm"
+            @click="pending = { kind: 'top', keep: keepTopNum }"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Permanent — confirm before cutting. -->
+    <UModal
+      :open="Boolean(pending)"
+      title="Prune the ballot?"
+      :description="prompt"
+      @update:open="(value) => { if (!value) pending = null }"
+    >
+      <template #footer>
+        <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 w-full">
+          <UButton label="Cancel" color="neutral" variant="ghost" class="justify-center" @click="pending = null" />
+          <UButton label="Cut titles" color="primary" icon="i-lucide-scissors" class="justify-center" @click="confirm" />
+        </div>
+      </template>
+    </UModal>
+  </UCard>
+</template>

--- a/app/components/CulledList.vue
+++ b/app/components/CulledList.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { CulledSuggestion } from '~/composables/useCulledSuggestions'
+
+// Read-only audit trail of titles pruned from the ballot. Collapsed by default so
+// it doesn't clutter the dashboard; culls are permanent, so there are no actions.
+defineProps<{ items: ReadonlyArray<CulledSuggestion> }>()
+const open = ref(false)
+</script>
+
+<template>
+  <UCard variant="subtle">
+    <button type="button" class="w-full flex items-center justify-between gap-2" @click="open = !open">
+      <span class="text-sm font-semibold flex items-center gap-1.5">
+        <UIcon name="i-lucide-archive" /> Pruned ({{ items.length }})
+      </span>
+      <UIcon :name="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" class="text-muted" />
+    </button>
+    <div v-if="open" class="mt-3 space-y-2">
+      <div v-for="s in items" :key="s.id" class="flex items-center justify-between gap-3 text-sm">
+        <span class="truncate">{{ s.tmdb_movie.title }}</span>
+        <span class="text-xs text-muted shrink-0">
+          {{ s.voteCount }} vote{{ s.voteCount === 1 ? '' : 's' }} · cut {{ formatDate(s.culled_at, { dateStyle: 'medium' }) }}
+        </span>
+      </div>
+    </div>
+  </UCard>
+</template>

--- a/app/composables/useAdminSuggestions.ts
+++ b/app/composables/useAdminSuggestions.ts
@@ -28,8 +28,10 @@ export function useAdminSuggestions(eventId: MaybeRefOrGetter<string | null | un
         .from('suggestions')
         .select(SELECT)
         .eq('event_id', id)
-        // Off the ballot while the author isn't "going" (admin-deleted rows still load).
+        // Off the ballot while the author isn't "going", and permanently once culled
+        // (admin-deleted rows still load for the moderation toggle).
         .is('rsvp_hidden_at', null)
+        .is('culled_at', null)
       if (error) throw error
       // Admins read every vote row (RLS); count only the live (non-soft-deleted)
       // ones so the admin count matches the public tally.
@@ -56,5 +58,5 @@ export function useAdminSuggestions(eventId: MaybeRefOrGetter<string | null | un
       .map(vote => vote.voter?.display_name ?? 'Unknown')
   }
 
-  return { suggestions, error, setDeleted, voterNames }
+  return { suggestions, error, refresh, setDeleted, voterNames }
 }

--- a/app/composables/useBallotPruning.ts
+++ b/app/composables/useBallotPruning.ts
@@ -1,0 +1,32 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Database } from '~/types/database.types'
+
+/**
+ * Admin ballot pruning for an event. Both actions call admin-only SECURITY DEFINER
+ * RPCs (the is_admin gate lives in the database — Invariant 1) and return how many
+ * titles were cut. Culls are permanent; a cut title's votes are refunded to their
+ * voters' budgets server-side.
+ */
+export function useBallotPruning(eventId: MaybeRefOrGetter<string | null | undefined>) {
+  const supabase = useSupabaseClient<Database>()
+
+  /** Cut every title with no live votes. */
+  async function cullZeroVotes(): Promise<number> {
+    const id = toValue(eventId)
+    if (!id) return 0
+    const { data, error } = await supabase.rpc('cull_zero_votes', { p_event_id: id })
+    if (error) throw error
+    return data ?? 0
+  }
+
+  /** Keep only the top `keep` titles by votes (ties → earliest-suggested); cut the rest. */
+  async function cullToTop(keep: number): Promise<number> {
+    const id = toValue(eventId)
+    if (!id) return 0
+    const { data, error } = await supabase.rpc('cull_to_top', { p_event_id: id, p_keep: keep })
+    if (error) throw error
+    return data ?? 0
+  }
+
+  return { cullZeroVotes, cullToTop }
+}

--- a/app/composables/useCulledSuggestions.ts
+++ b/app/composables/useCulledSuggestions.ts
@@ -1,0 +1,45 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Database } from '~/types/database.types'
+import type { AdminSuggestion } from '#shared/types/suggestion'
+
+/** A culled suggestion plus when it was cut — the admin audit trail. */
+export type CulledSuggestion = AdminSuggestion & { culled_at: string }
+
+const SELECT = `
+  id, event_id, user_id, tmdb_movie, deleted, culled_at, created_at,
+  author:profiles!suggestions_user_id_fkey(display_name, email),
+  votes(user_id, hidden_at, voter:profiles!votes_user_id_fkey(display_name))
+`
+
+/**
+ * The titles culled from an event's ballot — a read-only audit trail so an admin
+ * can confirm what pruning removed (culls are permanent and otherwise vanish from
+ * the dashboard). Realtime so a fresh cut shows up immediately. voteCount is the
+ * live count the title had when it was cut.
+ */
+export function useCulledSuggestions(eventId: MaybeRefOrGetter<string | null | undefined>) {
+  const supabase = useSupabaseClient<Database>()
+
+  const { data: rows, error } = useRealtimeQuery<CulledSuggestion[]>({
+    key: eventId,
+    channel: 'culled-suggestions',
+    tables: [{ table: 'suggestions' }],
+    empty: [],
+    errorFallback: 'Failed to load pruned titles',
+    load: async (id) => {
+      const { data, error } = await supabase
+        .from('suggestions')
+        .select(SELECT)
+        .eq('event_id', id)
+        .not('culled_at', 'is', null)
+      if (error) throw error
+      return ((data ?? []) as unknown as CulledSuggestion[])
+        .map(s => ({ ...s, voteCount: liveVoteCount(s.votes) }))
+    }
+  })
+
+  // Most recently cut first.
+  const culled = computed(() => [...rows.value].sort((a, b) => b.culled_at.localeCompare(a.culled_at)))
+
+  return { culled, error }
+}

--- a/app/composables/useEventStats.ts
+++ b/app/composables/useEventStats.ts
@@ -17,8 +17,9 @@ export function useEventStats(eventId: MaybeRefOrGetter<string | null>) {
         .from('suggestions')
         .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id, hidden_at)')
         .eq('event_id', id)
-        // rsvp-hidden suggestions are off the ballot (admin-deleted still load).
-        .is('rsvp_hidden_at', null),
+        // rsvp-hidden and culled suggestions are off the ballot (admin-deleted still load).
+        .is('rsvp_hidden_at', null)
+        .is('culled_at', null),
       supabase.from('rsvps').select('status').eq('event_id', id),
       supabase.from('bring_items').select('user_id').eq('event_id', id)
     ])

--- a/app/composables/useSuggestions.ts
+++ b/app/composables/useSuggestions.ts
@@ -36,7 +36,9 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
           .eq('event_id', id)
           .eq('deleted', false)
           // Hidden because the author left "going" — off the ballot until they return.
-          .is('rsvp_hidden_at', null),
+          .is('rsvp_hidden_at', null)
+          // Permanently culled (pruned as the event neared) — off the ballot for good.
+          .is('culled_at', null),
         supabase.rpc('suggestion_vote_counts', { p_event_id: id })
       ])
       if (rows.error) throw rows.error

--- a/app/composables/useUserStats.ts
+++ b/app/composables/useUserStats.ts
@@ -37,8 +37,9 @@ export function useUserStats(userId: MaybeRefOrGetter<string | null>) {
       .from('suggestions')
       .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id, hidden_at)')
       .in('event_id', lockedIds)
-      // rsvp-hidden suggestions are off the ballot, so they can't be winners.
+      // rsvp-hidden and culled suggestions are off the ballot, so they can't be winners.
       .is('rsvp_hidden_at', null)
+      .is('culled_at', null)
     // The votes embed isn't declared in the generated types (no FK relationship
     // row), so PostgREST's inferred shape doesn't match — cast as useSuggestions does.
     // Admin drill-down reads every vote (RLS); count only live votes so the winner

--- a/app/composables/useVoteRefunds.ts
+++ b/app/composables/useVoteRefunds.ts
@@ -1,0 +1,31 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Database } from '~/types/database.types'
+
+/**
+ * One-time "you've got a vote back" nudges for an event. When a movie a member
+ * voted for leaves the ballot (culled, or its suggester left "going"), their vote
+ * is refunded — claim_freed_votes returns the freed picks not yet acknowledged and
+ * marks them seen in the same call, so each fires exactly once. Checked on load and
+ * whenever the active event changes; toasts one per freed pick.
+ */
+export function useVoteRefunds(eventId: MaybeRefOrGetter<string | null | undefined>): void {
+  const supabase = useSupabaseClient<Database>()
+  const toast = useToast()
+
+  async function check(id: string): Promise<void> {
+    const { data, error } = await supabase.rpc('claim_freed_votes', { p_event_id: id })
+    if (error || !data?.length) return
+    for (const pick of data) {
+      toast.add({
+        title: 'You’ve got a vote back',
+        description: `“${pick.title ?? 'A pick'}” left the running — spend your vote on another movie.`,
+        icon: 'i-lucide-ticket',
+        color: 'info'
+      })
+    }
+  }
+
+  watch(() => toValue(eventId), (id) => {
+    if (id) void check(id)
+  }, { immediate: true })
+}

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -29,6 +29,8 @@ const eventStatsOpen = ref(false)
 
 const selectedEventId = ref<string>()
 const { suggestions, refresh: refreshSuggestions, setDeleted } = useAdminSuggestions(selectedEventId)
+// Audit trail of titles pruned from the ballot (culls are permanent + otherwise hidden).
+const { culled: culledSuggestions } = useCulledSuggestions(selectedEventId)
 
 // Bring list + headcount for the selected event (admins curate; people claim on the event page).
 const { items: bringItems, addItem: addBringItem, updateItem: updateBringItem, remove: removeBringItem } = useBringList(selectedEventId)
@@ -447,6 +449,8 @@ function onSelectEvent(event: MovieEvent): void {
         <UCard v-else variant="subtle" class="text-center text-muted">
           No suggestions for this event.
         </UCard>
+
+        <CulledList v-if="culledSuggestions.length" :items="culledSuggestions" class="mt-4" />
       </template>
 
       <!-- BRING LIST -->

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -28,7 +28,7 @@ const statsEvent = ref<MovieEvent | null>(null)
 const eventStatsOpen = ref(false)
 
 const selectedEventId = ref<string>()
-const { suggestions, setDeleted } = useAdminSuggestions(selectedEventId)
+const { suggestions, refresh: refreshSuggestions, setDeleted } = useAdminSuggestions(selectedEventId)
 
 // Bring list + headcount for the selected event (admins curate; people claim on the event page).
 const { items: bringItems, addItem: addBringItem, updateItem: updateBringItem, remove: removeBringItem } = useBringList(selectedEventId)
@@ -427,6 +427,13 @@ function onSelectEvent(event: MovieEvent): void {
             />
           </div>
           <WinnersBanner v-if="votingLocked && winners.length" :winners="winners" />
+
+          <!-- Prune the ballot as the night nears (open voting only) -->
+          <BallotPruneControls
+            v-if="!votingLocked && selectedEventId && suggestions.length"
+            :event-id="selectedEventId"
+            @pruned="refreshSuggestions"
+          />
         </div>
 
         <AdminSuggestionDashboard

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -392,6 +392,7 @@ async function onGuests(count: number): Promise<void> {
         <p class="text-sm text-muted">
           You won't be marked as going, so your <strong class="text-default">{{ leaveSummary }}</strong>
           for this movie night will be hidden. RSVP “Going” again and they'll come right back.
+          <span class="block mt-2 text-xs">A top-3 pick within a week of the night stays locked in.</span>
         </p>
       </template>
       <template #footer>

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -27,6 +27,8 @@ const { suggestions, refresh: refreshSuggestions, alreadySuggested, suggest, vot
 const { myStatus, myPlusOnes, counts, setStatus, setGuests } = useRsvp(currentEventId)
 // Who else is looking at this movie night right now (Realtime Presence).
 const { online } = usePresence(currentEventId)
+// One-time "you got a vote back" nudges when a pick I voted for leaves the ballot.
+useVoteRefunds(currentEventId)
 
 const suggestedMovieIds = computed(() => suggestions.value.map(s => s.tmdb_movie.id))
 const maxVotes = computed(() => Math.max(1, ...suggestions.value.map(s => s.voteCount ?? 0)))

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -70,6 +70,8 @@ export interface Database {
     Functions: {
       admin_set_admin: { Args: { target_id: string, value: boolean }, Returns: undefined }
       admin_set_blocked: { Args: { target_id: string, value: boolean }, Returns: undefined }
+      cull_zero_votes: { Args: { p_event_id: string }, Returns: number }
+      cull_to_top: { Args: { p_event_id: string, p_keep: number }, Returns: number }
       is_allowed: { Args: Record<string, never>, Returns: boolean }
       suggestion_vote_counts: { Args: { p_event_id: string }, Returns: { suggestion_id: string, votes: number }[] }
     }

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -65,11 +65,18 @@ export interface Database {
         Update: { id?: string, event_id?: string | null, kind?: string, scope?: string | null, subject?: string | null, recipient_count?: number, sent_by?: string | null, created_at?: string }
         Relationships: []
       }
+      vote_refund_acks: {
+        Row: { user_id: string, suggestion_id: string, created_at: string }
+        Insert: { user_id: string, suggestion_id: string, created_at?: string }
+        Update: { user_id?: string, suggestion_id?: string, created_at?: string }
+        Relationships: []
+      }
     }
     Views: { [_ in never]: never }
     Functions: {
       admin_set_admin: { Args: { target_id: string, value: boolean }, Returns: undefined }
       admin_set_blocked: { Args: { target_id: string, value: boolean }, Returns: undefined }
+      claim_freed_votes: { Args: { p_event_id: string }, Returns: { suggestion_id: string, title: string | null }[] }
       cull_zero_votes: { Args: { p_event_id: string }, Returns: number }
       cull_to_top: { Args: { p_event_id: string, p_keep: number }, Returns: number }
       is_allowed: { Args: Record<string, never>, Returns: boolean }

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -48,9 +48,9 @@ export interface Database {
         Relationships: []
       }
       suggestions: {
-        Row: { id: string, event_id: string, user_id: string, tmdb_movie: TmdbMovie, deleted: boolean, rsvp_hidden_at: string | null, created_at: string }
-        Insert: { id?: string, event_id: string, user_id?: string, tmdb_movie: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, created_at?: string }
-        Update: { id?: string, event_id?: string, user_id?: string, tmdb_movie?: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, created_at?: string }
+        Row: { id: string, event_id: string, user_id: string, tmdb_movie: TmdbMovie, deleted: boolean, rsvp_hidden_at: string | null, culled_at: string | null, created_at: string }
+        Insert: { id?: string, event_id: string, user_id?: string, tmdb_movie: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, culled_at?: string | null, created_at?: string }
+        Update: { id?: string, event_id?: string, user_id?: string, tmdb_movie?: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, culled_at?: string | null, created_at?: string }
         Relationships: []
       }
       votes: {

--- a/supabase/migrations/20260701000000_ballot_pruning.sql
+++ b/supabase/migrations/20260701000000_ballot_pruning.sql
@@ -1,0 +1,134 @@
+-- ============================================================================
+-- Ballot pruning. As an event nears, titles are permanently culled from the
+-- ballot: a zero-vote tail-cull and an admin-driven "advance the round" that keeps
+-- the top-N by votes (lowest-voted cut, ties broken by earliest-suggested).
+--
+-- Culls are PERMANENT — a non-restorable `culled_at`, deliberately distinct from
+-- `rsvp_hidden_at` (un-RSVP, restorable) and `deleted` (admin moderation) so the
+-- three reasons compose. A culled title's votes stop counting toward its voters'
+-- per-event budget (the tally + limit triggers exclude culled), so those votes are
+-- automatically refunded — voters can re-spend them on the survivors.
+--
+-- The cull RPCs are admin-only (SECURITY DEFINER + is_admin guard). They're also
+-- the seam a future scheduled job (pg_cron / Vercel cron) can call to automate the
+-- T-7 zero-vote cull; for now an admin triggers them from the Suggestions tab.
+-- ============================================================================
+
+alter table public.suggestions add column if not exists culled_at timestamptz;
+
+-- ---------- Read paths: a culled title is off the ballot everywhere ----------
+-- Tally counts only live votes on on-ballot suggestions.
+create or replace function public.suggestion_vote_counts(p_event_id uuid)
+  returns table (suggestion_id uuid, votes bigint)
+  language sql security definer stable set search_path = public as $$
+  select v.suggestion_id, count(*)::bigint
+  from public.votes v
+  join public.suggestions s on s.id = v.suggestion_id
+  where s.event_id = p_event_id and s.deleted = false and s.rsvp_hidden_at is null
+    and s.culled_at is null and v.hidden_at is null
+    and public.is_allowed()
+  group by v.suggestion_id
+$$;
+revoke all on function public.suggestion_vote_counts(uuid) from public;
+grant execute on function public.suggestion_vote_counts(uuid) to authenticated;
+
+-- Limits ignore culled rows too: a culled suggestion frees its author's slot, and
+-- a vote on a culled title no longer counts against the voter's budget (the refund).
+create or replace function public.enforce_suggestion_limit() returns trigger
+  language plpgsql security definer set search_path = public as $$
+begin
+  if auth.uid() is not null and (
+    select count(*) from public.suggestions
+    where event_id = new.event_id and user_id = auth.uid()
+      and deleted = false and rsvp_hidden_at is null and culled_at is null
+  ) >= public.suggestion_limit() then
+    raise exception 'Suggestion limit (%) reached for this event', public.suggestion_limit()
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+create or replace function public.enforce_vote_limit() returns trigger
+  language plpgsql security definer set search_path = public as $$
+declare
+  ev uuid;
+begin
+  select event_id into ev from public.suggestions where id = new.suggestion_id;
+  if auth.uid() is not null and (
+    select count(*) from public.votes v
+    join public.suggestions s on s.id = v.suggestion_id
+    where v.user_id = auth.uid() and s.event_id = ev
+      and s.deleted = false and s.rsvp_hidden_at is null and s.culled_at is null
+      and v.hidden_at is null
+  ) >= public.vote_limit() then
+    raise exception 'Vote limit (%) reached for this event', public.vote_limit()
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+-- ---------- Cull RPCs (admin-only) ----------
+-- Both only ever touch on-ballot rows (not already deleted / rsvp-hidden / culled)
+-- and stamp culled_at = now(). Returns the number of titles cut.
+
+-- Zero-vote tail-cull: drop every title with no live votes.
+create function public.cull_zero_votes(p_event_id uuid) returns integer
+  language plpgsql security definer set search_path = public as $$
+declare
+  culled integer;
+begin
+  if not public.is_admin() then
+    raise exception 'only admins may prune the ballot';
+  end if;
+  with on_ballot as (
+    select s.id, count(v.suggestion_id) filter (where v.hidden_at is null) as votes
+    from public.suggestions s
+    left join public.votes v on v.suggestion_id = s.id
+    where s.event_id = p_event_id and s.deleted = false
+      and s.rsvp_hidden_at is null and s.culled_at is null
+    group by s.id
+  )
+  update public.suggestions
+    set culled_at = now()
+    where id in (select id from on_ballot where votes = 0);
+  get diagnostics culled = row_count;
+  return culled;
+end;
+$$;
+revoke all on function public.cull_zero_votes(uuid) from public;
+grant execute on function public.cull_zero_votes(uuid) to authenticated;
+
+-- Runoff: keep the top p_keep by live votes (ties → earliest-suggested), cull the rest.
+create function public.cull_to_top(p_event_id uuid, p_keep integer) returns integer
+  language plpgsql security definer set search_path = public as $$
+declare
+  culled integer;
+begin
+  if not public.is_admin() then
+    raise exception 'only admins may prune the ballot';
+  end if;
+  if p_keep < 0 then
+    raise exception 'keep count must be >= 0';
+  end if;
+  with ranked as (
+    select s.id,
+      row_number() over (
+        order by count(v.suggestion_id) filter (where v.hidden_at is null) desc, s.created_at asc
+      ) as rk
+    from public.suggestions s
+    left join public.votes v on v.suggestion_id = s.id
+    where s.event_id = p_event_id and s.deleted = false
+      and s.rsvp_hidden_at is null and s.culled_at is null
+    group by s.id, s.created_at
+  )
+  update public.suggestions
+    set culled_at = now()
+    where id in (select id from ranked where rk > p_keep);
+  get diagnostics culled = row_count;
+  return culled;
+end;
+$$;
+revoke all on function public.cull_to_top(uuid, integer) from public;
+grant execute on function public.cull_to_top(uuid, integer) to authenticated;

--- a/supabase/migrations/20260702000000_lockin_top_suggestions.sql
+++ b/supabase/migrations/20260702000000_lockin_top_suggestions.sql
@@ -1,0 +1,79 @@
+-- ============================================================================
+-- Home-stretch lock-in. As the event nears, a strong contender shouldn't be
+-- yanked off the ballot just because the person who suggested it can't come.
+--
+-- A suggestion is "locked in" when it's a TOP-3 live-vote-getter (with at least
+-- one vote) AND the event is within a week. A locked-in suggestion is NOT hidden
+-- when its author leaves "going" — only the rest of their suggestions are. (Culling
+-- is admin-driven and intentional, so it's unaffected; this guards the automatic
+-- un-RSVP hide only.)
+-- ============================================================================
+
+-- Is this suggestion locked in (top-3 by live votes, ≥1 vote, event ≤7 days out)?
+-- SECURITY DEFINER so the trigger can rank behind RLS.
+create function public.is_locked_in(sid uuid) returns boolean
+  language sql security definer set search_path = public stable as $$
+  with ranked as (
+    select s.id,
+      count(v.suggestion_id) filter (where v.hidden_at is null) as votes,
+      row_number() over (
+        order by count(v.suggestion_id) filter (where v.hidden_at is null) desc, s.created_at asc
+      ) as rk
+    from public.suggestions s
+    left join public.votes v on v.suggestion_id = s.id
+    where s.deleted = false and s.rsvp_hidden_at is null and s.culled_at is null
+      and s.event_id = (select event_id from public.suggestions where id = sid)
+    group by s.id, s.created_at
+  )
+  select exists (
+    select 1
+    from ranked r
+    join public.suggestions s on s.id = r.id
+    join public.events e on e.id = s.event_id
+    where r.id = sid and r.rk <= 3 and r.votes > 0
+      and e.event_date <= now() + interval '7 days'
+  );
+$$;
+revoke all on function public.is_locked_in(uuid) from public;
+grant execute on function public.is_locked_in(uuid) to authenticated;
+
+-- Recreate the hide/restore trigger so the hide branch skips locked-in suggestions.
+create or replace function public.sync_rsvp_visibility() returns trigger
+  language plpgsql security definer set search_path = '' as $$
+declare
+  uid   uuid;
+  eid   uuid;
+  going boolean;
+begin
+  if tg_op = 'DELETE' then
+    uid := old.user_id; eid := old.event_id; going := false;
+  else
+    uid := new.user_id; eid := new.event_id; going := (new.status = 'going');
+  end if;
+
+  if going then
+    -- Restore: un-hide this user's suggestions + votes for the event.
+    update public.suggestions
+      set rsvp_hidden_at = null
+      where user_id = uid and event_id = eid and rsvp_hidden_at is not null;
+    update public.votes v
+      set hidden_at = null
+      from public.suggestions s
+      where v.suggestion_id = s.id and s.event_id = eid
+        and v.user_id = uid and v.hidden_at is not null;
+  else
+    -- Hide this user's suggestions, EXCEPT any locked in for the home stretch.
+    update public.suggestions
+      set rsvp_hidden_at = now()
+      where user_id = uid and event_id = eid and rsvp_hidden_at is null
+        and not public.is_locked_in(id);
+    update public.votes v
+      set hidden_at = now()
+      from public.suggestions s
+      where v.suggestion_id = s.id and s.event_id = eid
+        and v.user_id = uid and v.hidden_at is null;
+  end if;
+
+  return null;
+end;
+$$;

--- a/supabase/migrations/20260703000000_vote_refund_notices.sql
+++ b/supabase/migrations/20260703000000_vote_refund_notices.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- "You've got a vote back" notices. When a movie a member voted for leaves the
+-- ballot — culled (pruning) or rsvp-hidden (its suggester left "going") — that
+-- member's vote is refunded: it stops counting toward their budget so they can
+-- re-spend it. Tell them, once.
+--
+-- claim_freed_votes returns the member's freed-but-unacknowledged picks for an
+-- event AND records the acknowledgment in the same call, so the nudge never nags
+-- again. Derived from current state (not stored events), so if an rsvp-hidden pick
+-- is later restored before the member ever sees it, no stale notice fires.
+-- ============================================================================
+
+create table public.vote_refund_acks (
+  user_id       uuid not null references public.profiles (id) on delete cascade,
+  suggestion_id uuid not null references public.suggestions (id) on delete cascade,
+  created_at    timestamptz not null default now(),
+  primary key (user_id, suggestion_id)
+);
+-- RLS on with no policies: only the SECURITY DEFINER RPC below ever touches this.
+alter table public.vote_refund_acks enable row level security;
+
+create function public.claim_freed_votes(p_event_id uuid)
+  returns table (suggestion_id uuid, title text)
+  language sql security definer set search_path = public volatile as $$
+  with freed as (
+    select v.suggestion_id, s.tmdb_movie ->> 'title' as title
+    from public.votes v
+    join public.suggestions s on s.id = v.suggestion_id
+    join public.events e on e.id = s.event_id
+    where s.event_id = p_event_id
+      and v.user_id = auth.uid()
+      and v.hidden_at is null                                       -- my vote is still live
+      and (s.culled_at is not null or s.rsvp_hidden_at is not null) -- but the pick left the ballot
+      and e.voting_locked_at is null                               -- and I can still re-spend
+      and not exists (
+        select 1 from public.vote_refund_acks a
+        where a.user_id = auth.uid() and a.suggestion_id = v.suggestion_id
+      )
+  ),
+  ack as (
+    insert into public.vote_refund_acks (user_id, suggestion_id)
+    select auth.uid(), suggestion_id from freed
+    on conflict do nothing
+  )
+  select suggestion_id, title from freed;
+$$;
+revoke all on function public.claim_freed_votes(uuid) from public;
+grant execute on function public.claim_freed_votes(uuid) to authenticated;

--- a/test/BallotPruneControls.nuxt.test.ts
+++ b/test/BallotPruneControls.nuxt.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment nuxt
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import BallotPruneControls from '../app/components/BallotPruneControls.vue'
+
+const cullZeroVotes = vi.fn(async () => 2)
+const cullToTop = vi.fn(async () => 3)
+mockNuxtImport('useBallotPruning', () => () => ({ cullZeroVotes, cullToTop }))
+mockNuxtImport('useToast', () => () => ({ add: () => {} }))
+
+afterEach(() => {
+  cullZeroVotes.mockClear()
+  cullToTop.mockClear()
+  // Teleported modals persist across mounts — clear any leftover dialog buttons.
+  document.body.querySelectorAll('[role="dialog"]').forEach(el => el.remove())
+})
+
+const bodyButton = (label: string): HTMLElement | undefined =>
+  [...document.body.querySelectorAll('button')].find(b => b.textContent?.includes(label))
+
+describe('BallotPruneControls', () => {
+  it('cuts zero-vote titles only after the cut is confirmed', async () => {
+    const w = await mountSuspended(BallotPruneControls, { props: { eventId: 'e1' } })
+    await w.findAll('button').find(b => b.text().includes('Cut zero-vote titles'))?.trigger('click')
+    await nextTick()
+    // Nothing happens until the confirm.
+    expect(cullZeroVotes).not.toHaveBeenCalled()
+    bodyButton('Cut titles')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+    expect(cullZeroVotes).toHaveBeenCalled()
+    expect(w.emitted('pruned')?.[0]).toEqual([2])
+  })
+
+  it('cuts to the top-N keep count (default 8) on confirm', async () => {
+    const w = await mountSuspended(BallotPruneControls, { props: { eventId: 'e1' } })
+    await w.findAll('button').find(b => b.text().trim() === 'Cut')?.trigger('click')
+    await nextTick()
+    bodyButton('Cut titles')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+    expect(cullToTop).toHaveBeenCalledWith(8)
+    expect(w.emitted('pruned')?.[0]).toEqual([3])
+  })
+
+  it('does not cut when the confirm is cancelled', async () => {
+    const w = await mountSuspended(BallotPruneControls, { props: { eventId: 'e1' } })
+    await w.findAll('button').find(b => b.text().includes('Cut zero-vote titles'))?.trigger('click')
+    await nextTick()
+    bodyButton('Cancel')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+    expect(cullZeroVotes).not.toHaveBeenCalled()
+  })
+})

--- a/test/CulledList.nuxt.test.ts
+++ b/test/CulledList.nuxt.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment nuxt
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import CulledList from '../app/components/CulledList.vue'
+import type { CulledSuggestion } from '../app/composables/useCulledSuggestions'
+
+const item = (id: string, title: string, votes: number, culledAt: string): CulledSuggestion => ({
+  id,
+  event_id: 'e1',
+  user_id: 'u',
+  tmdb_movie: { id: 1, title },
+  deleted: false,
+  culled_at: culledAt,
+  created_at: '2026-01-01T00:00:00Z',
+  voteCount: votes,
+  votes: [],
+  author: null
+})
+
+describe('CulledList', () => {
+  it('shows the pruned count and stays collapsed by default', async () => {
+    const w = await mountSuspended(CulledList, { props: { items: [item('s1', 'Heat', 2, '2026-06-20T00:00:00Z')] } })
+    expect(w.text()).toContain('Pruned (1)')
+    expect(w.text()).not.toContain('Heat')
+  })
+
+  it('reveals the cut titles and their vote count when expanded', async () => {
+    const w = await mountSuspended(CulledList, { props: { items: [item('s1', 'Heat', 2, '2026-06-20T00:00:00Z')] } })
+    await w.get('button').trigger('click')
+    expect(w.text()).toContain('Heat')
+    expect(w.text()).toContain('2 votes')
+  })
+})

--- a/test/overview.nuxt.test.ts
+++ b/test/overview.nuxt.test.ts
@@ -53,6 +53,7 @@ mockNuxtImport('useAppSettings', () => () => ({
   maxVotes: cfgMaxVotes
 }))
 mockNuxtImport('usePresence', () => () => ({ online: ref([]) }))
+mockNuxtImport('useVoteRefunds', () => () => {})
 
 // Heavy children pull in their own composables/network — stub them; this page
 // test only cares about the header + the admin-gated selector.

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -371,4 +371,62 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('votes').delete().eq('user_id', memberId).in('suggestion_id', ids)
     await admin!.from('suggestions').delete().in('id', ids)
   })
+
+  it('locks in a top-3 voted suggestion within a week so an un-RSVP can’t hide it', async () => {
+    // Event 3 days out — inside the lock-in window.
+    const { data: ev } = await admin!
+      .from('events').insert({ title: 'Soon', event_date: new Date(stamp + 3 * 86_400_000).toISOString() })
+      .select('id').single()
+    const soonId = ev!.id
+
+    const email = `rls_lockin_${stamp}@example.com`
+    const uid = await makeUser(email)
+    await admin!.from('invites').insert({ email })
+    const client = await signInAs(email)
+    await client.from('rsvps').insert({ event_id: soonId, user_id: uid, status: 'going' })
+    const { data: a } = await client.from('suggestions').insert({ event_id: soonId, tmdb_movie: { id: 950, title: 'Contender' } }).select('id').single()
+    const { data: b } = await client.from('suggestions').insert({ event_id: soonId, tmdb_movie: { id: 951, title: 'Longshot' } }).select('id').single()
+    // Contender has a vote (top-3, >0); Longshot has none.
+    await admin!.from('votes').insert({ suggestion_id: a!.id, user_id: memberId })
+
+    // Author bails.
+    await client.from('rsvps').update({ status: 'no' }).eq('event_id', soonId).eq('user_id', uid)
+
+    const aRow = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', a!.id).single()
+    const bRow = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', b!.id).single()
+    expect(aRow.data!.rsvp_hidden_at, 'a top-3 voted title within a week stays on the ballot').toBeNull()
+    expect(bRow.data!.rsvp_hidden_at, 'a zero-vote title is still hidden on un-RSVP').not.toBeNull()
+
+    await admin!.from('votes').delete().in('suggestion_id', [a!.id, b!.id])
+    await admin!.from('suggestions').delete().in('id', [a!.id, b!.id])
+    await admin!.from('rsvps').delete().eq('user_id', uid)
+    await admin!.from('invites').delete().eq('email', email)
+    await admin!.from('events').delete().eq('id', soonId)
+  })
+
+  it('does not lock in a voted suggestion when the event is more than a week out', async () => {
+    const { data: ev } = await admin!
+      .from('events').insert({ title: 'Later', event_date: new Date(stamp + 30 * 86_400_000).toISOString() })
+      .select('id').single()
+    const farId = ev!.id
+
+    const email = `rls_nolock_${stamp}@example.com`
+    const uid = await makeUser(email)
+    await admin!.from('invites').insert({ email })
+    const client = await signInAs(email)
+    await client.from('rsvps').insert({ event_id: farId, user_id: uid, status: 'going' })
+    const { data: a } = await client.from('suggestions').insert({ event_id: farId, tmdb_movie: { id: 960, title: 'Early Bird' } }).select('id').single()
+    await admin!.from('votes').insert({ suggestion_id: a!.id, user_id: memberId })
+
+    await client.from('rsvps').update({ status: 'no' }).eq('event_id', farId).eq('user_id', uid)
+
+    const aRow = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', a!.id).single()
+    expect(aRow.data!.rsvp_hidden_at, 'a top title >1 week out is still hidden on un-RSVP').not.toBeNull()
+
+    await admin!.from('votes').delete().eq('suggestion_id', a!.id)
+    await admin!.from('suggestions').delete().eq('id', a!.id)
+    await admin!.from('rsvps').delete().eq('user_id', uid)
+    await admin!.from('invites').delete().eq('email', email)
+    await admin!.from('events').delete().eq('id', farId)
+  })
 })

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -429,4 +429,28 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('invites').delete().eq('email', email)
     await admin!.from('events').delete().eq('id', farId)
   })
+
+  it('claim_freed_votes notifies a voter once when their pick leaves the ballot', async () => {
+    await memberClient.from('rsvps').upsert({ event_id: eventId, user_id: memberId, status: 'going' }, { onConflict: 'event_id,user_id' })
+    const { data: s } = await admin!
+      .from('suggestions').insert({ event_id: eventId, user_id: adminUserId, tmdb_movie: { id: 970, title: 'Refunded' } })
+      .select('id').single()
+    await memberClient.from('votes').insert({ suggestion_id: s!.id })
+
+    // On the ballot → nothing to refund.
+    const before = await memberClient.rpc('claim_freed_votes', { p_event_id: eventId })
+    expect((before.data ?? []).find(r => r.suggestion_id === s!.id), 'no refund while on the ballot').toBeFalsy()
+
+    // Cull it → the member's vote is freed.
+    await admin!.from('suggestions').update({ culled_at: new Date().toISOString() }).eq('id', s!.id)
+
+    const first = await memberClient.rpc('claim_freed_votes', { p_event_id: eventId })
+    expect((first.data ?? []).find(r => r.suggestion_id === s!.id)?.title, 'the freed pick is reported once').toBe('Refunded')
+    const second = await memberClient.rpc('claim_freed_votes', { p_event_id: eventId })
+    expect((second.data ?? []).find(r => r.suggestion_id === s!.id), 'and never again').toBeFalsy()
+
+    await admin!.from('vote_refund_acks').delete().eq('user_id', memberId)
+    await admin!.from('votes').delete().eq('user_id', memberId).eq('suggestion_id', s!.id)
+    await admin!.from('suggestions').delete().eq('id', s!.id)
+  })
 })

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -51,12 +51,14 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
   const outsiderEmail = `rls_outsider_${stamp}@example.com`
 
   let memberId = ''
+  let adminUserId = ''
   let memberClient: SupabaseClient
   let outsiderClient: SupabaseClient
   let eventId = ''
 
   beforeAll(async () => {
     const adminId = await makeUser(adminEmail)
+    adminUserId = adminId
     memberId = await makeUser(memberEmail)
     await makeUser(outsiderEmail)
 
@@ -292,5 +294,81 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('suggestions').delete().in('id', [aId, bId])
     await admin!.from('rsvps').delete().eq('user_id', uid)
     await admin!.from('invites').delete().eq('email', email)
+  })
+
+  it('cull RPCs cut the right titles (zero-vote + keep-top-N) and are admin-only', async () => {
+    const adminClient = await signInAs(adminEmail)
+    const mk = async (movieId: number, title: string): Promise<string> => {
+      const { data } = await admin!
+        .from('suggestions').insert({ event_id: eventId, user_id: memberId, tmdb_movie: { id: movieId, title } })
+        .select('id').single()
+      return data!.id
+    }
+    const top = await mk(900, 'Top')
+    const mid = await mk(901, 'Mid')
+    const zero = await mk(902, 'Zero')
+    // Seed votes via the service role (exempt from the gate/cap): top=2, mid=1, zero=0.
+    await admin!.from('votes').insert([
+      { suggestion_id: top, user_id: memberId },
+      { suggestion_id: top, user_id: adminUserId },
+      { suggestion_id: mid, user_id: memberId }
+    ])
+
+    // A non-admin cannot prune.
+    const denied = await memberClient.rpc('cull_zero_votes', { p_event_id: eventId })
+    expect(denied.error, 'a non-admin must not be able to prune').toBeTruthy()
+
+    // Zero-vote tail-cull removes 'zero' only.
+    const z = await adminClient.rpc('cull_zero_votes', { p_event_id: eventId })
+    expect(z.error).toBeNull()
+    expect(z.data, 'one zero-vote title cut').toBe(1)
+    const zeroRow = await admin!.from('suggestions').select('culled_at').eq('id', zero).single()
+    expect(zeroRow.data!.culled_at, 'zero is culled').not.toBeNull()
+
+    // Keep-top-1 runoff cuts 'mid', keeps 'top'.
+    const r = await adminClient.rpc('cull_to_top', { p_event_id: eventId, p_keep: 1 })
+    expect(r.error).toBeNull()
+    expect(r.data, 'one runner-up cut').toBe(1)
+    const midRow = await admin!.from('suggestions').select('culled_at').eq('id', mid).single()
+    expect(midRow.data!.culled_at, 'mid is culled').not.toBeNull()
+    const topRow = await admin!.from('suggestions').select('culled_at').eq('id', top).single()
+    expect(topRow.data!.culled_at, 'top survives').toBeNull()
+
+    // The tally now reports only the survivor.
+    const tally = await memberClient.rpc('suggestion_vote_counts', { p_event_id: eventId })
+    expect((tally.data ?? []).map(t => t.suggestion_id), 'only the survivor is counted').toEqual([top])
+
+    await admin!.from('votes').delete().in('suggestion_id', [top, mid, zero])
+    await admin!.from('suggestions').delete().in('id', [top, mid, zero])
+  })
+
+  it('refunds a culled title’s vote back to the voter’s budget', async () => {
+    await memberClient.from('rsvps').upsert({ event_id: eventId, user_id: memberId, status: 'going' }, { onConflict: 'event_id,user_id' })
+    const mk = async (movieId: number, title: string): Promise<string> => {
+      const { data } = await admin!
+        .from('suggestions').insert({ event_id: eventId, user_id: memberId, tmdb_movie: { id: movieId, title } })
+        .select('id').single()
+      return data!.id
+    }
+    const ids = [await mk(910, 'A'), await mk(911, 'B'), await mk(912, 'C'), await mk(913, 'D')]
+
+    // Member spends the full 3-vote budget on A, B, C.
+    for (const id of ids.slice(0, 3)) {
+      const { error } = await memberClient.from('votes').insert({ suggestion_id: id })
+      expect(error, 'votes within the cap are allowed').toBeNull()
+    }
+    // At the cap, a 4th vote (D) is rejected.
+    const capped = await memberClient.from('votes').insert({ suggestion_id: ids[3] })
+    expect(capped.error, 'the 4th vote is over the cap').toBeTruthy()
+
+    // Cull C → the member's vote on it no longer counts toward their budget.
+    await admin!.from('suggestions').update({ culled_at: new Date().toISOString() }).eq('id', ids[2])
+
+    // The refunded slot lets the member vote on the surviving D.
+    const refunded = await memberClient.from('votes').insert({ suggestion_id: ids[3] })
+    expect(refunded.error, 'the freed slot lets the member vote again').toBeNull()
+
+    await admin!.from('votes').delete().eq('user_id', memberId).in('suggestion_id', ids)
+    await admin!.from('suggestions').delete().in('id', ids)
   })
 })

--- a/test/useBallotPruning.nuxt.test.ts
+++ b/test/useBallotPruning.nuxt.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+const rpc = vi.fn<(fn: string, args: Record<string, unknown>) => Promise<{ data: number | null, error: { message: string } | null }>>(
+  () => Promise.resolve({ data: 0, error: null })
+)
+const supabase = { rpc }
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+beforeEach(() => {
+  rpc.mockClear()
+  rpc.mockResolvedValue({ data: 0, error: null })
+})
+
+describe('useBallotPruning', () => {
+  it('cullZeroVotes calls the cull_zero_votes RPC with the event id', async () => {
+    rpc.mockResolvedValueOnce({ data: 3, error: null })
+    const { cullZeroVotes } = useBallotPruning(ref('e1'))
+    const cut = await cullZeroVotes()
+    expect(rpc).toHaveBeenCalledWith('cull_zero_votes', { p_event_id: 'e1' })
+    expect(cut).toBe(3)
+  })
+
+  it('cullToTop passes the keep count through', async () => {
+    rpc.mockResolvedValueOnce({ data: 5, error: null })
+    const { cullToTop } = useBallotPruning(ref('e1'))
+    const cut = await cullToTop(8)
+    expect(rpc).toHaveBeenCalledWith('cull_to_top', { p_event_id: 'e1', p_keep: 8 })
+    expect(cut).toBe(5)
+  })
+
+  it('is a no-op (no RPC) when there is no event id', async () => {
+    const { cullZeroVotes } = useBallotPruning(ref(null))
+    expect(await cullZeroVotes()).toBe(0)
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('throws when the RPC errors', async () => {
+    rpc.mockResolvedValueOnce({ data: null, error: { message: 'only admins may prune the ballot' } })
+    const { cullToTop } = useBallotPruning(ref('e1'))
+    await expect(cullToTop(4)).rejects.toMatchObject({ message: 'only admins may prune the ballot' })
+  })
+})

--- a/test/useVoteRefunds.nuxt.test.ts
+++ b/test/useVoteRefunds.nuxt.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+const rpc = vi.fn<(fn: string, args: Record<string, unknown>) => Promise<{ data: { suggestion_id: string, title: string | null }[] | null, error: unknown }>>(
+  () => Promise.resolve({ data: [], error: null })
+)
+const add = vi.fn()
+mockNuxtImport('useSupabaseClient', () => () => ({ rpc }))
+mockNuxtImport('useToast', () => () => ({ add }))
+
+beforeEach(() => {
+  rpc.mockClear()
+  add.mockClear()
+  rpc.mockResolvedValue({ data: [], error: null })
+})
+
+describe('useVoteRefunds', () => {
+  it('toasts once per freed pick on load', async () => {
+    rpc.mockResolvedValueOnce({
+      data: [{ suggestion_id: 's1', title: 'Heat' }, { suggestion_id: 's2', title: 'Jaws' }],
+      error: null
+    })
+    useVoteRefunds(ref('e1'))
+    await flushPromises()
+    expect(rpc).toHaveBeenCalledWith('claim_freed_votes', { p_event_id: 'e1' })
+    expect(add).toHaveBeenCalledTimes(2)
+    expect(add.mock.calls[0]![0]).toMatchObject({ description: expect.stringContaining('Heat') })
+  })
+
+  it('does nothing when there are no freed votes', async () => {
+    useVoteRefunds(ref('e1'))
+    await flushPromises()
+    expect(add).not.toHaveBeenCalled()
+  })
+
+  it('does not call the RPC without an event id', async () => {
+    useVoteRefunds(ref(null))
+    await flushPromises()
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('stays quiet when the RPC errors', async () => {
+    rpc.mockResolvedValueOnce({ data: null, error: { message: 'nope' } })
+    useVoteRefunds(ref('e1'))
+    await flushPromises()
+    expect(add).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Scope

Third RSVP-participation PR (follows #127, #130). Lets an admin **prune the ballot** as a
movie night nears so an impossibly-long lineup narrows toward the double feature:

- **Zero-vote tail-cull** — cut every title that still has no votes.
- **Keep-top-N runoff** — keep the top N by votes (ties → earliest-suggested), cut the rest.
- **Vote refund** — a cut title's votes stop counting against their voters' budgets, so
  voters get those votes back to spend on the survivors. Falls out automatically.
- **Permanent** — a non-restorable `culled_at`, distinct from `rsvp_hidden_at` (un-RSVP,
  restorable) and `deleted` (moderation), so the three reasons compose.

**Manual-first** (as discussed): an admin triggers cuts from the Suggestions tab. The cull
RPCs are written as the seam a later scheduled job (pg_cron / Vercel cron) can call to
automate the T-7 zero-vote cull — I'd do that as a small follow-up rather than pull cron
infra into this PR. Shout if you'd rather automate now.

## Implementation

Five focused commits:

1. **`feat(db)` migration** — `suggestions.culled_at` + two admin-only SECURITY DEFINER RPCs
   (`cull_zero_votes`, `cull_to_top(keep)`). The tally and **both participation-limit
   triggers** now exclude culled rows, so a culled title is off the ballot and its votes no
   longer count against budgets — the refund, for free. `cull_to_top` ranks by live votes
   desc, `created_at` asc and cuts everything past rank N.
2. **`test(rls)`** — cull RPCs cut the right titles, reject non-admins, survivor stays in the
   tally, and a capped voter can vote again once their pick is cut.
3. **Read paths** — `.is('culled_at', null)` added to the overview, admin, event-stats, and
   user-stats reads (alongside `deleted`/`rsvp_hidden_at`), plus the `culled_at` type column
   and a `refresh()` on `useAdminSuggestions`.
4. **`useBallotPruning`** — thin wrapper over the two RPCs (+ their generated types).
5. **`BallotPruneControls`** — new component in the admin Suggestions tab (open voting only):
   "Cut zero-vote titles" and "keep top N", each behind a permanent-cut confirmation.
   Extracted into its own component so it's unit-tested in isolation.

## Screenshots

New surface is the admin **Suggestions** tab, between the voting controls and the dashboard:
a "Prune the ballot" card with the two cut actions + a confirm dialog.

|         | admin Suggestions tab (new)               |
| ------- | ----------------------------------------- |
| desktop | "Prune the ballot" card + confirm modal   |
| mobile  | same, stacked                             |

_(Static screenshots to follow before merge.)_

## How to Test

**Automated**
- Integration (`test/rls.integration.test.ts`, Supabase-local): cull RPCs + admin-only + refund.
- Unit: `useBallotPruning` (RPC wiring, no-op without id, error propagation);
  `BallotPruneControls` (confirm-gated cut, default keep-8, cancel does nothing).
- `npm run typecheck`, `npm run lint` (0 errors), `npx vitest run` (393 passing) green.

**Manual**
1. Admin → Suggestions tab on an event with open voting and a few titles (some with 0 votes).
2. **Cut zero-vote titles** → confirm → the no-vote titles vanish from the ballot for everyone.
3. **keep top 2 → Cut** → confirm → only the top 2 survive; anyone who voted for a cut title
   gets that vote back (their budget frees up).

## Invariants & Risk

- **Authorization / Invariant 1:** culling is admin-only — `is_admin()` guard inside SECURITY
  DEFINER RPCs; the admin button is just UX.
- **Vote integrity / Invariant 3:** still no stored counter; culls just add `culled_at` to the
  tally + limit exclusions. The dedup unique index is unchanged, so a culled movie's title slot
  stays reserved (it can't be re-suggested).
- Culls are **permanent** by design (no un-cull path). **Migration must reach prod.** Members
  see culls live via the suggestions realtime stream.