### PR TITLE
feat: personal take + TMDB synopsis on suggestion cards

### DIFF
--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -150,13 +150,15 @@ function onHeartClick(e: MouseEvent): void {
 
         <!-- What it's about (TMDB synopsis) — for anyone who'd rather not watch the trailer. -->
         <p
+        <button
           v-if="movie.overview"
-          class="text-xs text-muted mt-2 cursor-pointer"
+          type="button"
+          class="text-xs text-muted mt-2 text-left w-full cursor-pointer"
           :class="overviewOpen ? '' : 'line-clamp-2'"
           @click="overviewOpen = !overviewOpen"
         >
           {{ movie.overview }}
-        </p>
+        </button>
 
         <!-- The suggester's personal take. -->
         <div v-if="editingBlurb" class="mt-2 space-y-1">

--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -178,7 +178,7 @@ function onHeartClick(e: MouseEvent): void {
         <template v-else>
           <blockquote v-if="suggestion.blurb" class="mt-2 text-xs italic text-muted border-l-2 border-primary/40 pl-2">
             “{{ suggestion.blurb }}”
-            <button v-if="isOwner && !locked" type="button" class="not-italic text-primary ml-1" @click="startBlurb">
+            <UButton v-if="isOwner && !locked" label="edit" color="primary" variant="link" size="xs" class="not-italic ml-1 p-0" @click="startBlurb" />
               edit
             </button>
           </blockquote>

--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -8,11 +8,27 @@ const props = withDefaults(
   defineProps<{ suggestion: Suggestion, rank: number, maxVotes: number, locked?: boolean, voteCapReached?: boolean, canVote?: boolean }>(),
   { canVote: true }
 )
-const emit = defineEmits<{ vote: [], unvote: [], remove: [], trailer: [] }>()
+const emit = defineEmits<{ vote: [], unvote: [], remove: [], trailer: [], blurb: [text: string] }>()
 
 const { myId } = useAuth()
 
 const movie = computed(() => props.suggestion.tmdb_movie)
+
+// "What it's about" (TMDB synopsis) — clamped, click to expand.
+const overviewOpen = ref(false)
+
+// The suggester's personal take — owner can add/edit; saving emits the new text
+// (empty clears it). Parent persists via the author-only RPC.
+const editingBlurb = ref(false)
+const blurbDraft = ref('')
+function startBlurb(): void {
+  blurbDraft.value = props.suggestion.blurb ?? ''
+  editingBlurb.value = true
+}
+function saveBlurb(): void {
+  emit('blurb', blurbDraft.value.trim())
+  editingBlurb.value = false
+}
 const year = computed(() => movieYear(movie.value))
 // Public count from the tally (votes.length would only see the viewer's own vote).
 const voteCount = computed(() => props.suggestion.voteCount ?? 0)
@@ -66,7 +82,7 @@ function onHeartClick(e: MouseEvent): void {
 
 <template>
   <UCard variant="subtle" :class="highlight ? 'ring-2 ring-primary/40' : ''" :ui="{ body: 'sm:p-4 p-3' }">
-    <div class="flex items-center gap-3">
+    <div class="flex items-start gap-3">
       <!-- rank -->
       <div class="shrink-0 flex items-center justify-center size-7 rounded-full font-bold text-sm" :class="rankClass">
         {{ rank }}
@@ -131,6 +147,50 @@ function onHeartClick(e: MouseEvent): void {
             @click="emit('remove')"
           />
         </div>
+
+        <!-- What it's about (TMDB synopsis) — for anyone who'd rather not watch the trailer. -->
+        <p
+          v-if="movie.overview"
+          class="text-xs text-muted mt-2 cursor-pointer"
+          :class="overviewOpen ? '' : 'line-clamp-2'"
+          @click="overviewOpen = !overviewOpen"
+        >
+          {{ movie.overview }}
+        </p>
+
+        <!-- The suggester's personal take. -->
+        <div v-if="editingBlurb" class="mt-2 space-y-1">
+          <UTextarea
+            v-model="blurbDraft"
+            :rows="2"
+            :maxlength="500"
+            autoresize
+            placeholder="Why should we screen this? (optional)"
+            class="w-full"
+          />
+          <div class="flex items-center gap-1">
+            <UButton label="Save" icon="i-lucide-check" size="xs" @click="saveBlurb" />
+            <UButton label="Cancel" color="neutral" variant="ghost" size="xs" @click="editingBlurb = false" />
+          </div>
+        </div>
+        <template v-else>
+          <blockquote v-if="suggestion.blurb" class="mt-2 text-xs italic text-muted border-l-2 border-primary/40 pl-2">
+            “{{ suggestion.blurb }}”
+            <button v-if="isOwner && !locked" type="button" class="not-italic text-primary ml-1" @click="startBlurb">
+              edit
+            </button>
+          </blockquote>
+          <UButton
+            v-else-if="isOwner && !locked"
+            label="Add your take"
+            icon="i-lucide-message-square-plus"
+            color="neutral"
+            variant="ghost"
+            size="xs"
+            class="mt-1"
+            @click="startBlurb"
+          />
+        </template>
       </div>
     </div>
   </UCard>

--- a/app/composables/useSuggestions.ts
+++ b/app/composables/useSuggestions.ts
@@ -32,7 +32,7 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
       const [rows, counts] = await Promise.all([
         supabase
           .from('suggestions')
-          .select('id, event_id, user_id, tmdb_movie, deleted, created_at, votes(user_id, hidden_at)')
+          .select('id, event_id, user_id, tmdb_movie, deleted, blurb, created_at, votes(user_id, hidden_at)')
           .eq('event_id', id)
           .eq('deleted', false)
           // Hidden because the author left "going" — off the ballot until they return.
@@ -120,5 +120,13 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
     await refresh()
   }
 
-  return { suggestions, error, refresh, alreadySuggested, suggest, vote, unvote, removeSuggestion }
+  // Set/clear the author's personal blurb (RLS has no author-update path, so this
+  // goes through the author-only RPC). An empty string clears it.
+  async function setBlurb(suggestion: Suggestion, blurb: string): Promise<void> {
+    const { error } = await supabase.rpc('set_suggestion_blurb', { p_suggestion_id: suggestion.id, p_blurb: blurb })
+    if (error) throw error
+    await refresh()
+  }
+
+  return { suggestions, error, refresh, alreadySuggested, suggest, vote, unvote, removeSuggestion, setBlurb }
 }

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -23,7 +23,7 @@ const trailerMovie = ref<TmdbMovie | null>(null)
 const currentEvent = computed(() => events.value[eventIndex.value] ?? null)
 const currentEventId = computed(() => currentEvent.value?.id ?? null)
 
-const { suggestions, refresh: refreshSuggestions, alreadySuggested, suggest, vote, unvote, removeSuggestion } = useSuggestions(currentEventId)
+const { suggestions, refresh: refreshSuggestions, alreadySuggested, suggest, vote, unvote, removeSuggestion, setBlurb } = useSuggestions(currentEventId)
 const { myStatus, myPlusOnes, counts, setStatus, setGuests } = useRsvp(currentEventId)
 // Who else is looking at this movie night right now (Realtime Presence).
 const { online } = usePresence(currentEventId)
@@ -137,6 +137,11 @@ async function onUnvote(suggestion: Suggestion): Promise<void> {
 async function onRemove(suggestion: Suggestion): Promise<void> {
   if (await run(() => removeSuggestion(suggestion), 'Could not remove suggestion')) {
     toast.add({ title: 'Suggestion removed', color: 'neutral' })
+  }
+}
+async function onBlurb(suggestion: Suggestion, text: string): Promise<void> {
+  if (await run(() => setBlurb(suggestion, text), 'Could not save your take')) {
+    toast.add({ title: text ? 'Your take was saved' : 'Your take was removed', icon: 'i-lucide-check', color: 'success' })
   }
 }
 async function applyRsvp(status: RsvpStatus): Promise<void> {
@@ -348,6 +353,7 @@ async function onGuests(count: number): Promise<void> {
               @unvote="onUnvote(suggestion)"
               @remove="onRemove(suggestion)"
               @trailer="openTrailer(suggestion)"
+              @blurb="onBlurb(suggestion, $event)"
             />
           </TransitionGroup>
           <UCard v-else variant="subtle" class="text-center py-10">

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -48,9 +48,9 @@ export interface Database {
         Relationships: []
       }
       suggestions: {
-        Row: { id: string, event_id: string, user_id: string, tmdb_movie: TmdbMovie, deleted: boolean, rsvp_hidden_at: string | null, culled_at: string | null, created_at: string }
-        Insert: { id?: string, event_id: string, user_id?: string, tmdb_movie: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, culled_at?: string | null, created_at?: string }
-        Update: { id?: string, event_id?: string, user_id?: string, tmdb_movie?: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, culled_at?: string | null, created_at?: string }
+        Row: { id: string, event_id: string, user_id: string, tmdb_movie: TmdbMovie, deleted: boolean, rsvp_hidden_at: string | null, culled_at: string | null, blurb: string | null, created_at: string }
+        Insert: { id?: string, event_id: string, user_id?: string, tmdb_movie: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, culled_at?: string | null, blurb?: string | null, created_at?: string }
+        Update: { id?: string, event_id?: string, user_id?: string, tmdb_movie?: TmdbMovie, deleted?: boolean, rsvp_hidden_at?: string | null, culled_at?: string | null, blurb?: string | null, created_at?: string }
         Relationships: []
       }
       votes: {
@@ -80,6 +80,7 @@ export interface Database {
       cull_zero_votes: { Args: { p_event_id: string }, Returns: number }
       cull_to_top: { Args: { p_event_id: string, p_keep: number }, Returns: number }
       is_allowed: { Args: Record<string, never>, Returns: boolean }
+      set_suggestion_blurb: { Args: { p_suggestion_id: string, p_blurb: string }, Returns: undefined }
       suggestion_vote_counts: { Args: { p_event_id: string }, Returns: { suggestion_id: string, votes: number }[] }
     }
     Enums: { [_ in never]: never }

--- a/shared/types/suggestion.ts
+++ b/shared/types/suggestion.ts
@@ -18,6 +18,9 @@ export interface Suggestion {
   tmdb_movie: TmdbMovie
   deleted: boolean
   created_at: string
+  // The suggester's personal note on why they picked it. Optional — only the
+  // reads that display it (overview) select it.
+  blurb?: string | null
   voteCount: number
   // `hidden_at` is present on admin/stats reads (to drop soft-deleted votes from
   // counts); the overview read strips it, so it's optional.

--- a/supabase/migrations/20260704000000_suggestion_blurb.sql
+++ b/supabase/migrations/20260704000000_suggestion_blurb.sql
@@ -1,0 +1,37 @@
+-- ============================================================================
+-- Personal blurb on a suggestion: a short note from the suggester about why the
+-- group should screen it / why they love it. Optional and editable by the author.
+-- Existing suggestions get it for free (nullable column).
+--
+-- The blurb is plain text, rendered escaped (never v-html), so it's not the stored-
+-- HTML XSS vector of Invariant 5. Length is capped in the DB (and mirrored in the
+-- UI). Editing goes through an author-only SECURITY DEFINER RPC because there's no
+-- author-update RLS policy on suggestions (only admins update, for moderation) —
+-- this keeps authors to ONLY their own blurb, never `deleted` / `culled_at` / etc.
+-- ============================================================================
+
+alter table public.suggestions
+  add column if not exists blurb text
+  constraint suggestions_blurb_len check (blurb is null or char_length(blurb) <= 500);
+
+create function public.set_suggestion_blurb(p_suggestion_id uuid, p_blurb text)
+  returns void language plpgsql security definer set search_path = public as $$
+declare
+  trimmed text := nullif(btrim(p_blurb), '');
+begin
+  if not public.is_allowed() or public.is_blocked() then
+    raise exception 'not allowed' using errcode = 'insufficient_privilege';
+  end if;
+  if char_length(coalesce(trimmed, '')) > 500 then
+    raise exception 'blurb too long (max 500)' using errcode = 'check_violation';
+  end if;
+  update public.suggestions
+    set blurb = trimmed
+    where id = p_suggestion_id and user_id = auth.uid();
+  if not found then
+    raise exception 'not your suggestion' using errcode = 'insufficient_privilege';
+  end if;
+end;
+$$;
+revoke all on function public.set_suggestion_blurb(uuid, text) from public;
+grant execute on function public.set_suggestion_blurb(uuid, text) to authenticated;

--- a/test/SuggestionCard.nuxt.test.ts
+++ b/test/SuggestionCard.nuxt.test.ts
@@ -107,4 +107,31 @@ describe('SuggestionCard', () => {
     const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2, canVote: false } })
     expect(w.get('[aria-label="Remove vote"]').attributes('disabled')).toBeUndefined()
   })
+
+  it('shows the TMDB synopsis when present', async () => {
+    const withOverview = { ...suggestion, tmdb_movie: { ...suggestion.tmdb_movie, overview: 'A crew pulls one last heist.' } }
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion: withOverview, rank: 1, maxVotes: 2 } })
+    expect(w.text()).toContain('A crew pulls one last heist.')
+  })
+
+  it('lets the owner add a take and emits the text on save', async () => {
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion, rank: 1, maxVotes: 2 } })
+    await w.findAll('button').find(b => b.text().includes('Add your take'))?.trigger('click')
+    await w.get('textarea').setValue('Peak Michael Mann.')
+    await w.findAll('button').find(b => b.text().trim() === 'Save')?.trigger('click')
+    expect(w.emitted('blurb')?.[0]).toEqual(['Peak Michael Mann.'])
+  })
+
+  it('shows an existing take and no "add" button for the owner', async () => {
+    const withBlurb = { ...suggestion, blurb: 'A desert-island pick for me.' }
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion: withBlurb, rank: 1, maxVotes: 2 } })
+    expect(w.text()).toContain('A desert-island pick for me.')
+    expect(w.findAll('button').find(b => b.text().includes('Add your take'))).toBeUndefined()
+  })
+
+  it('does not let a non-owner add a take', async () => {
+    const notMine = { ...suggestion, user_id: 'someone-else' }
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion: notMine, rank: 1, maxVotes: 2 } })
+    expect(w.findAll('button').find(b => b.text().includes('Add your take'))).toBeUndefined()
+  })
 })

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -453,4 +453,40 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('votes').delete().eq('user_id', memberId).eq('suggestion_id', s!.id)
     await admin!.from('suggestions').delete().eq('id', s!.id)
   })
+
+  it('set_suggestion_blurb: author can set/clear, others cannot, length-capped', async () => {
+    const { data: mine } = await admin!
+      .from('suggestions').insert({ event_id: eventId, user_id: memberId, tmdb_movie: { id: 980, title: 'Blurbed' } })
+      .select('id').single()
+    const sid = mine!.id
+
+    // Author sets it — trimmed and stored.
+    const set = await memberClient.rpc('set_suggestion_blurb', { p_suggestion_id: sid, p_blurb: '  My desert-island pick.  ' })
+    expect(set.error, 'the author can set their blurb').toBeNull()
+    const after = await admin!.from('suggestions').select('blurb').eq('id', sid).single()
+    expect(after.data!.blurb, 'blurb is trimmed + stored').toBe('My desert-island pick.')
+
+    // An allowlisted non-author can't edit someone else's blurb.
+    const { data: theirs } = await admin!
+      .from('suggestions').insert({ event_id: eventId, user_id: adminUserId, tmdb_movie: { id: 981, title: 'NotMine' } })
+      .select('id').single()
+    const notMine = await memberClient.rpc('set_suggestion_blurb', { p_suggestion_id: theirs!.id, p_blurb: 'hijack' })
+    expect(notMine.error, 'a non-author is rejected even when allowlisted').toBeTruthy()
+
+    // A non-allowlisted user can't either.
+    const outsider = await outsiderClient.rpc('set_suggestion_blurb', { p_suggestion_id: sid, p_blurb: 'nope' })
+    expect(outsider.error, 'a non-allowlisted user is rejected').toBeTruthy()
+
+    // Over the 500-char cap is rejected.
+    const tooLong = await memberClient.rpc('set_suggestion_blurb', { p_suggestion_id: sid, p_blurb: 'x'.repeat(501) })
+    expect(tooLong.error, 'over 500 chars is rejected').toBeTruthy()
+
+    // Whitespace clears it to null.
+    const cleared = await memberClient.rpc('set_suggestion_blurb', { p_suggestion_id: sid, p_blurb: '   ' })
+    expect(cleared.error).toBeNull()
+    const empty = await admin!.from('suggestions').select('blurb').eq('id', sid).single()
+    expect(empty.data!.blurb, 'empty/whitespace clears to null').toBeNull()
+
+    await admin!.from('suggestions').delete().in('id', [sid, theirs!.id])
+  })
 })

--- a/test/useSuggestions.nuxt.test.ts
+++ b/test/useSuggestions.nuxt.test.ts
@@ -5,7 +5,8 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
 interface InsertCall { table: string, payload: Record<string, unknown> }
 interface DeleteCall { table: string, filters: Record<string, unknown> }
-const calls: { inserts: InsertCall[], deletes: DeleteCall[] } = { inserts: [], deletes: [] }
+interface RpcCall { fn: string, args: Record<string, unknown> }
+const calls: { inserts: InsertCall[], deletes: DeleteCall[], rpcs: RpcCall[] } = { inserts: [], deletes: [], rpcs: [] }
 
 // Minimal Supabase stub that records inserts/deletes and satisfies refresh()+realtime.
 const supabase = {
@@ -41,7 +42,10 @@ const supabase = {
       }
     }
   },
-  rpc: () => Promise.resolve({ data: [], error: null }),
+  rpc: (fn: string, args: Record<string, unknown>) => {
+    calls.rpcs.push({ fn, args })
+    return Promise.resolve({ data: [], error: null })
+  },
   channel() {
     const ch = { on: () => ch, subscribe: () => ch, send: () => Promise.resolve('ok') }
     return ch
@@ -55,6 +59,7 @@ mockNuxtImport('useState', () => (key: string) => ref(key === 'my-id' ? 'me' : n
 beforeEach(() => {
   calls.inserts = []
   calls.deletes = []
+  calls.rpcs = []
 })
 
 describe('useSuggestions write path', () => {
@@ -78,6 +83,13 @@ describe('useSuggestions write path', () => {
     const { vote } = useSuggestions(ref('e1'))
     await vote({ id: 's1', votes: [{ user_id: 'me' }] } as never)
     expect(calls.inserts.find(i => i.table === 'votes')).toBeUndefined()
+  })
+
+  it('setBlurb() calls the author-only RPC with the suggestion id + text', async () => {
+    const { setBlurb } = useSuggestions(ref('e1'))
+    await setBlurb({ id: 's1' } as never, 'A desert-island pick for me.')
+    const call = calls.rpcs.find(r => r.fn === 'set_suggestion_blurb')
+    expect(call?.args).toEqual({ p_suggestion_id: 's1', p_blurb: 'A desert-island pick for me.' })
   })
 
   it('unvote() deletes by suggestion_id only — RLS scopes it to my row', async () => {


### PR DESCRIPTION
## Scope

Two additions to suggestion cards:
- **Personal blurb** — the suggester can add a short note on why the group should screen a
  movie / why they love it, and **edit** it later. Existing suggestions get it for free.
- **TMDB synopsis** — show the movie's overview ("what it's about") on the card so people can
  decide without watching the trailer.

## Implementation

Four small commits:

1. **`feat(db)`** — `suggestions.blurb` (nullable, 500-char CHECK) + an **author-only SECURITY
   DEFINER RPC** `set_suggestion_blurb`. There's no author-update RLS policy on suggestions
   (only admins update, for moderation), so the RPC is the controlled path — it keeps an author
   to **only their own blurb**, never `deleted`/`culled_at`/etc. Trims input; empty clears to null.
2. **composable** — `blurb` on the `Suggestion` type + overview select; a `setBlurb` action
   through the RPC.
3. **card UI** — `SuggestionCard` renders the TMDB synopsis (clamped, click to expand) and the
   blurb as a quote; the owner gets an inline "Add your take" / edit textarea that emits the
   text, which the overview persists.
4. **`test(rls)`** — author can set/clear, an allowlisted non-author and a non-allowlisted user
   are both rejected, and over-cap is rejected.

**Security (Invariant 5):** the blurb is **plain text rendered escaped** (interpolation, never
`v-html`), so it isn't the stored-HTML XSS vector — no sanitizer needed. The TMDB overview was
already stored on `tmdb_movie` (`server/utils/tmdb.ts` maps it) and rendered defensively
(`v-if`), matching the existing `SuggestSection`/`MovieFinder` pattern.

## Screenshots

New on each ranked card on `/overview`: a 2-line synopsis (tap to expand) and, for your own
picks, an "Add your take" editor; everyone sees the resulting quote.

|         | suggestion card (new)                                  |
| ------- | ------------------------------------------------------ |
| desktop | synopsis + "Add your take" / quoted blurb              |
| mobile  | same, stacked                                          |

_(Static screenshots to follow before merge.)_

## How to Test

**Automated**
- Unit: `useSuggestions.setBlurb` calls the RPC with the right args; `SuggestionCard` shows the
  synopsis, lets the owner add a take (emits text), shows an existing take, and hides the editor
  from non-owners.
- Integration (`test/rls.integration.test.ts`, Supabase-local): `set_suggestion_blurb`
  authorization + 500-char cap + clear-on-empty.
- `npm run typecheck`, `npm run lint` (0 errors), `npx vitest run` (404 passing) green.

**Manual**
1. On `/overview`, open one of your own suggestions → **Add your take** → type → Save. Your note
   shows as a quote to everyone; **edit** updates it; clearing it removes it.
2. Try to edit someone else's card — no editor appears (and the RPC rejects it server-side).
3. Any card with a TMDB overview shows the synopsis; tap to expand the full text.

## Invariants & Risk

- **Authorization (Invariant 1):** blurb edits go through the author-only RPC; the UI edit
  button is just UX. **Rendered HTML (Invariant 5):** blurb is escaped text, not `v-html`.
- Additive, nullable column — existing suggestions unaffected. **Migration must reach prod.**