### PR TITLE
feat: auto RSVP reminders for e-vite non-responders

### DIFF
--- a/app/components/EventInviteManager.vue
+++ b/app/components/EventInviteManager.vue
@@ -12,6 +12,23 @@ const props = defineProps<{ eventId: string, event?: MovieEvent | null }>()
 const toast = useToast()
 const { invites, stats, addInvite, removeInvite, removeInvites, seedFromLastEvent, sendInvites } = useEventInvites(() => props.eventId)
 const { save: saveInviteOptions } = useInviteOptions(() => props.eventId)
+const { setEnabled: setRemindersEnabled } = useEventReminders(() => props.eventId)
+
+// Per-event auto-reminder toggle (defaults on). Re-sync if the event loads late.
+const remindersOn = ref(props.event?.reminders_enabled ?? true)
+watch(() => props.event?.id, () => {
+  remindersOn.value = props.event?.reminders_enabled ?? true
+})
+async function onToggleReminders(value: boolean): Promise<void> {
+  remindersOn.value = value
+  try {
+    await setRemindersEnabled(value)
+    toast.add({ title: value ? 'Auto-reminders on for this event' : 'Auto-reminders off for this event', icon: 'i-lucide-check', color: 'success' })
+  } catch {
+    remindersOn.value = !value // revert on failure
+    toast.add({ title: 'Could not update reminders', color: 'error' })
+  }
+}
 // The TRUE RSVP total = e-vite email replies + in-app RSVPs, merged + deduped.
 // `stats.*` above is the email funnel only (invited/opened/clicked); these are the
 // reconciled headcounts the admin actually plans around.
@@ -352,6 +369,14 @@ function statusBadge(invite: EventInvite): { label: string, color: 'success' | '
         @click="onSend"
       />
     </div>
+
+    <!-- Per-event auto-reminder toggle -->
+    <USwitch
+      :model-value="remindersOn"
+      label="Auto-remind people who haven't RSVP'd"
+      description="On the reminder checkpoints set in admin settings. Off skips this event."
+      @update:model-value="onToggleReminders"
+    />
 
     <!-- Bulk select toolbar -->
     <div v-if="invites.length" class="flex items-center gap-3 px-1">

--- a/app/components/ReminderCheckpointsSetting.vue
+++ b/app/components/ReminderCheckpointsSetting.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+// Admin control for the RSVP-reminder checkpoints (app_settings.reminder_days):
+// which days before an event to auto-email invitees who haven't replied. Blank
+// disables reminders. RLS enforces admin-only writes.
+const { reminderDays, setReminderDays } = useAppSettings()
+const toast = useToast()
+const draft = ref('')
+const saving = ref(false)
+
+watch(reminderDays, (v) => {
+  draft.value = formatReminderDays(v)
+}, { immediate: true })
+
+async function save(): Promise<void> {
+  saving.value = true
+  try {
+    const days = parseReminderDays(draft.value)
+    await setReminderDays(days)
+    draft.value = formatReminderDays(days)
+    toast.add({
+      title: days.length ? 'Reminder checkpoints saved' : 'Reminders turned off',
+      icon: 'i-lucide-check',
+      color: 'success'
+    })
+  } catch {
+    toast.add({ title: 'Could not save the checkpoints', color: 'error' })
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <UCard variant="subtle">
+    <div class="flex flex-wrap items-end gap-3">
+      <UFormField label="Reminder checkpoints (days before)" hint="e.g. 7, 3, 1 · blank = off" class="flex-1 min-w-48">
+        <UInput v-model="draft" placeholder="7, 3, 1" class="w-full" />
+      </UFormField>
+      <UButton label="Save" icon="i-lucide-save" :loading="saving" @click="save" />
+    </div>
+    <p class="text-xs text-muted mt-2">
+      Auto-emails invitees who haven't RSVP'd, on each of these days before an event. Each person stops once they reply. Leave blank to turn reminders off.
+    </p>
+  </UCard>
+</template>

--- a/app/composables/useAppSettings.ts
+++ b/app/composables/useAppSettings.ts
@@ -8,17 +8,20 @@ export function useAppSettings() {
   // Per-event participation caps (null = use the defaults in shared/utils/limits).
   const maxSuggestions = ref<number | null>(null)
   const maxVotes = ref<number | null>(null)
+  // RSVP-reminder checkpoints: days-before-event to nudge non-responders ([] = off).
+  const reminderDays = ref<number[]>([])
   const pending = ref(true)
 
   async function refresh(): Promise<void> {
     const { data } = await supabase
       .from('app_settings')
-      .select('max_invites, max_suggestions, max_votes')
+      .select('max_invites, max_suggestions, max_votes, reminder_days')
       .eq('id', true)
       .maybeSingle()
     maxInvites.value = data?.max_invites ?? null
     maxSuggestions.value = data?.max_suggestions ?? null
     maxVotes.value = data?.max_votes ?? null
+    reminderDays.value = data?.reminder_days ?? []
     pending.value = false
   }
 
@@ -47,5 +50,12 @@ export function useAppSettings() {
     maxVotes.value = votes
   }
 
-  return { maxInvites, maxSuggestions, maxVotes, pending, setMaxInvites, setParticipationCaps }
+  /** Set the RSVP-reminder checkpoints (days before the event; [] = off). RLS
+   *  enforces admin-only. */
+  async function setReminderDays(days: number[]): Promise<void> {
+    await update({ reminder_days: days })
+    reminderDays.value = days
+  }
+
+  return { maxInvites, maxSuggestions, maxVotes, reminderDays, pending, setMaxInvites, setParticipationCaps, setReminderDays }
 }

--- a/app/composables/useEventReminders.ts
+++ b/app/composables/useEventReminders.ts
@@ -1,0 +1,17 @@
+import type { MaybeRefOrGetter } from 'vue'
+import type { Database } from '~/types/database.types'
+
+/** Toggle the auto RSVP-reminder cron for a single event. RLS enforces admin-only
+ *  writes (events update policy); the UI toggle is just the trigger. */
+export function useEventReminders(eventId: MaybeRefOrGetter<string | null | undefined>) {
+  const supabase = useSupabaseClient<Database>()
+
+  async function setEnabled(enabled: boolean): Promise<void> {
+    const id = toValue(eventId)
+    if (!id) return
+    const { error } = await supabase.from('events').update({ reminders_enabled: enabled }).eq('id', id)
+    if (error) throw error
+  }
+
+  return { setEnabled }
+}

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -377,6 +377,7 @@ function onSelectEvent(event: MovieEvent): void {
 
           <InviteLimitSetting />
           <ParticipationLimitsSetting />
+          <ReminderCheckpointsSetting />
 
           <UAlert
             v-if="loadError"

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -18,21 +18,21 @@ export interface Database {
         Relationships: []
       }
       app_settings: {
-        Row: { id: boolean, max_invites: number | null, max_suggestions: number | null, max_votes: number | null, updated_at: string }
-        Insert: { id?: boolean, max_invites?: number | null, max_suggestions?: number | null, max_votes?: number | null, updated_at?: string }
-        Update: { id?: boolean, max_invites?: number | null, max_suggestions?: number | null, max_votes?: number | null, updated_at?: string }
+        Row: { id: boolean, max_invites: number | null, max_suggestions: number | null, max_votes: number | null, reminder_days: number[], updated_at: string }
+        Insert: { id?: boolean, max_invites?: number | null, max_suggestions?: number | null, max_votes?: number | null, reminder_days?: number[], updated_at?: string }
+        Update: { id?: boolean, max_invites?: number | null, max_suggestions?: number | null, max_votes?: number | null, reminder_days?: number[], updated_at?: string }
         Relationships: []
       }
       event_invites: {
-        Row: { id: string, event_id: string, email: string, display_name: string | null, token: string, rsvp: string | null, rsvp_at: string | null, plus_ones: number, invited_by: string | null, resend_id: string | null, sent_at: string | null, delivered_at: string | null, opened_at: string | null, clicked_at: string | null, bounced_at: string | null, created_at: string }
-        Insert: { id?: string, event_id: string, email: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, plus_ones?: number, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, created_at?: string }
-        Update: { id?: string, event_id?: string, email?: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, plus_ones?: number, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, created_at?: string }
+        Row: { id: string, event_id: string, email: string, display_name: string | null, token: string, rsvp: string | null, rsvp_at: string | null, plus_ones: number, invited_by: string | null, resend_id: string | null, sent_at: string | null, delivered_at: string | null, opened_at: string | null, clicked_at: string | null, bounced_at: string | null, reminded_at: string | null, created_at: string }
+        Insert: { id?: string, event_id: string, email: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, plus_ones?: number, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, reminded_at?: string | null, created_at?: string }
+        Update: { id?: string, event_id?: string, email?: string, display_name?: string | null, token?: string, rsvp?: string | null, rsvp_at?: string | null, plus_ones?: number, invited_by?: string | null, resend_id?: string | null, sent_at?: string | null, delivered_at?: string | null, opened_at?: string | null, clicked_at?: string | null, bounced_at?: string | null, reminded_at?: string | null, created_at?: string }
         Relationships: []
       }
       events: {
-        Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, voting_locked_at: string | null, invite_options: Record<string, unknown> | null, poster_display: Record<string, unknown> | null, created_by: string | null, created_at: string }
-        Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, invite_options?: Record<string, unknown> | null, poster_display?: Record<string, unknown> | null, created_by?: string | null, created_at?: string }
-        Update: { id?: string, title?: string, description?: string, event_date?: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, invite_options?: Record<string, unknown> | null, poster_display?: Record<string, unknown> | null, created_by?: string | null, created_at?: string }
+        Row: { id: string, title: string, description: string, event_date: string, start_time: string | null, location: string | null, location_url: string | null, poster_url: string | null, voting_locked_at: string | null, invite_options: Record<string, unknown> | null, poster_display: Record<string, unknown> | null, reminders_enabled: boolean, created_by: string | null, created_at: string }
+        Insert: { id?: string, title: string, description?: string, event_date: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, invite_options?: Record<string, unknown> | null, poster_display?: Record<string, unknown> | null, reminders_enabled?: boolean, created_by?: string | null, created_at?: string }
+        Update: { id?: string, title?: string, description?: string, event_date?: string, start_time?: string | null, location?: string | null, location_url?: string | null, poster_url?: string | null, voting_locked_at?: string | null, invite_options?: Record<string, unknown> | null, poster_display?: Record<string, unknown> | null, reminders_enabled?: boolean, created_by?: string | null, created_at?: string }
         Relationships: []
       }
       rsvps: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -31,6 +31,9 @@ export default defineNuxtConfig({
     resendFrom: 'Benteen Screen On The Green <movienight@benteenscreenonthegreen.com>',
     // Signing secret for Resend (Svix) webhooks → /api/webhooks/resend.
     resendWebhookSecret: '',
+    // Shared secret guarding the reminder cron route. Vercel Cron sends it as
+    // `Authorization: Bearer <CRON_SECRET>`; mapped from the unprefixed env var.
+    cronSecret: process.env.CRON_SECRET || '',
     // Absolute site URL used in email links; falls back to the request origin.
     siteUrl: ''
   },

--- a/server/api/crons/reminders.get.ts
+++ b/server/api/crons/reminders.get.ts
@@ -1,0 +1,92 @@
+import { serverSupabaseServiceRole } from '#supabase/server'
+import type { Database } from '~/types/database.types'
+
+/**
+ * Daily RSVP-reminder cron. Vercel Cron hits this (GET) once a day and
+ * authenticates with the CRON_SECRET bearer token. For every reminders-enabled
+ * upcoming event whose days-until matches a configured checkpoint
+ * (`app_settings.reminder_days`), it emails the invitees who haven't RSVP'd yet
+ * — reusing their one-click token links — throttled to at most once per
+ * checkpoint, then stamps `reminded_at` and logs the batch in `comms_log`.
+ *
+ * Runs as the service role (no session): event_invites is admin-only and there's
+ * no user here. The secret keeps the public route from being triggered by anyone.
+ */
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event)
+  if (!config.cronSecret || getHeader(event, 'authorization') !== `Bearer ${config.cronSecret}`) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const { resendApiKey, resendFrom } = requireEmailConfig(event)
+  const admin = serverSupabaseServiceRole<Database>(event)
+
+  const { data: settings } = await admin.from('app_settings').select('reminder_days').eq('id', true).single()
+  const reminderDays = settings?.reminder_days ?? [7, 3, 1]
+  if (!reminderDays.length) return { ok: true, events: 0, sent: 0, note: 'reminders disabled' }
+
+  const now = new Date()
+  const horizon = new Date(now.getTime() + (Math.max(...reminderDays) + 1) * 86_400_000).toISOString()
+
+  const { data: rows, error } = await admin
+    .from('events')
+    .select('id, title, event_date, reminders_enabled, event_invites(id, email, token, rsvp, sent_at, reminded_at)')
+    .gte('event_date', now.toISOString())
+    .lte('event_date', horizon)
+  if (error) throw createError({ statusCode: 500, statusMessage: 'Could not load events', data: { cause: error.message } })
+
+  // The events→event_invites relationship isn't declared in the generated types
+  // (Relationships are empty), so PostgREST's embed infers an error type — cast to
+  // the real shape, as the app composables do for their embeds.
+  type EventRow = {
+    id: string
+    title: string
+    event_date: string
+    reminders_enabled: boolean
+    event_invites: ReminderInvite[] | null
+  }
+  const due = selectDueReminders(
+    ((rows ?? []) as unknown as EventRow[]).map(e => ({
+      id: e.id, title: e.title, event_date: e.event_date, reminders_enabled: e.reminders_enabled, invites: e.event_invites ?? []
+    })),
+    now,
+    reminderDays
+  )
+
+  const origin = resolveOrigin(event)
+  const appUrl = `${origin}/overview`
+  const stamp = now.toISOString()
+  let totalSent = 0
+
+  for (const d of due) {
+    const items = d.invites.map((inv) => {
+      const mail = buildEventReminderEmail({
+        eventTitle: d.eventTitle,
+        eventDate: formatEmailDate(d.eventDate) || null,
+        daysLeft: d.daysLeft,
+        rsvpUrl: `${origin}/rsvp?token=${inv.token}`,
+        appUrl
+      })
+      return { to: inv.email, subject: mail.subject, html: mail.html, text: mail.text }
+    })
+
+    let ids: (string | null)[]
+    try {
+      ;({ ids } = await sendBatch(resendApiKey, resendFrom, items))
+    } catch (e) {
+      // A batch fails as a unit (e.g. an unverified sender). Leave reminded_at
+      // untouched so the next run retries; don't fail the whole cron.
+      console.error('[crons/reminders] batch failed -', e instanceof Error ? e.message : e)
+      continue
+    }
+
+    // Stamp + log only the invites that actually went out (got a Resend id).
+    const sentIds = d.invites.filter((_, i) => ids[i] != null).map(inv => inv.id)
+    if (!sentIds.length) continue
+    await admin.from('event_invites').update({ reminded_at: stamp }).in('id', sentIds)
+    await admin.from('comms_log').insert({ event_id: d.eventId, kind: 'reminder', subject: `Reminder — ${d.eventTitle}`, recipient_count: sentIds.length })
+    totalSent += sentIds.length
+  }
+
+  return { ok: true, events: due.length, sent: totalSent }
+})

--- a/shared/types/event.ts
+++ b/shared/types/event.ts
@@ -14,6 +14,8 @@ export interface MovieEvent {
   invite_options: Record<string, unknown> | null
   /** Per-event poster header display (jsonb). Read via normalizePosterDisplay. */
   poster_display: Record<string, unknown> | null
+  /** Whether the auto RSVP-reminder cron emails this event's non-responders. */
+  reminders_enabled: boolean
   created_at: string
 }
 

--- a/shared/utils/email.ts
+++ b/shared/utils/email.ts
@@ -105,6 +105,41 @@ export function buildAnnounceEmail(opts: {
   return { subject, html, text }
 }
 
+/** Nudge an invitee who hasn't RSVP'd yet. Same one-click RSVP buttons as the
+ *  e-vite (token in the query — no sign-in); `daysLeft` drives the urgency copy. */
+export function buildEventReminderEmail(opts: {
+  eventTitle: string
+  eventDate: string | null
+  daysLeft: number
+  rsvpUrl: string // base: https://site/rsvp?token=abc
+  appUrl?: string | null
+}): BuiltEmail {
+  const last = opts.daysLeft <= 1
+  const when = opts.daysLeft <= 0 ? 'today' : opts.daysLeft === 1 ? 'tomorrow' : `in ${opts.daysLeft} days`
+  const heading = last ? 'Last call' : 'Don\'t forget to RSVP'
+  const subject = last ? `Last call: RSVP for ${opts.eventTitle}` : `Reminder: RSVP for ${opts.eventTitle}`
+
+  const rsvp = (status: string, label: string, bg: string): string =>
+    `<a href="${escapeHtml(`${opts.rsvpUrl}&status=${status}`)}" style="display:inline-block;background:${bg};color:#fff;text-decoration:none;padding:11px 18px;border-radius:8px;font-weight:600;font-size:15px;margin:0 8px 8px 0">${escapeHtml(label)}</a>`
+
+  const lineup = opts.appUrl
+    ? `<p style="margin:20px 0 0;font-size:14px"><a href="${escapeHtml(opts.appUrl)}" style="color:#16a34a;font-weight:600;text-decoration:none">See the lineup &amp; vote →</a></p>`
+    : ''
+
+  const html = shell(
+    `<h1 style="font-size:20px;margin:0 0 4px">${heading} 🎬</h1>`
+    + `<p style="color:#6b7280;margin:0 0 16px"><strong>${escapeHtml(opts.eventTitle)}</strong>${opts.eventDate ? ` — ${escapeHtml(opts.eventDate)}` : ''}</p>`
+    + `<p>Movie Night is ${when} and we haven't heard from you yet. Are you in?</p>`
+    + `<p style="margin:22px 0 4px">${rsvp('going', 'I\'m going', '#16a34a')}${rsvp('maybe', 'Maybe', '#6b7280')}${rsvp('no', 'Can\'t make it', '#374151')}</p>`
+    + lineup
+  )
+  const text = `${heading} — ${opts.eventTitle}${opts.eventDate ? ` (${opts.eventDate})` : ''}.`
+    + `\n\nMovie Night is ${when} and we haven't heard from you yet.`
+    + `\n\nRSVP:\nGoing: ${opts.rsvpUrl}&status=going\nMaybe: ${opts.rsvpUrl}&status=maybe\nCan't make it: ${opts.rsvpUrl}&status=no`
+    + (opts.appUrl ? `\n\nSee the lineup & vote: ${opts.appUrl}` : '')
+  return { subject, html, text }
+}
+
 // ---- Themeable per-event e-vite -------------------------------------------
 
 interface Palette {

--- a/shared/utils/reminders.ts
+++ b/shared/utils/reminders.ts
@@ -1,0 +1,63 @@
+// Pure RSVP-reminder selection — given events + their e-vite rows and the
+// configured checkpoint days, decide who gets reminded today and how many days
+// out the event is. Kept pure so the cron route stays a thin I/O shell and this
+// logic is unit-testable without a database or clock.
+
+export interface ReminderInvite {
+  id: string
+  email: string
+  token: string
+  rsvp: string | null
+  sent_at: string | null
+  reminded_at: string | null
+}
+
+export interface ReminderEvent {
+  id: string
+  title: string
+  event_date: string
+  reminders_enabled: boolean
+  invites: ReminderInvite[]
+}
+
+export interface DueReminder {
+  eventId: string
+  eventTitle: string
+  eventDate: string
+  daysLeft: number
+  invites: ReminderInvite[]
+}
+
+/** Whole days from `now` until the event (floored: an event 7d4h away is 7). */
+export function daysUntil(now: Date, eventIso: string): number {
+  return Math.floor((new Date(eventIso).getTime() - now.getTime()) / 86_400_000)
+}
+
+/**
+ * Pick the reminders due right now: for each reminders-enabled event whose
+ * days-until matches a configured checkpoint, the invitees who were e-vited
+ * (`sent_at`), haven't responded (`rsvp` null), and weren't reminded within
+ * `throttleHours` (so a daily cron sends at most once per checkpoint).
+ */
+export function selectDueReminders(
+  events: ReadonlyArray<ReminderEvent>,
+  now: Date,
+  reminderDays: ReadonlyArray<number>,
+  throttleHours = 20
+): DueReminder[] {
+  const checkpoints = new Set(reminderDays)
+  const cutoff = now.getTime() - throttleHours * 3_600_000
+  const due: DueReminder[] = []
+  for (const ev of events) {
+    if (!ev.reminders_enabled) continue
+    const daysLeft = daysUntil(now, ev.event_date)
+    if (daysLeft < 0 || !checkpoints.has(daysLeft)) continue
+    const invites = ev.invites.filter(i =>
+      i.sent_at != null
+      && i.rsvp == null
+      && (i.reminded_at == null || new Date(i.reminded_at).getTime() < cutoff)
+    )
+    if (invites.length) due.push({ eventId: ev.id, eventTitle: ev.title, eventDate: ev.event_date, daysLeft, invites })
+  }
+  return due
+}

--- a/shared/utils/reminders.ts
+++ b/shared/utils/reminders.ts
@@ -28,6 +28,21 @@ export interface DueReminder {
   invites: ReminderInvite[]
 }
 
+/** Parse an admin's free-text checkpoint list ("7, 3, 1") into a sorted-desc,
+ *  de-duplicated array of positive whole days. Junk and non-positive values drop. */
+export function parseReminderDays(input: string): number[] {
+  const days = input
+    .split(/[\s,]+/)
+    .map(s => Math.floor(Number(s)))
+    .filter(n => Number.isFinite(n) && n > 0)
+  return [...new Set(days)].sort((a, b) => b - a)
+}
+
+/** Render checkpoints back to "7, 3, 1" for the input field. */
+export function formatReminderDays(days: ReadonlyArray<number>): string {
+  return [...days].sort((a, b) => b - a).join(', ')
+}
+
 /** Whole days from `now` until the event (floored: an event 7d4h away is 7). */
 export function daysUntil(now: Date, eventIso: string): number {
   return Math.floor((new Date(eventIso).getTime() - now.getTime()) / 86_400_000)

--- a/supabase/migrations/20260705000000_sync_member_rsvp_to_evite.sql
+++ b/supabase/migrations/20260705000000_sync_member_rsvp_to_evite.sql
@@ -1,0 +1,42 @@
+-- ============================================================================
+-- Mirror a member's in-app RSVP into their e-vite row. The one-click RSVP route
+-- already syncs the other direction (event_invites → rsvps); this closes the loop
+-- so the e-vite roster reflects in-app responses and the reminder system never
+-- nags a member who already replied in the app.
+--
+-- Members have no write access to event_invites (admin-only RLS), so this is a
+-- SECURITY DEFINER trigger. It matches the e-vite row by (event, email). A DELETE
+-- (un-RSVP) clears the response back to "no reply" so they're remindable again.
+-- ============================================================================
+
+create function public.sync_member_rsvp_to_evite() returns trigger
+  language plpgsql security definer set search_path = public as $$
+declare
+  uid          uuid;
+  eid          uuid;
+  new_status   text;
+  member_email text;
+begin
+  if tg_op = 'DELETE' then
+    uid := old.user_id; eid := old.event_id; new_status := null;
+  else
+    uid := new.user_id; eid := new.event_id; new_status := new.status;
+  end if;
+
+  select lower(trim(email)) into member_email from public.profiles where id = uid;
+  if member_email is null or member_email = '' then
+    return coalesce(new, old);
+  end if;
+
+  update public.event_invites
+    set rsvp = new_status,
+        rsvp_at = case when new_status is null then null else now() end
+    where event_id = eid and lower(trim(email)) = member_email;
+
+  return coalesce(new, old);
+end;
+$$;
+
+create trigger rsvps_sync_to_evite
+  after insert or update or delete on public.rsvps
+  for each row execute function public.sync_member_rsvp_to_evite();

--- a/supabase/migrations/20260706000000_reminder_infra.sql
+++ b/supabase/migrations/20260706000000_reminder_infra.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- RSVP reminder infrastructure. A daily cron emails invitees who haven't replied
+-- yet, on admin-configurable "checkpoint" days before the event.
+--
+--  * event_invites.reminded_at — last reminder send, to throttle (one per day max).
+--  * app_settings.reminder_days — the configurable checkpoints (days before the
+--    event to send), default {7,3,1}. Empty array = reminders off globally.
+--  * events.reminders_enabled — per-event off switch (on by default).
+--  * comms_log.kind gains 'reminder' so reminder batches are logged like the rest.
+-- ============================================================================
+
+alter table public.event_invites add column if not exists reminded_at timestamptz;
+
+alter table public.app_settings
+  add column if not exists reminder_days int[] not null default '{7,3,1}';
+
+alter table public.events
+  add column if not exists reminders_enabled boolean not null default true;
+
+alter table public.comms_log drop constraint if exists comms_log_kind_check;
+alter table public.comms_log
+  add constraint comms_log_kind_check check (kind in ('announcement', 'invite', 'reminder'));

--- a/test/EventInviteManager.nuxt.test.ts
+++ b/test/EventInviteManager.nuxt.test.ts
@@ -45,6 +45,7 @@ mockNuxtImport('useEventInvites', () => () => ({
 }))
 mockNuxtImport('useToast', () => () => ({ add: (t: Toast) => toasts.push(t) }))
 mockNuxtImport('useInviteOptions', () => () => ({ save: saveOptionsFn }))
+mockNuxtImport('useEventReminders', () => () => ({ setEnabled: async () => {} }))
 mockNuxtImport('useEventRsvps', () => () => ({
   roster: ref({
     going: [{ key: 'u1', name: 'Ada', email: 'ada@x.com', avatar: null, status: 'going', plusOnes: 0, viaEmail: false }],

--- a/test/ReminderCheckpointsSetting.nuxt.test.ts
+++ b/test/ReminderCheckpointsSetting.nuxt.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
+import ReminderCheckpointsSetting from '../app/components/ReminderCheckpointsSetting.vue'
+
+const setReminderDays = vi.fn()
+const toastAdd = vi.fn()
+mockNuxtImport('useAppSettings', () => () => ({
+  reminderDays: ref<number[]>([7, 3, 1]),
+  setReminderDays
+}))
+mockNuxtImport('useToast', () => () => ({ add: toastAdd }))
+
+beforeEach(() => {
+  setReminderDays.mockReset()
+  setReminderDays.mockResolvedValue(undefined)
+  toastAdd.mockReset()
+})
+
+const clickSave = (w: Awaited<ReturnType<typeof mountSuspended>>): Promise<void> =>
+  w.findAll('button').find(b => b.text() === 'Save')!.trigger('click')
+
+describe('ReminderCheckpointsSetting', () => {
+  it('hydrates the field from the current checkpoints', async () => {
+    const w = await mountSuspended(ReminderCheckpointsSetting)
+    expect(w.find('input').element.value).toBe('7, 3, 1')
+  })
+
+  it('parses, sorts, and saves the edited checkpoints', async () => {
+    const w = await mountSuspended(ReminderCheckpointsSetting)
+    await w.find('input').setValue('1, 5, 5, 10')
+    await clickSave(w)
+    expect(setReminderDays).toHaveBeenCalledWith([10, 5, 1])
+  })
+
+  it('saves an empty list (reminders off) for a blank field', async () => {
+    const w = await mountSuspended(ReminderCheckpointsSetting)
+    await w.find('input').setValue('')
+    await clickSave(w)
+    expect(setReminderDays).toHaveBeenCalledWith([])
+  })
+
+  it('surfaces an error toast when the save fails', async () => {
+    setReminderDays.mockRejectedValueOnce(new Error('boom'))
+    const w = await mountSuspended(ReminderCheckpointsSetting)
+    await clickSave(w)
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ color: 'error' }))
+  })
+})

--- a/test/email.test.ts
+++ b/test/email.test.ts
@@ -3,12 +3,33 @@ import type { InviteOptions } from '../shared/types/invite-options'
 import {
   buildAnnounceEmail,
   buildEventInviteEmail,
+  buildEventReminderEmail,
   buildInviteEmail,
   escapeHtml,
   formatEmailDate,
   htmlToText,
   uniqueEmails
 } from '../shared/utils/email'
+
+describe('buildEventReminderEmail', () => {
+  it('includes the tokenized one-click RSVP links', () => {
+    const m = buildEventReminderEmail({ eventTitle: 'Jaws', eventDate: 'Friday', daysLeft: 3, rsvpUrl: 'https://x/rsvp?token=abc' })
+    expect(m.html).toContain('https://x/rsvp?token=abc&amp;status=going')
+    expect(m.text).toContain('https://x/rsvp?token=abc&status=no')
+  })
+
+  it('uses "in N days" copy and a normal subject when there is time', () => {
+    const m = buildEventReminderEmail({ eventTitle: 'Jaws', eventDate: null, daysLeft: 3, rsvpUrl: 'https://x/rsvp?token=abc' })
+    expect(m.subject).toBe('Reminder: RSVP for Jaws')
+    expect(m.text).toContain('in 3 days')
+  })
+
+  it('switches to "Last call" + "tomorrow" at one day out', () => {
+    const m = buildEventReminderEmail({ eventTitle: 'Jaws', eventDate: null, daysLeft: 1, rsvpUrl: 'https://x/rsvp?token=abc' })
+    expect(m.subject).toBe('Last call: RSVP for Jaws')
+    expect(m.text).toContain('tomorrow')
+  })
+})
 
 describe('buildEventInviteEmail', () => {
   it('includes tokenized Going/Maybe/No RSVP links', () => {

--- a/test/reminders.test.ts
+++ b/test/reminders.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { daysUntil, selectDueReminders, type ReminderEvent } from '../shared/utils/reminders'
+
+const NOW = new Date('2026-06-29T15:00:00Z')
+const inDays = (n: number): string => new Date(NOW.getTime() + n * 86_400_000).toISOString()
+
+const invite = (over: Partial<ReminderEvent['invites'][number]> = {}): ReminderEvent['invites'][number] => ({
+  id: 'i1', email: 'a@x.com', token: 'tok', rsvp: null, sent_at: inDays(-10), reminded_at: null, ...over
+})
+const event = (over: Partial<ReminderEvent> = {}): ReminderEvent => ({
+  id: 'e1', title: 'Movie Night', event_date: inDays(7), reminders_enabled: true, invites: [invite()], ...over
+})
+
+describe('daysUntil', () => {
+  it('floors the whole-day gap (an event 7d later from 15:00 is 7)', () => {
+    expect(daysUntil(NOW, inDays(7))).toBe(7)
+    expect(daysUntil(NOW, new Date(NOW.getTime() + 7 * 86_400_000 + 4 * 3_600_000).toISOString())).toBe(7)
+  })
+  it('is 0 today and negative for the past', () => {
+    expect(daysUntil(NOW, new Date(NOW.getTime() + 3 * 3_600_000).toISOString())).toBe(0)
+    expect(daysUntil(NOW, inDays(-1))).toBe(-1)
+  })
+})
+
+describe('selectDueReminders', () => {
+  it('selects non-responders when days-until hits a checkpoint', () => {
+    const due = selectDueReminders([event({ event_date: inDays(7) })], NOW, [7, 3, 1])
+    expect(due).toHaveLength(1)
+    expect(due[0]!.daysLeft).toBe(7)
+    expect(due[0]!.invites.map(i => i.id)).toEqual(['i1'])
+  })
+
+  it('skips events whose days-until is not a checkpoint', () => {
+    expect(selectDueReminders([event({ event_date: inDays(5) })], NOW, [7, 3, 1])).toEqual([])
+  })
+
+  it('skips events with reminders disabled', () => {
+    expect(selectDueReminders([event({ reminders_enabled: false })], NOW, [7, 3, 1])).toEqual([])
+  })
+
+  it('excludes invitees who already responded', () => {
+    const e = event({ invites: [invite({ rsvp: 'going' }), invite({ id: 'i2', rsvp: null })] })
+    const due = selectDueReminders([e], NOW, [7, 3, 1])
+    expect(due[0]!.invites.map(i => i.id)).toEqual(['i2'])
+  })
+
+  it('excludes invitees who were never e-vited (no sent_at)', () => {
+    const e = event({ invites: [invite({ sent_at: null })] })
+    expect(selectDueReminders([e], NOW, [7, 3, 1])).toEqual([])
+  })
+
+  it('throttles invitees reminded within the window, but re-includes stale ones', () => {
+    const e = event({ invites: [
+      invite({ id: 'fresh', reminded_at: new Date(NOW.getTime() - 2 * 3_600_000).toISOString() }), // 2h ago → skip
+      invite({ id: 'stale', reminded_at: new Date(NOW.getTime() - 26 * 3_600_000).toISOString() }) // 26h ago → send
+    ] })
+    const due = selectDueReminders([e], NOW, [7, 3, 1])
+    expect(due[0]!.invites.map(i => i.id)).toEqual(['stale'])
+  })
+
+  it('skips past events even if 0 is not a checkpoint', () => {
+    expect(selectDueReminders([event({ event_date: inDays(-1) })], NOW, [7, 3, 1])).toEqual([])
+  })
+})

--- a/test/reminders.test.ts
+++ b/test/reminders.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { daysUntil, selectDueReminders, type ReminderEvent } from '../shared/utils/reminders'
+import { daysUntil, formatReminderDays, parseReminderDays, selectDueReminders, type ReminderEvent } from '../shared/utils/reminders'
 
 const NOW = new Date('2026-06-29T15:00:00Z')
 const inDays = (n: number): string => new Date(NOW.getTime() + n * 86_400_000).toISOString()
@@ -9,6 +9,19 @@ const invite = (over: Partial<ReminderEvent['invites'][number]> = {}): ReminderE
 })
 const event = (over: Partial<ReminderEvent> = {}): ReminderEvent => ({
   id: 'e1', title: 'Movie Night', event_date: inDays(7), reminders_enabled: true, invites: [invite()], ...over
+})
+
+describe('parseReminderDays / formatReminderDays', () => {
+  it('parses, sorts desc, de-dupes, and drops junk / non-positive', () => {
+    expect(parseReminderDays('1, 3, 7')).toEqual([7, 3, 1])
+    expect(parseReminderDays('7 7 3')).toEqual([7, 3])
+    expect(parseReminderDays('7, abc, 0, -2, 3')).toEqual([7, 3])
+    expect(parseReminderDays('')).toEqual([])
+  })
+  it('formats back to a sorted-desc list', () => {
+    expect(formatReminderDays([1, 7, 3])).toBe('7, 3, 1')
+    expect(formatReminderDays([])).toBe('')
+  })
 })
 
 describe('daysUntil', () => {

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -489,4 +489,34 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
 
     await admin!.from('suggestions').delete().in('id', [sid, theirs!.id])
   })
+
+  it('mirrors a member’s in-app RSVP into their e-vite row (set / change / clear)', async () => {
+    const email = `rls_sync_${stamp}@example.com`
+    const uid = await makeUser(email)
+    await admin!.from('invites').insert({ email })
+    const client = await signInAs(email)
+    // The member is on this event's e-vite list, not yet responded.
+    await admin!.from('event_invites').insert({ event_id: eventId, email })
+
+    // In-app RSVP → mirrored to the e-vite row.
+    await client.from('rsvps').upsert({ event_id: eventId, user_id: uid, status: 'going' }, { onConflict: 'event_id,user_id' })
+    let row = await admin!.from('event_invites').select('rsvp, rsvp_at').eq('event_id', eventId).eq('email', email).single()
+    expect(row.data!.rsvp, 'in-app going mirrors to the e-vite row').toBe('going')
+    expect(row.data!.rsvp_at, 'and stamps a response time').not.toBeNull()
+
+    // Changing the in-app answer updates the e-vite row.
+    await client.from('rsvps').update({ status: 'maybe' }).eq('event_id', eventId).eq('user_id', uid)
+    row = await admin!.from('event_invites').select('rsvp').eq('event_id', eventId).eq('email', email).single()
+    expect(row.data!.rsvp, 'a changed answer is mirrored').toBe('maybe')
+
+    // Clearing the in-app RSVP resets them to "no reply".
+    await client.from('rsvps').delete().eq('event_id', eventId).eq('user_id', uid)
+    row = await admin!.from('event_invites').select('rsvp, rsvp_at').eq('event_id', eventId).eq('email', email).single()
+    expect(row.data!.rsvp, 'un-RSVP clears the e-vite response').toBeNull()
+    expect(row.data!.rsvp_at, 'and the response time').toBeNull()
+
+    await admin!.from('event_invites').delete().eq('event_id', eventId).eq('email', email)
+    await admin!.from('rsvps').delete().eq('user_id', uid)
+    await admin!.from('invites').delete().eq('email', email)
+  })
 })

--- a/test/useEventReminders.nuxt.test.ts
+++ b/test/useEventReminders.nuxt.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+interface UpdateCall { table: string, patch: Record<string, unknown>, id: unknown }
+const calls: UpdateCall[] = []
+
+const supabase = {
+  from(table: string) {
+    return {
+      update: (patch: Record<string, unknown>) => ({
+        eq: (_col: string, id: unknown) => {
+          calls.push({ table, patch, id })
+          return Promise.resolve({ error: null })
+        }
+      })
+    }
+  }
+}
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+beforeEach(() => {
+  calls.length = 0
+})
+
+describe('useEventReminders', () => {
+  it('updates events.reminders_enabled for the given event', async () => {
+    const { setEnabled } = useEventReminders(ref('e1'))
+    await setEnabled(false)
+    expect(calls).toEqual([{ table: 'events', patch: { reminders_enabled: false }, id: 'e1' }])
+  })
+
+  it('is a no-op without an event id', async () => {
+    const { setEnabled } = useEventReminders(ref(null))
+    await setEnabled(true)
+    expect(calls).toEqual([])
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/crons/reminders",
+      "schedule": "0 15 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Auto-email people who were e-vited to an event but **haven't RSVP'd yet**, on
**admin-configurable checkpoint days** before the event. Plus the companion fix:
**an in-app RSVP now marks the person in the e-vite list** (so reminders never nag someone
who already replied in the app).

## Implementation

Six focused commits:

1. **`feat(db)` in-app → e-vite sync** — a `SECURITY DEFINER` trigger on `rsvps` mirrors a
   member's status into their `event_invites` row (by email): set/change on insert+update,
   clear on delete. Closes the loop with the one-click route.
2. **`feat(db)` reminder schema** — `event_invites.reminded_at` (throttle),
   `app_settings.reminder_days int[]` (**configurable checkpoints**, default `{7,3,1}`, empty =
   off), `events.reminders_enabled` (per-event off switch), `'reminder'` added to `comms_log.kind`.
3. **Reminder email** — `buildEventReminderEmail`, reusing the e-vite's one-click token buttons;
   copy escalates by days-left ("in N days" → "tomorrow" → "today", "Last call" subject inside a day).
4. **Cron** — pure `selectDueReminders` (reminders-enabled events whose days-until hits a
   checkpoint → e-vited non-responders not reminded within the throttle window) + the
   `/api/crons/reminders` route that sends via Resend batch, stamps `reminded_at`, logs to
   `comms_log`. Runs as the **service role**, guarded by a **`CRON_SECRET` bearer token**.
   `vercel.json` schedules it daily (15:00 UTC).
5. **Configurable checkpoints UI** — `useAppSettings.reminderDays` + a `ReminderCheckpointsSetting`
   in the admin People tab ("7, 3, 1", blank = off), with parse/format helpers.
6. **Per-event toggle** — a `USwitch` in `EventInviteManager` flips `events.reminders_enabled`.

## Decisions (per our chat)

- **Cadence:** configurable checkpoints (default 7/3/1), each person drops out the moment they reply.
- **Recipients:** only **no-response** invitees (left "maybe"/"can't" alone).
- **Control:** on by default, with a per-event off switch (and global off = clear the checkpoints).
- **Trigger:** Vercel Cron (no scheduler existed before) — the lowest-infra fit for the Vercel deploy.

## How to Test

**Automated**
- Unit: `selectDueReminders`/`daysUntil`/`parse|formatReminderDays`; `buildEventReminderEmail`;
  `ReminderCheckpointsSetting`; `useEventReminders`.
- Integration (`test/rls.integration.test.ts`): in-app RSVP set/change/clear mirrors to the
  e-vite row.
- `npm run build` ✅ (run, given the deploy-break lesson), `typecheck`, `lint` (0 errors),
  `vitest` (425 passing) all green.

**Manual**
1. Admin → People → set "Reminder checkpoints" (e.g. `7, 3, 1`).
2. E-vite a guest who doesn't reply; on a checkpoint day the cron emails them (one-click links).
3. RSVP in-app as an invited member → their e-vite row flips to that status (no longer "no reply").
4. Toggle "Auto-remind…" off on an event → the cron skips it.

## Setup notes (for deploy)

- Set **`CRON_SECRET`** in Vercel (the cron route 401s without a matching `Authorization: Bearer`).
  Vercel injects it on scheduled runs automatically.
- Reminder emails reuse the existing Resend config (`NUXT_RESEND_API_KEY` / `NUXT_RESEND_FROM`).
- **Three migrations** must reach prod (`20260705/06`, plus the sync trigger).

## Invariants & Risk

- **Invariant 1/2:** the cron runs server-side as the service role behind the secret; the key never
  reaches the client. **Invariant 5:** reminder emails are built by the shared escaped builders.
- Reminder sends are **at-least-once** (same trade-off as the e-vite blast): a batch sent but not
  stamped could re-send next run; the throttle + checkpoint gating keep duplicates rare.