### PR TITLE
fix(ci): skip Claude review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,8 +18,10 @@ concurrency:
 
 jobs:
   review:
-    # Skip draft PRs.
-    if: github.event.pull_request.draft == false
+    # Skip drafts, and Dependabot PRs (GitHub withholds secrets from Dependabot,
+    # so the Claude action can't auth and the check just fails — a dep bump doesn't
+    # need an AI review anyway).
+    if: github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Scope

Fixes the red CI on every Dependabot PR. Two independent causes:

### 1. `review` fails — secrets withheld from Dependabot (this PR fixes)
`claude-code-review.yml` runs on every PR and needs `secrets.ANTHROPIC_API_KEY`. GitHub
**does not expose Actions secrets to Dependabot-triggered PRs** (a supply-chain safeguard), so
the Claude action can't authenticate and the check fails in seconds. Guarded the job with
`github.actor != 'dependabot[bot]'` — a dependency bump doesn't need an AI review.

### 2. `verify` fails — stale lockfile (already fixed on main, no code here)
`npm ci` errored `Missing: cac / commander / crossws from lock file` — `package-lock.json` was
out of sync with `package.json` (strict `npm ci` fails; lenient `npm install`/Vercel auto-fix,
which is why local + deploys were fine). This was **fixed on main by release 1.16.2 (#154) on
2026-07-04**; the open Dependabot PRs (#149–#151) ran on 2026-07-02 against the broken main, so
they carry the stale lock. **Rebasing them picks up the fix** — I'm triggering `@dependabot rebase`
on each.

## How to Test

- After merge, Dependabot PRs: `review` is skipped (green), and once rebased, `verify` runs
  `npm ci` cleanly against the synced lock.
- No app code changed.