### PR TITLE
fix: repair malformed SuggestionCard template breaking the build

### DIFF
--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -149,7 +149,6 @@ function onHeartClick(e: MouseEvent): void {
         </div>
 
         <!-- What it's about (TMDB synopsis) — for anyone who'd rather not watch the trailer. -->
-        <p
         <button
           v-if="movie.overview"
           type="button"
@@ -179,8 +178,6 @@ function onHeartClick(e: MouseEvent): void {
           <blockquote v-if="suggestion.blurb" class="mt-2 text-xs italic text-muted border-l-2 border-primary/40 pl-2">
             “{{ suggestion.blurb }}”
             <UButton v-if="isOwner && !locked" label="edit" color="primary" variant="link" size="xs" class="not-italic ml-1 p-0" @click="startBlurb" />
-              edit
-            </button>
           </blockquote>
           <UButton
             v-else-if="isOwner && !locked"


### PR DESCRIPTION
## Scope

**Unblocks deploys.** The last 3 production builds failed with:

```
app/components/SuggestionCard.vue (161:9): Invalid end tag
```

## Root cause

After #134 merged, an edit on `main` converted the clickable synopsis `<p>` to a `<button>`
(good — interactive elements should be buttons) and the inline "edit" `<button>` to a
`<UButton/>`. Both replacements were applied **incompletely**, leaving malformed markup:

```html
<p
<button            <!-- stray <p line left above the new <button -->
  v-if="movie.overview"
...

<UButton ... label="edit" @click="startBlurb" />
  edit             <!-- leftover text + close from the old <button> -->
</button>
```

A `<button>` parsed as having a `<p` "attribute" and an orphaned `</button>` made the closer an
"invalid end tag." It slipped through because `typecheck` (vue-tsc) and the vitest SFC compiler
tolerated it, but the production Vite Vue compiler rejected it.

## Fix

Remove the stray `<p` line and the orphaned `edit</button>`, leaving a clean `<button>` synopsis
and the self-closing `<UButton label="edit"/>`.

## How to Test

- `npm run build` now succeeds (verified clean, cache cleared) — this was the failing step.
- Deterministic proof: compiling the SFC reports `Invalid end tag` before the fix, `0 errors`
  after.
- `npm run typecheck`, `npm run lint` (0 errors), `npx vitest run` (404 passing) all green; the
  16 `SuggestionCard` unit tests pass.

## Invariants & Risk

None — markup-only repair, no behavior change. Synopsis + personal-take features from #134 work
as intended.