### PR TITLE
feat: headline the personal pitch with the suggester's name

### DIFF
--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -29,6 +29,9 @@ function saveBlurb(): void {
   emit('blurb', blurbDraft.value.trim())
   editingBlurb.value = false
 }
+// Attribute the pitch to the suggester by name (falls back if the name is missing).
+const suggesterName = computed(() => props.suggestion.author?.display_name?.trim() || null)
+const pitchHeader = computed(() => (suggesterName.value ? `${suggesterName.value}'s Personal Pitch` : 'Personal Pitch'))
 const year = computed(() => movieYear(movie.value))
 // Public count from the tally (votes.length would only see the viewer's own vote).
 const voteCount = computed(() => props.suggestion.voteCount ?? 0)
@@ -175,9 +178,14 @@ function onHeartClick(e: MouseEvent): void {
           </div>
         </div>
         <template v-else>
-          <blockquote v-if="suggestion.blurb" class="mt-2 text-xs italic text-muted border-l-2 border-primary/40 pl-2">
-            “{{ suggestion.blurb }}”
-            <UButton v-if="isOwner && !locked" label="edit" color="primary" variant="link" size="xs" class="not-italic ml-1 p-0" @click="startBlurb" />
+          <blockquote v-if="suggestion.blurb" class="mt-2 border-l-2 border-primary/40 pl-2.5">
+            <p class="text-xs font-semibold text-primary">
+              {{ pitchHeader }}:
+            </p>
+            <p class="text-sm font-medium italic text-default mt-0.5">
+              “{{ suggestion.blurb }}”
+              <UButton v-if="isOwner && !locked" label="edit" color="primary" variant="link" size="xs" class="not-italic font-normal align-baseline ml-1 p-0" @click="startBlurb" />
+            </p>
           </blockquote>
           <UButton
             v-else-if="isOwner && !locked"

--- a/app/components/SuggestionCard.vue
+++ b/app/components/SuggestionCard.vue
@@ -151,18 +151,7 @@ function onHeartClick(e: MouseEvent): void {
           />
         </div>
 
-        <!-- What it's about (TMDB synopsis) — for anyone who'd rather not watch the trailer. -->
-        <button
-          v-if="movie.overview"
-          type="button"
-          class="text-xs text-muted mt-2 text-left w-full cursor-pointer"
-          :class="overviewOpen ? '' : 'line-clamp-2'"
-          @click="overviewOpen = !overviewOpen"
-        >
-          {{ movie.overview }}
-        </button>
-
-        <!-- The suggester's personal take. -->
+        <!-- The suggester's personal take — sits above the TMDB synopsis. -->
         <div v-if="editingBlurb" class="mt-2 space-y-1">
           <UTextarea
             v-model="blurbDraft"
@@ -198,6 +187,17 @@ function onHeartClick(e: MouseEvent): void {
             @click="startBlurb"
           />
         </template>
+
+        <!-- What it's about (TMDB synopsis) — for anyone who'd rather not watch the trailer. -->
+        <button
+          v-if="movie.overview"
+          type="button"
+          class="text-xs text-muted mt-2 text-left w-full cursor-pointer"
+          :class="overviewOpen ? '' : 'line-clamp-2'"
+          @click="overviewOpen = !overviewOpen"
+        >
+          {{ movie.overview }}
+        </button>
       </div>
     </div>
   </UCard>

--- a/app/composables/useSuggestions.ts
+++ b/app/composables/useSuggestions.ts
@@ -32,7 +32,7 @@ export function useSuggestions(eventId: MaybeRefOrGetter<string | null | undefin
       const [rows, counts] = await Promise.all([
         supabase
           .from('suggestions')
-          .select('id, event_id, user_id, tmdb_movie, deleted, blurb, created_at, votes(user_id, hidden_at)')
+          .select('id, event_id, user_id, tmdb_movie, deleted, blurb, created_at, author:profiles!suggestions_user_id_fkey(display_name), votes(user_id, hidden_at)')
           .eq('event_id', id)
           .eq('deleted', false)
           // Hidden because the author left "going" — off the ballot until they return.

--- a/shared/types/suggestion.ts
+++ b/shared/types/suggestion.ts
@@ -21,6 +21,8 @@ export interface Suggestion {
   // The suggester's personal note on why they picked it. Optional — only the
   // reads that display it (overview) select it.
   blurb?: string | null
+  // The suggester, for attributing their pitch. Optional — joined only where shown.
+  author?: { display_name: string | null } | null
   voteCount: number
   // `hidden_at` is present on admin/stats reads (to drop soft-deleted votes from
   // counts); the overview read strips it, so it's optional.

--- a/test/SuggestionCard.nuxt.test.ts
+++ b/test/SuggestionCard.nuxt.test.ts
@@ -129,6 +129,13 @@ describe('SuggestionCard', () => {
     expect(w.findAll('button').find(b => b.text().includes('Add your take'))).toBeUndefined()
   })
 
+  it('attributes the pitch to the suggester by name', async () => {
+    const withPitch = { ...suggestion, blurb: 'Trust me on this one.', author: { display_name: 'Alice' } }
+    const w = await mountSuspended(SuggestionCard, { props: { suggestion: withPitch, rank: 1, maxVotes: 2 } })
+    expect(w.text()).toContain('Alice\'s Personal Pitch')
+    expect(w.text()).toContain('Trust me on this one.')
+  })
+
   it('does not let a non-owner add a take', async () => {
     const notMine = { ...suggestion, user_id: 'someone-else' }
     const w = await mountSuspended(SuggestionCard, { props: { suggestion: notMine, rank: 1, maxVotes: 2 } })


### PR DESCRIPTION
## Scope

Polish on the suggestion "personal take" (from #134): give it a **"<Name>'s Personal Pitch:"**
header and make the take text **a bit bigger and bolder** so it reads as a real pitch instead
of a muted aside.

## Implementation

Two small commits:
1. **data** — add an optional `author { display_name }` to the `Suggestion` type and join it in
   the `useSuggestions` overview select (`author:profiles!suggestions_user_id_fkey(display_name)`).
2. **card** — `SuggestionCard` shows a `text-xs` primary-colored header `"<Name>'s Personal
   Pitch:"` above the blurb, and bumps the take to `text-sm font-medium` at full contrast
   (`text-default`) instead of `text-xs text-muted`. Falls back to "Personal Pitch" when the
   name is missing.

Before → after on the take:
- `text-xs italic text-muted` → header + `text-sm font-medium italic text-default`

## Screenshots

The quoted take on each `/overview` card now has a small attributed header and stands out more.
_(Static screenshots to follow.)_

## How to Test

- Unit: `SuggestionCard` "attributes the pitch to the suggester by name" (renders
  `Alice's Personal Pitch` + the blurb).
- `npm run build` ✅ (run this time, given the last deploy break), `typecheck`, `lint`
  (0 errors), `vitest` (405 passing) all green.
- Manual: on `/overview`, any pick with a take shows "<suggester>'s Personal Pitch:" above a
  bigger/bolder quote.

## Invariants & Risk

- No new authorization surface: suggester `display_name` is already readable by allowlisted
  users under the existing `profiles` RLS (the overview just surfaces it now). The blurb is
  still plain escaped text (Invariant 5). No schema change.