### PR TITLE
fix: chunk comms-blast BCC at 49 (re-land stranded fix)

### DIFF
--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -108,9 +108,12 @@ export function chunk<T>(items: readonly T[], size: number): T[][] {
   return out
 }
 
-// Resend caps a single send (to + cc + bcc) at 50 recipients — distinct from the
-// 100-per-request batch endpoint above, which is a different Resend API.
-const ANNOUNCE_RECIPIENT_LIMIT = 50
+// Resend caps a single send at 50 recipients across to + cc + bcc. We always set
+// one `to` (so real addresses stay BCC-hidden), which uses a slot — so only 49 BCC
+// fit per send. (50 BCC + the `to` = 51 → Resend rejects the whole group, which is
+// why a blast to >49 only delivered the final leftover group.) Distinct from the
+// 100-per-request batch endpoint above — that's a different Resend API.
+const ANNOUNCE_RECIPIENT_LIMIT = 49
 
 export interface SendAnnounceResult {
   /** Recipients in groups that sent successfully. */

--- a/test/sendAnnounce.test.ts
+++ b/test/sendAnnounce.test.ts
@@ -21,10 +21,14 @@ beforeEach(() => {
 })
 
 describe('sendAnnounce', () => {
-  it('BCCs recipients in groups of 50 — one send per group, not one giant send', async () => {
+  it('BCCs recipients in groups of 49 so every send stays within Resend\'s 50-recipient cap', async () => {
     const res = await sendAnnounce('key', 'from@x', params, recipients(120), opts)
     expect(emailSend).toHaveBeenCalledTimes(3)
-    expect(emailSend.mock.calls.map(c => (c[0] as { bcc: string[] }).bcc.length)).toEqual([50, 50, 20])
+    const sends = emailSend.mock.calls.map(c => c[0] as { to: string, bcc: string[] })
+    expect(sends.map(s => s.bcc.length)).toEqual([49, 49, 22])
+    // The `to` takes one slot, so to + bcc must never exceed 50 (the off-by-one that
+    // made full groups fail and only delivered the leftover).
+    for (const s of sends) expect(1 + s.bcc.length).toBeLessThanOrEqual(50)
     expect(res).toEqual({ sent: 120, failed: 0, error: null })
   })
 
@@ -36,11 +40,11 @@ describe('sendAnnounce', () => {
 
   it('continues past a failed group and reports partial delivery (not a total failure)', async () => {
     emailSend
-      .mockResolvedValueOnce({ data: { id: 're_1' }, error: null }) // group 1 (50) ok
-      .mockRejectedValueOnce(new Error('Too many recipients')) // group 2 (50) fails
-      .mockResolvedValueOnce({ data: { id: 're_3' }, error: null }) // group 3 (20) ok
+      .mockResolvedValueOnce({ data: { id: 're_1' }, error: null }) // group 1 (49) ok
+      .mockRejectedValueOnce(new Error('Too many recipients')) // group 2 (49) fails
+      .mockResolvedValueOnce({ data: { id: 're_3' }, error: null }) // group 3 (22) ok
     const res = await sendAnnounce('key', 'from@x', params, recipients(120), opts)
-    expect(res).toEqual({ sent: 70, failed: 50, error: 'Too many recipients' })
+    expect(res).toEqual({ sent: 71, failed: 49, error: 'Too many recipients' })
   })
 
   it('sends nothing for an empty recipient list', async () => {


### PR DESCRIPTION
## Scope

**Re-lands the actual fix for "the blast only sent to 14."**

## What happened

The 502 fix (#142) chunked the BCC at **50**. But Resend's 50-recipient cap counts `to + cc + bcc`,
and we always set one `to` (to keep addresses BCC-hidden) — so each full group was `50 BCC + 1 to =
51` → **rejected**, and only the final leftover group (the "14") fit under the cap. The real fix
(chunk at **49**) was committed but **pushed to the #142 branch after it had already merged**, so it
never reached `main` — it was stranded (same failure mode as the memory'd no-stacking rule). This
re-lands it cleanly (cherry-pick).

## Fix

`ANNOUNCE_RECIPIENT_LIMIT = 49`, so every send is `49 BCC + 1 to = 50` — exactly at the cap, never
over. All groups deliver. The test now asserts `to + bcc <= 50` for every send to guard the
off-by-one.

## How to Test

- Unit: 120 recipients → BCC groups `[49, 49, 22]`, each `≤ 50` total; partial-failure accounting
  updated. `npm run build`, `typecheck`, `vitest` green.
- Manual: send a blast to your full list → it reports the true total (e.g. "Sent to 64"), not 14.

## Risk

One-constant change + test. **Merge + redeploy to actually fix the blast.**