### PR TITLE
fix: comms blast 502 — chunk BCC under Resend's 50-recipient cap

### DIFF
--- a/app/components/EventAnnounceComposer.vue
+++ b/app/components/EventAnnounceComposer.vue
@@ -40,17 +40,26 @@ async function onSubmit(event: FormSubmitEvent<{ subject?: string, message: stri
   }
   sending.value = true
   try {
-    const res = await $fetch<{ ok: boolean, count: number }>('/api/events/announce', {
+    const res = await $fetch<{ ok: boolean, count: number, failed?: number, error?: string | null }>('/api/events/announce', {
       method: 'POST',
       body: { eventId: props.eventId, subject: event.data.subject || undefined, message: event.data.message, scope: event.data.scope }
     })
-    toast.add({
-      title: res.count ? `Sent to ${res.count} ${res.count === 1 ? 'person' : 'people'}` : 'No recipients matched',
-      icon: 'i-lucide-send',
-      color: res.count ? 'success' : 'warning'
-    })
-    state.subject = ''
-    state.message = ''
+    const failed = res.failed ?? 0
+    if (res.count && failed) {
+      // Partial delivery — some groups went out, some didn't (don't pretend full success).
+      toast.add({ title: `Sent to ${res.count}, ${failed} failed`, description: res.error ?? undefined, icon: 'i-lucide-send', color: 'warning' })
+    } else if (res.count) {
+      toast.add({ title: `Sent to ${res.count} ${res.count === 1 ? 'person' : 'people'}`, icon: 'i-lucide-send', color: 'success' })
+    } else if (failed) {
+      toast.add({ title: 'Could not send the blast', description: res.error ?? undefined, color: 'error' })
+    } else {
+      toast.add({ title: 'No recipients matched', color: 'warning' })
+    }
+    // Keep the draft if nothing went out, so the admin can retry.
+    if (res.count) {
+      state.subject = ''
+      state.message = ''
+    }
   } catch (error) {
     toast.add({ title: 'Could not send the blast', description: messageOf(error), color: 'error' })
   } finally {

--- a/server/api/events/announce.post.ts
+++ b/server/api/events/announce.post.ts
@@ -63,38 +63,29 @@ export default defineEventHandler(async (event) => {
     link: `${resolveOrigin(event)}/overview`
   })
 
-  // Resend caps a single send at 50 recipients (to + cc + bcc), so a blast to a
-  // larger group must go out as several BCC'd emails — otherwise Resend rejects the
-  // whole send and the blast 502s. A small gap between sends stays under the rate limit.
-  const RECIPIENT_LIMIT = 50
-  const groups = chunk(emails, RECIPIENT_LIMIT)
-  try {
-    for (let i = 0; i < groups.length; i++) {
-      if (i > 0) await new Promise(resolve => setTimeout(resolve, 250))
-      await sendEmail(resendApiKey, resendFrom, {
-        to: resendFrom, // a `to` is required; real recipients are BCC'd
-        bcc: groups[i],
-        subject: mail.subject,
-        html: mail.html,
-        text: mail.text,
-        replyTo: user.email ?? undefined
-      })
-    }
-  } catch (error) {
-    throw createError({ statusCode: 502, statusMessage: error instanceof Error ? error.message : 'Send failed' })
+  // Send in BCC groups of 50 (Resend's per-send cap). Continues past a failed
+  // group, so a mid-blast error doesn't lose the groups that already delivered —
+  // the result reports sent/failed for the UI to surface (no all-or-nothing 502).
+  const { sent, failed, error } = await sendAnnounce(
+    resendApiKey,
+    resendFrom,
+    { subject: mail.subject, html: mail.html, text: mail.text, replyTo: user.email ?? undefined },
+    emails
+  )
+
+  // Record what actually went out (best-effort — a logging failure must not fail
+  // the request; surface it in logs instead).
+  if (sent > 0) {
+    const { error: logError } = await admin.from('comms_log').insert({
+      event_id: eventId,
+      kind: 'announcement',
+      scope,
+      subject: mail.subject,
+      recipient_count: sent,
+      sent_by: userId
+    })
+    if (logError) console.error('[events/announce] comms_log insert failed -', logError.message)
   }
 
-  // Record the send in the comms log (best-effort — the email already went out, so a
-  // logging failure must not fail the request; surface it in logs instead).
-  const { error: logError } = await admin.from('comms_log').insert({
-    event_id: eventId,
-    kind: 'announcement',
-    scope,
-    subject: mail.subject,
-    recipient_count: emails.length,
-    sent_by: userId
-  })
-  if (logError) console.error('[events/announce] comms_log insert failed -', logError.message)
-
-  return { ok: true, count: emails.length }
+  return { ok: true, count: sent, failed, error }
 })

--- a/server/api/events/announce.post.ts
+++ b/server/api/events/announce.post.ts
@@ -63,15 +63,23 @@ export default defineEventHandler(async (event) => {
     link: `${resolveOrigin(event)}/overview`
   })
 
+  // Resend caps a single send at 50 recipients (to + cc + bcc), so a blast to a
+  // larger group must go out as several BCC'd emails — otherwise Resend rejects the
+  // whole send and the blast 502s. A small gap between sends stays under the rate limit.
+  const RECIPIENT_LIMIT = 50
+  const groups = chunk(emails, RECIPIENT_LIMIT)
   try {
-    await sendEmail(resendApiKey, resendFrom, {
-      to: resendFrom, // a `to` is required; real recipients are BCC'd
-      bcc: emails,
-      subject: mail.subject,
-      html: mail.html,
-      text: mail.text,
-      replyTo: user.email ?? undefined
-    })
+    for (let i = 0; i < groups.length; i++) {
+      if (i > 0) await new Promise(resolve => setTimeout(resolve, 250))
+      await sendEmail(resendApiKey, resendFrom, {
+        to: resendFrom, // a `to` is required; real recipients are BCC'd
+        bcc: groups[i],
+        subject: mail.subject,
+        html: mail.html,
+        text: mail.text,
+        replyTo: user.email ?? undefined
+      })
+    }
   } catch (error) {
     throw createError({ statusCode: 502, statusMessage: error instanceof Error ? error.message : 'Send failed' })
   }

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -101,7 +101,8 @@ const INVITE_INTER_BATCH_MS = 250
 
 const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 
-function chunk<T>(items: readonly T[], size: number): T[][] {
+/** Split a list into fixed-size groups (last group may be smaller). */
+export function chunk<T>(items: readonly T[], size: number): T[][] {
   const out: T[][] = []
   for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size))
   return out

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -108,6 +108,64 @@ export function chunk<T>(items: readonly T[], size: number): T[][] {
   return out
 }
 
+// Resend caps a single send (to + cc + bcc) at 50 recipients — distinct from the
+// 100-per-request batch endpoint above, which is a different Resend API.
+const ANNOUNCE_RECIPIENT_LIMIT = 50
+
+export interface SendAnnounceResult {
+  /** Recipients in groups that sent successfully. */
+  readonly sent: number
+  /** Recipients in groups that failed. */
+  readonly failed: number
+  /** First failure message (e.g. an unverified sender domain); null on full success. */
+  readonly error: string | null
+}
+
+/**
+ * Sends one announcement to many recipients, BCC'd in groups of 50 (Resend's
+ * per-send recipient cap — a single BCC to more than that is rejected, which is
+ * what 502'd the blast). Continues past a failed group so a mid-blast error
+ * doesn't lose the groups that already went out, returning sent/failed counts +
+ * the first error like `sendEventInvites`.
+ *
+ * ⚠️ At-least-once, like the e-vite blast: announcements have no per-recipient
+ * record, so a retry after a partial failure re-delivers to the groups that
+ * already succeeded. The returned `failed`/`error` are the operator's signal.
+ */
+export async function sendAnnounce(
+  apiKey: string,
+  from: string,
+  params: { subject: string, html: string, text: string, replyTo?: string },
+  recipients: readonly string[],
+  opts: { groupSize?: number, interBatchMs?: number } = {}
+): Promise<SendAnnounceResult> {
+  const groupSize = opts.groupSize ?? ANNOUNCE_RECIPIENT_LIMIT
+  const interBatchMs = opts.interBatchMs ?? INVITE_INTER_BATCH_MS
+  const groups = chunk(recipients, groupSize)
+  let sent = 0
+  let firstError: string | null = null
+  for (let i = 0; i < groups.length; i++) {
+    if (i > 0) await sleep(interBatchMs)
+    const group = groups[i]!
+    try {
+      await sendEmail(apiKey, from, {
+        to: from, // a `to` is required; real recipients are BCC'd
+        bcc: [...group],
+        subject: params.subject,
+        html: params.html,
+        text: params.text,
+        replyTo: params.replyTo
+      })
+      sent += group.length
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      if (!firstError) firstError = message
+      console.error('[events/announce] batch failed -', message)
+    }
+  }
+  return { sent, failed: recipients.length - sent, error: firstError }
+}
+
 /** One guest's prepared e-vite: the `event_invites` row id + the built email. */
 export interface InviteRecipient {
   readonly id: string

--- a/test/sendAnnounce.test.ts
+++ b/test/sendAnnounce.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the Resend SDK's single-send endpoint (sendAnnounce → sendEmail → emails.send).
+const { emailSend } = vi.hoisted(() => ({ emailSend: vi.fn() }))
+vi.mock('resend', () => ({
+  Resend: class {
+    emails = { send: emailSend }
+  }
+}))
+
+const { sendAnnounce } = await import('../server/utils/email')
+
+const params = { subject: 's', html: '<p>h</p>', text: 't' }
+const recipients = (n: number): string[] => Array.from({ length: n }, (_, i) => `u${i}@x.com`)
+// Skip the inter-group delay so tests don't actually wait.
+const opts = { interBatchMs: 0 }
+
+beforeEach(() => {
+  emailSend.mockReset()
+  emailSend.mockResolvedValue({ data: { id: 're_1' }, error: null })
+})
+
+describe('sendAnnounce', () => {
+  it('BCCs recipients in groups of 50 — one send per group, not one giant send', async () => {
+    const res = await sendAnnounce('key', 'from@x', params, recipients(120), opts)
+    expect(emailSend).toHaveBeenCalledTimes(3)
+    expect(emailSend.mock.calls.map(c => (c[0] as { bcc: string[] }).bcc.length)).toEqual([50, 50, 20])
+    expect(res).toEqual({ sent: 120, failed: 0, error: null })
+  })
+
+  it('sends a single group untouched when under the cap', async () => {
+    const res = await sendAnnounce('key', 'from@x', params, recipients(10), opts)
+    expect(emailSend).toHaveBeenCalledTimes(1)
+    expect(res.sent).toBe(10)
+  })
+
+  it('continues past a failed group and reports partial delivery (not a total failure)', async () => {
+    emailSend
+      .mockResolvedValueOnce({ data: { id: 're_1' }, error: null }) // group 1 (50) ok
+      .mockRejectedValueOnce(new Error('Too many recipients')) // group 2 (50) fails
+      .mockResolvedValueOnce({ data: { id: 're_3' }, error: null }) // group 3 (20) ok
+    const res = await sendAnnounce('key', 'from@x', params, recipients(120), opts)
+    expect(res).toEqual({ sent: 70, failed: 50, error: 'Too many recipients' })
+  })
+
+  it('sends nothing for an empty recipient list', async () => {
+    const res = await sendAnnounce('key', 'from@x', params, [], opts)
+    expect(emailSend).not.toHaveBeenCalled()
+    expect(res).toEqual({ sent: 0, failed: 0, error: null })
+  })
+})

--- a/test/sendBatch.test.ts
+++ b/test/sendBatch.test.ts
@@ -8,12 +8,24 @@ vi.mock('resend', () => ({
   }
 }))
 
-const { sendBatch } = await import('../server/utils/email')
+const { sendBatch, chunk } = await import('../server/utils/email')
 
 const mail = (to: string) => ({ to, subject: 's', html: '<p>h</p>', text: 't' })
 
 beforeEach(() => {
   batchSend.mockReset()
+})
+
+describe('chunk', () => {
+  it('splits into fixed-size groups (last group may be smaller)', () => {
+    const items = Array.from({ length: 120 }, (_, i) => i)
+    const groups = chunk(items, 50)
+    expect(groups.map(g => g.length)).toEqual([50, 50, 20])
+  })
+  it('returns one group when under the size, and none when empty', () => {
+    expect(chunk([1, 2, 3], 50)).toEqual([[1, 2, 3]])
+    expect(chunk([], 50)).toEqual([])
+  })
 })
 
 describe('sendBatch', () => {


### PR DESCRIPTION
## Scope

Fixes the **502 when sending a comms blast**.

## Root cause

`server/api/events/announce.post.ts` BCC'd **every recipient in a single Resend send**.
Resend caps a send at **50 recipients** (to + cc + bcc) — so once the audience grew past 50,
Resend rejected the whole send and the route's `catch` threw a **502**. (The e-vite path
already chunks; this one didn't.)

## Fix

Split the recipients into BCC groups of 50 and send one email per group, with a 250ms gap
between sends (rate-limit friendly). Exported and unit-tested the existing `chunk` helper.

## How to Test

- Unit: `chunk` splits 120 → `[50, 50, 20]`, handles small/empty lists. `npm run build` ✅,
  `typecheck`, `lint` (0 errors), `vitest` green.
- Manual: send a blast to an audience > 50 → now delivers in 50-person BCC groups instead of 502.

## If it still fails after this

The remaining likely cause would be the **Resend sender domain not being verified**
(`NUXT_RESEND_FROM` → benteenscreenonthegreen.com). The error message is surfaced in the
composer toast and Vercel function logs — if it mentions the domain/sender, verify it in Resend.

## Invariants & Risk

- Server-only Resend key (Invariant 2) unchanged; admin-gated route unchanged. No schema change.