### PR TITLE
feat: manual "remind non-responders" button + copyable RSVP link

### DIFF
--- a/app/components/EventInviteManager.vue
+++ b/app/components/EventInviteManager.vue
@@ -10,7 +10,7 @@ import { INVITE_ACCENTS, INVITE_THEMES, type InviteAccent, type InviteOptions, t
 // and shows live RSVP / open / click tracking.
 const props = defineProps<{ eventId: string, event?: MovieEvent | null }>()
 const toast = useToast()
-const { invites, stats, addInvite, removeInvite, removeInvites, seedFromLastEvent, sendInvites } = useEventInvites(() => props.eventId)
+const { invites, stats, addInvite, removeInvite, removeInvites, seedFromLastEvent, sendInvites, remindNonResponders } = useEventInvites(() => props.eventId)
 const { save: saveInviteOptions } = useInviteOptions(() => props.eventId)
 const { setEnabled: setRemindersEnabled } = useEventReminders(() => props.eventId)
 
@@ -39,7 +39,42 @@ const newName = ref('')
 const sending = ref(false)
 const seeding = ref(false)
 const deleting = ref(false)
+const reminding = ref(false)
 const emailSchema = z.string().email()
+
+// People who were e-vited but haven't RSVP'd — the manual "remind now" audience.
+const remindable = computed(() => invites.value.filter(i => !i.rsvp && i.sent_at).length)
+
+async function onRemind(): Promise<void> {
+  reminding.value = true
+  try {
+    const { sent, failed, error } = await remindNonResponders()
+    if (sent && failed) {
+      toast.add({ title: `Reminded ${sent}, ${failed} failed`, description: error ?? undefined, icon: 'i-lucide-bell', color: 'warning' })
+    } else if (sent) {
+      toast.add({ title: `Reminded ${sent} ${sent === 1 ? 'person' : 'people'}`, icon: 'i-lucide-bell', color: 'success' })
+    } else if (failed) {
+      toast.add({ title: 'Could not send reminders', description: error ?? undefined, color: 'error' })
+    } else {
+      toast.add({ title: 'Everyone has already replied', color: 'neutral' })
+    }
+  } catch (error) {
+    toast.add({ title: 'Could not send reminders', description: error instanceof Error ? error.message : undefined, color: 'error' })
+  } finally {
+    reminding.value = false
+  }
+}
+
+// A link the admin can personally text/DM someone: it opens the one-click RSVP page.
+async function copyRsvpLink(invite: EventInvite): Promise<void> {
+  const url = `${location.origin}/rsvp?token=${invite.token}`
+  try {
+    await navigator.clipboard.writeText(url)
+    toast.add({ title: 'RSVP link copied', icon: 'i-lucide-check', color: 'success' })
+  } catch {
+    toast.add({ title: 'Copy failed — here it is', description: url, color: 'warning' })
+  }
+}
 
 // --- E-vite editor ---------------------------------------------------------
 const THEME_LABELS: Record<InviteTheme, string> = { marquee: 'Marquee', neon: 'Neon', classic: 'Classic' }
@@ -368,6 +403,16 @@ function statusBadge(invite: EventInvite): { label: string, color: 'success' | '
         :disabled="!unsent"
         @click="onSend"
       />
+      <UButton
+        :label="remindable ? `Remind ${remindable} non-responder${remindable === 1 ? '' : 's'}` : 'No one to remind'"
+        icon="i-lucide-bell"
+        color="neutral"
+        variant="outline"
+        size="sm"
+        :loading="reminding"
+        :disabled="!remindable"
+        @click="onRemind"
+      />
     </div>
 
     <!-- Per-event auto-reminder toggle -->
@@ -419,6 +464,15 @@ function statusBadge(invite: EventInvite): { label: string, color: 'success' | '
           </p>
         </div>
         <UBadge :label="statusBadge(invite).label" :color="statusBadge(invite).color" variant="subtle" size="sm" class="shrink-0" />
+        <UButton
+          icon="i-lucide-link"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          aria-label="Copy RSVP link"
+          class="shrink-0"
+          @click="copyRsvpLink(invite)"
+        />
         <UButton
           icon="i-lucide-x"
           color="neutral"

--- a/app/components/EventInviteManager.vue
+++ b/app/components/EventInviteManager.vue
@@ -230,6 +230,8 @@ function statusBadge(invite: EventInvite): { label: string, color: 'success' | '
   if (invite.rsvp === 'going') return { label: 'Going', color: 'success' }
   if (invite.rsvp === 'maybe') return { label: 'Maybe', color: 'warning' }
   if (invite.rsvp === 'no') return { label: 'Can\'t make it', color: 'neutral' }
+  // Nudged but still no reply — so admins can see who's been reminded (and not double-send).
+  if (invite.reminded_at) return { label: 'Reminded', color: 'info' }
   if (invite.clicked_at) return { label: 'Clicked', color: 'info' }
   if (invite.opened_at) return { label: 'Opened', color: 'info' }
   if (invite.sent_at) return { label: 'Sent', color: 'neutral' }

--- a/app/composables/useEventInvites.ts
+++ b/app/composables/useEventInvites.ts
@@ -139,6 +139,19 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
     return { sent: result.sent, failed: result.failed, error: result.error }
   }
 
+  /** Manually email everyone who was e-vited but hasn't RSVP'd yet, now (bypassing
+   *  the checkpoint schedule + throttle). Returns sent/failed + the first error. */
+  async function remindNonResponders(): Promise<{ sent: number, failed: number, error: string | null }> {
+    const id = toValue(eventId)
+    if (!id) return { sent: 0, failed: 0, error: null }
+    const result = await $fetch<{ ok: boolean, sent: number, failed: number, error: string | null }>(
+      `/api/events/${id}/reminders/send`,
+      { method: 'POST' }
+    )
+    await refresh()
+    return { sent: result.sent, failed: result.failed, error: result.error }
+  }
+
   // Live updates as RSVPs / opens land (event_invites is in the realtime publication).
   let channel: ReturnType<typeof supabase.channel> | null = null
   watch(() => toValue(eventId), (id) => {
@@ -160,5 +173,5 @@ export function useEventInvites(eventId: MaybeRefOrGetter<string | null>) {
     if (channel) supabase.removeChannel(channel)
   })
 
-  return { invites, pending, stats, refresh, addInvite, removeInvite, removeInvites, seedFromLastEvent, sendInvites }
+  return { invites, pending, stats, refresh, addInvite, removeInvite, removeInvites, seedFromLastEvent, sendInvites, remindNonResponders }
 }

--- a/server/api/crons/reminders.get.ts
+++ b/server/api/crons/reminders.get.ts
@@ -55,37 +55,23 @@ export default defineEventHandler(async (event) => {
 
   const origin = resolveOrigin(event)
   const appUrl = `${origin}/overview`
-  const stamp = now.toISOString()
   let totalSent = 0
 
   for (const d of due) {
-    const items = d.invites.map((inv) => {
-      const mail = buildEventReminderEmail({
-        eventTitle: d.eventTitle,
-        eventDate: formatEmailDate(d.eventDate) || null,
-        daysLeft: d.daysLeft,
-        rsvpUrl: `${origin}/rsvp?token=${inv.token}`,
-        appUrl
-      })
-      return { to: inv.email, subject: mail.subject, html: mail.html, text: mail.text }
+    const { sent } = await sendEventReminders(admin, {
+      apiKey: resendApiKey,
+      from: resendFrom,
+      eventTitle: d.eventTitle,
+      eventDate: formatEmailDate(d.eventDate) || null,
+      daysLeft: d.daysLeft,
+      origin,
+      appUrl,
+      invites: d.invites
     })
-
-    let ids: (string | null)[]
-    try {
-      ;({ ids } = await sendBatch(resendApiKey, resendFrom, items))
-    } catch (e) {
-      // A batch fails as a unit (e.g. an unverified sender). Leave reminded_at
-      // untouched so the next run retries; don't fail the whole cron.
-      console.error('[crons/reminders] batch failed -', e instanceof Error ? e.message : e)
-      continue
+    if (sent > 0) {
+      await admin.from('comms_log').insert({ event_id: d.eventId, kind: 'reminder', subject: `Reminder — ${d.eventTitle}`, recipient_count: sent })
+      totalSent += sent
     }
-
-    // Stamp + log only the invites that actually went out (got a Resend id).
-    const sentIds = d.invites.filter((_, i) => ids[i] != null).map(inv => inv.id)
-    if (!sentIds.length) continue
-    await admin.from('event_invites').update({ reminded_at: stamp }).in('id', sentIds)
-    await admin.from('comms_log').insert({ event_id: d.eventId, kind: 'reminder', subject: `Reminder — ${d.eventTitle}`, recipient_count: sentIds.length })
-    totalSent += sentIds.length
   }
 
   return { ok: true, events: due.length, sent: totalSent }

--- a/server/api/events/[id]/reminders/send.post.ts
+++ b/server/api/events/[id]/reminders/send.post.ts
@@ -1,0 +1,60 @@
+import { serverSupabaseClient } from '#supabase/server'
+import type { Database } from '~/types/database.types'
+
+/**
+ * Manual "remind non-responders now" — the admin-triggered counterpart to the
+ * daily reminder cron. Emails every invitee who was e-vited (`sent_at`) but hasn't
+ * RSVP'd (`rsvp` null) for this event, ignoring the checkpoint schedule + the
+ * throttle (the admin explicitly asked to send now). Admin-only, RLS-scoped.
+ */
+export default defineEventHandler(async (event) => {
+  const { user, userId } = await requireUser(event)
+
+  const eventId = getRouterParam(event, 'id')
+  if (!eventId) throw createError({ statusCode: 400, statusMessage: 'Missing event id' })
+
+  const db = await serverSupabaseClient<Database>(event)
+  await requireAdmin(db, userId)
+
+  const { data: ev } = await db.from('events').select('title, event_date').eq('id', eventId).single()
+  if (!ev) throw createError({ statusCode: 404, statusMessage: 'Event not found' })
+
+  const { data: invites, error: queueError } = await db
+    .from('event_invites')
+    .select('id, email, token')
+    .eq('event_id', eventId)
+    .is('rsvp', null)
+    .not('sent_at', 'is', null)
+  if (queueError) throw createError({ statusCode: 500, statusMessage: 'Could not load the guest list', data: { cause: queueError.message } })
+  const queue = invites ?? []
+  if (!queue.length) return { ok: true, sent: 0, failed: 0, error: null }
+
+  const { resendApiKey, resendFrom } = requireEmailConfig(event)
+  const origin = resolveOrigin(event)
+  const daysLeft = Math.max(0, daysUntil(new Date(), ev.event_date))
+
+  const { sent, failed, error } = await sendEventReminders(db, {
+    apiKey: resendApiKey,
+    from: resendFrom,
+    replyTo: user.email ?? undefined,
+    eventTitle: ev.title,
+    eventDate: ev.event_date ? formatEmailDate(ev.event_date) : null,
+    daysLeft,
+    origin,
+    appUrl: `${origin}/overview`,
+    invites: queue
+  })
+
+  if (sent > 0) {
+    const { error: logError } = await db.from('comms_log').insert({
+      event_id: eventId,
+      kind: 'reminder',
+      subject: `Reminder — ${ev.title}`,
+      recipient_count: sent,
+      sent_by: userId
+    })
+    if (logError) console.error('[events/reminders/send] comms_log insert failed -', logError.message)
+  }
+
+  return { ok: true, sent, failed, error }
+})

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -2,13 +2,14 @@ import { Resend } from 'resend'
 import type { H3Event } from 'h3'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '~/types/database.types'
+import { buildEventReminderEmail } from '../../shared/utils/email'
 
 // The email *builders* (subject/html/text) live in shared/utils/email.ts so the
 // admin UI can render a live preview with the exact same output. This server-only
 // module keeps the Resend send wrappers, the config/origin helpers its routes
-// share, and the e-vite batch orchestration (`sendEventInvites`). The API key must
-// never reach the client; only *types* are imported from supabase-js / the DB
-// types, so this file still loads outside the `#supabase/server` runtime.
+// share, and the batch orchestration (`sendEventInvites` / `sendEventReminders`).
+// The API key must never reach the client; the only value imported is a pure
+// builder from shared/utils, so this file still loads outside `#supabase/server`.
 
 // Resend's constructor just stores the key (it opens no connection), but a large
 // invite blast would otherwise build a fresh client per 100-recipient batch.
@@ -267,4 +268,73 @@ export async function sendEventInvites(
     }
   }
   return { sent, failed: failures.length, error: failures[0]?.error ?? null }
+}
+
+// ── Reminder sends (shared by the daily cron + the manual "remind now" route) ──
+
+/** One non-responder to nudge: the `event_invites` row id + their token link. */
+export interface ReminderRecipient {
+  readonly id: string
+  readonly email: string
+  readonly token: string
+}
+
+/**
+ * Sends the RSVP reminder to a list of non-responders for one event, in
+ * rate-limit-friendly batches, and stamps `reminded_at` on the ones that went
+ * out. Each reminder is a distinct one-click token email (like the e-vite), so it
+ * uses the batch endpoint, not a BCC. Returns sent/failed counts + the first
+ * error; the caller records the `comms_log` entry.
+ */
+export async function sendEventReminders(
+  db: SupabaseClient<Database>,
+  opts: {
+    readonly apiKey: string
+    readonly from: string
+    readonly replyTo?: string
+    readonly eventTitle: string
+    readonly eventDate: string | null // already formatted for the email body
+    readonly daysLeft: number
+    readonly origin: string
+    readonly appUrl: string
+    readonly invites: readonly ReminderRecipient[]
+    readonly batchSize?: number
+    readonly interBatchMs?: number
+  }
+): Promise<{ sent: number, failed: number, error: string | null }> {
+  const batchSize = opts.batchSize ?? INVITE_BATCH_SIZE
+  const interBatchMs = opts.interBatchMs ?? INVITE_INTER_BATCH_MS
+  const stamp = new Date().toISOString()
+  let sent = 0
+  let firstError: string | null = null
+  const batches = chunk(opts.invites, batchSize)
+  for (let b = 0; b < batches.length; b++) {
+    if (b > 0) await sleep(interBatchMs)
+    const group = batches[b]!
+    try {
+      const items = group.map((inv) => {
+        const mail = buildEventReminderEmail({
+          eventTitle: opts.eventTitle,
+          eventDate: opts.eventDate,
+          daysLeft: opts.daysLeft,
+          rsvpUrl: `${opts.origin}/rsvp?token=${inv.token}`,
+          appUrl: opts.appUrl
+        })
+        return { to: inv.email, subject: mail.subject, html: mail.html, text: mail.text, replyTo: opts.replyTo }
+      })
+      const { ids } = await sendBatch(opts.apiKey, opts.from, items)
+      // Stamp only the ones Resend accepted, so a failed batch retries next time.
+      const sentIds = group.filter((_, i) => ids[i] != null).map(inv => inv.id)
+      if (sentIds.length) {
+        const { error: stampError } = await db.from('event_invites').update({ reminded_at: stamp }).in('id', sentIds)
+        if (stampError) console.warn('[reminders] reminded_at stamp failed -', stampError.message)
+      }
+      sent += sentIds.length
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Unknown error'
+      if (!firstError) firstError = message
+      console.error('[reminders] batch failed -', message)
+    }
+  }
+  return { sent, failed: opts.invites.length - sent, error: firstError }
 }

--- a/shared/types/event-invite.ts
+++ b/shared/types/event-invite.ts
@@ -17,6 +17,7 @@ export interface EventInvite {
   opened_at: string | null
   clicked_at: string | null
   bounced_at: string | null
+  reminded_at: string | null
   created_at: string
 }
 

--- a/test/EventInviteManager.nuxt.test.ts
+++ b/test/EventInviteManager.nuxt.test.ts
@@ -71,6 +71,8 @@ beforeEach(() => {
   toasts.length = 0
   sendFn.mockReset()
   sendFn.mockResolvedValue({ sent: 0, failed: 0, error: null })
+  remindFn.mockReset()
+  remindFn.mockResolvedValue({ sent: 0, failed: 0, error: null })
 })
 
 describe('EventInviteManager', () => {
@@ -187,17 +189,33 @@ describe('EventInviteManager', () => {
     expect(toasts.at(-1)?.title).toContain('saved')
   })
 
-  it('manually reminds non-responders on click', async () => {
+  // Mount with one e-vited, non-responding guest (rsvp null + sent_at) so the
+  // remind button is enabled, click it, then restore the shared fixture.
+  async function clickRemind(): Promise<void> {
     const prev = invites.value
-    // One e-vited, non-responding guest (rsvp null + sent_at set) → remindable.
     invites.value = [{ ...prev[1]!, rsvp: null, sent_at: 't' }]
-    remindFn.mockClear()
-    remindFn.mockResolvedValueOnce({ sent: 1, failed: 0, error: null })
     const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e', event: eventObj } })
     await w.findAll('button').find(b => b.text().includes('Remind'))!.trigger('click')
     await flushPromises()
-    expect(remindFn).toHaveBeenCalled()
-    expect(toasts.at(-1)?.title).toContain('Reminded 1')
     invites.value = prev
+  }
+
+  it('reports a successful manual reminder', async () => {
+    remindFn.mockResolvedValueOnce({ sent: 1, failed: 0, error: null })
+    await clickRemind()
+    expect(remindFn).toHaveBeenCalled()
+    expect(toasts.at(-1)).toMatchObject({ title: 'Reminded 1 person', color: 'success' })
+  })
+
+  it('reports a partial manual reminder (some sent, some failed) with the reason', async () => {
+    remindFn.mockResolvedValueOnce({ sent: 2, failed: 1, error: 'Unverified domain' })
+    await clickRemind()
+    expect(toasts.at(-1)).toMatchObject({ title: 'Reminded 2, 1 failed', description: 'Unverified domain', color: 'warning' })
+  })
+
+  it('reports an all-failed manual reminder as an error with the reason', async () => {
+    remindFn.mockResolvedValueOnce({ sent: 0, failed: 2, error: 'Unverified domain' })
+    await clickRemind()
+    expect(toasts.at(-1)).toMatchObject({ title: 'Could not send reminders', description: 'Unverified domain', color: 'error' })
   })
 })

--- a/test/EventInviteManager.nuxt.test.ts
+++ b/test/EventInviteManager.nuxt.test.ts
@@ -13,6 +13,7 @@ const invites = ref([
   { id: 'b', event_id: 'e', email: 'sam@x.com', display_name: 'Sam', token: '2', rsvp: null, rsvp_at: null, invited_by: null, resend_id: null, sent_at: null, delivered_at: null, opened_at: null, clicked_at: null, bounced_at: null, created_at: '' }
 ])
 const sendFn = vi.fn<() => Promise<SendResult>>(async () => ({ sent: 0, failed: 0, error: null }))
+const remindFn = vi.fn<() => Promise<SendResult>>(async () => ({ sent: 0, failed: 0, error: null }))
 const removeMany = vi.fn(async () => {})
 const seedFn = vi.fn(async () => 0)
 const saveOptionsFn = vi.fn(async () => {})
@@ -41,7 +42,8 @@ mockNuxtImport('useEventInvites', () => () => ({
   removeInvite: async () => {},
   removeInvites: removeMany,
   seedFromLastEvent: seedFn,
-  sendInvites: sendFn
+  sendInvites: sendFn,
+  remindNonResponders: remindFn
 }))
 mockNuxtImport('useToast', () => () => ({ add: (t: Toast) => toasts.push(t) }))
 mockNuxtImport('useInviteOptions', () => () => ({ save: saveOptionsFn }))
@@ -183,5 +185,19 @@ describe('EventInviteManager', () => {
     await flushPromises()
     expect(saveOptionsFn).toHaveBeenCalledTimes(1)
     expect(toasts.at(-1)?.title).toContain('saved')
+  })
+
+  it('manually reminds non-responders on click', async () => {
+    const prev = invites.value
+    // One e-vited, non-responding guest (rsvp null + sent_at set) → remindable.
+    invites.value = [{ ...prev[1]!, rsvp: null, sent_at: 't' }]
+    remindFn.mockClear()
+    remindFn.mockResolvedValueOnce({ sent: 1, failed: 0, error: null })
+    const w = await mountSuspended(EventInviteManager, { props: { eventId: 'e', event: eventObj } })
+    await w.findAll('button').find(b => b.text().includes('Remind'))!.trigger('click')
+    await flushPromises()
+    expect(remindFn).toHaveBeenCalled()
+    expect(toasts.at(-1)?.title).toContain('Reminded 1')
+    invites.value = prev
   })
 })

--- a/test/sendEventReminders.test.ts
+++ b/test/sendEventReminders.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock Resend's batch endpoint (each reminder is a distinct token email → sendBatch).
+const { batchSend } = vi.hoisted(() => ({ batchSend: vi.fn() }))
+vi.mock('resend', () => ({
+  Resend: class {
+    batch = { send: batchSend }
+  }
+}))
+
+const { sendEventReminders } = await import('../server/utils/email')
+
+// Minimal db stub recording the reminded_at stamps.
+const updates: Array<{ patch: Record<string, unknown>, ids: string[] }> = []
+const db = {
+  from() {
+    return {
+      update: (patch: Record<string, unknown>) => ({
+        in: (_col: string, ids: string[]) => {
+          updates.push({ patch, ids })
+          return Promise.resolve({ error: null })
+        }
+      })
+    }
+  }
+} as never
+
+const invite = (id: string): { id: string, email: string, token: string } => ({ id, email: `${id}@x.com`, token: `tok-${id}` })
+const baseOpts = {
+  apiKey: 'key', from: 'from@x', eventTitle: 'Movie Night', eventDate: 'Friday',
+  daysLeft: 3, origin: 'https://x', appUrl: 'https://x/overview', interBatchMs: 0
+}
+
+beforeEach(() => {
+  batchSend.mockReset()
+  updates.length = 0
+})
+
+describe('sendEventReminders', () => {
+  it('sends a distinct token reminder per invite and stamps reminded_at on the ones sent', async () => {
+    batchSend.mockResolvedValue({ data: { data: [{ id: 're_1' }, { id: 're_2' }] }, error: null })
+    const res = await sendEventReminders(db, { ...baseOpts, invites: [invite('a'), invite('b')] })
+    expect(batchSend).toHaveBeenCalledTimes(1)
+    const items = batchSend.mock.calls[0]![0] as Array<{ to: string, html: string }>
+    expect(items[0]!.to).toBe('a@x.com')
+    expect(items[0]!.html).toContain('https://x/rsvp?token=tok-a')
+    expect(updates).toEqual([{ patch: expect.objectContaining({ reminded_at: expect.any(String) }), ids: ['a', 'b'] }])
+    expect(res).toEqual({ sent: 2, failed: 0, error: null })
+  })
+
+  it('only stamps invites Resend accepted (a null id = not sent)', async () => {
+    batchSend.mockResolvedValue({ data: { data: [{ id: 're_1' }, null] }, error: null })
+    const res = await sendEventReminders(db, { ...baseOpts, invites: [invite('a'), invite('b')] })
+    expect(updates[0]!.ids).toEqual(['a'])
+    expect(res).toEqual({ sent: 1, failed: 1, error: null })
+  })
+
+  it('reports a failed batch without stamping, and keeps going', async () => {
+    batchSend.mockRejectedValue(new Error('Unverified domain'))
+    const res = await sendEventReminders(db, { ...baseOpts, invites: [invite('a')] })
+    expect(updates).toHaveLength(0)
+    expect(res).toEqual({ sent: 0, failed: 1, error: 'Unverified domain' })
+  })
+
+  it('does nothing when there are no non-responders', async () => {
+    const res = await sendEventReminders(db, { ...baseOpts, invites: [] })
+    expect(batchSend).not.toHaveBeenCalled()
+    expect(res).toEqual({ sent: 0, failed: 0, error: null })
+  })
+})


### PR DESCRIPTION
## Scope

Two admin conveniences on the e-vite manager (the "we need a button" ask + the lightweight
half of the "textable link" idea):

- **"Remind N non-responders" button** — email everyone who was e-vited but hasn't RSVP'd, **now**,
  bypassing the checkpoint schedule + throttle. The admin-triggered counterpart to the daily cron.
- **Copy RSVP link** per guest — a link the admin can personally text/DM someone; it opens the
  existing one-click RSVP page (their token).

## Implementation

1. **`refactor`** — extract `sendEventReminders` from the cron into a testable `email.ts` helper
   (batches, stamps `reminded_at` on the ones Resend accepted, returns `{ sent, failed, error }`).
   The cron now calls it — DRY, and it adds send-path coverage the cron lacked.
2. **`feat`** — admin-only `POST /api/events/[id]/reminders/send` (RLS-scoped) reminds the
   non-responders (`rsvp` null + `sent_at` set), logs `comms_log`. `useEventInvites.remindNonResponders`.
3. **`feat`** — the button (with sent/failed toasts) + the per-guest copy-link button.

## How to Test

- Unit: `sendEventReminders` (distinct token email per invite, stamps only sent ones, partial-failure
  accounting, empty list); `EventInviteManager` remind-button click. `npm run build`, `typecheck`,
  `lint` (0 errors), `vitest` (436) green.
- Manual: Admin → Invites → **Remind N non-responders** emails the pending guests now; the 🔗 on a
  guest copies their RSVP link to paste into a text.

## Invariants & Risk

- Admin-gated route, server-only Resend key (Invariant 2). Reminder emails use the shared escaped
  builder (Invariant 5). At-least-once send (documented on `sendEventReminders`) — a re-click
  re-emails, but `reminded_at` is stamped so the cron won't pile on.

## Not in this PR — the bigger "SMS / phone" idea (need your steer)

Your message also floated real texting + phone capture + a general join link. Those are a real fork
I didn't want to guess on — see my message for the options.