### PR TITLE
Event weather fix, admin reminder digest + audit log, and top-3 lock-in at any time

### DIFF
--- a/server/api/crons/reminders.get.ts
+++ b/server/api/crons/reminders.get.ts
@@ -56,13 +56,15 @@ export default defineEventHandler(async (event) => {
   const origin = resolveOrigin(event)
   const appUrl = `${origin}/overview`
   let totalSent = 0
+  const digest: AdminReminderDigestItem[] = []
 
   for (const d of due) {
+    const eventDate = formatEmailDate(d.eventDate) || null
     const { sent } = await sendEventReminders(admin, {
       apiKey: resendApiKey,
       from: resendFrom,
       eventTitle: d.eventTitle,
-      eventDate: formatEmailDate(d.eventDate) || null,
+      eventDate,
       daysLeft: d.daysLeft,
       origin,
       appUrl,
@@ -71,8 +73,26 @@ export default defineEventHandler(async (event) => {
     if (sent > 0) {
       await admin.from('comms_log').insert({ event_id: d.eventId, kind: 'reminder', subject: `Reminder — ${d.eventTitle}`, recipient_count: sent })
       totalSent += sent
+      digest.push({ eventTitle: d.eventTitle, eventDate, daysLeft: d.daysLeft, remindedCount: sent })
     }
   }
 
-  return { ok: true, events: due.length, sent: totalSent }
+  // Notify admins of the automated send they don't otherwise see. Best-effort:
+  // the reminders already went out, so a digest failure must not fail the cron.
+  let notified = 0
+  if (totalSent > 0) {
+    try {
+      ;({ notified } = await sendAdminReminderDigest(admin, {
+        apiKey: resendApiKey,
+        from: resendFrom,
+        items: digest,
+        totalReminded: totalSent,
+        adminUrl: `${origin}/admin`
+      }))
+    } catch (e) {
+      console.error('[crons/reminders] admin digest failed -', e instanceof Error ? e.message : e)
+    }
+  }
+
+  return { ok: true, events: due.length, sent: totalSent, adminsNotified: notified }
 })

--- a/server/api/weather.get.ts
+++ b/server/api/weather.get.ts
@@ -28,10 +28,16 @@ export default defineEventHandler(async (event): Promise<Forecast> => {
   if (!withinForecastWindow(date, new Date())) return UNAVAILABLE
 
   try {
-    const geo = await $fetch<GeoResponse>('https://geocoding-api.open-meteo.com/v1/search', {
-      query: { name: location, count: 1, language: 'en', format: 'json' }
-    })
-    const place = geo.results?.[0]
+    // Open-Meteo's geocoder only resolves place names, so try the full location
+    // then progressively simpler segments (see geocodeCandidates) until one hits.
+    let place: { latitude: number, longitude: number, name: string } | undefined
+    for (const candidate of geocodeCandidates(location)) {
+      const geo = await $fetch<GeoResponse>('https://geocoding-api.open-meteo.com/v1/search', {
+        query: { name: candidate, count: 1, language: 'en', format: 'json' }
+      })
+      place = geo.results?.[0]
+      if (place) break
+    }
     if (!place) return UNAVAILABLE
 
     const fc = await $fetch<ForecastResponse>('https://api.open-meteo.com/v1/forecast', {

--- a/server/utils/email.ts
+++ b/server/utils/email.ts
@@ -2,7 +2,7 @@ import { Resend } from 'resend'
 import type { H3Event } from 'h3'
 import type { SupabaseClient } from '@supabase/supabase-js'
 import type { Database } from '~/types/database.types'
-import { buildEventReminderEmail } from '../../shared/utils/email'
+import { type AdminReminderDigestItem, buildAdminReminderDigestEmail, buildEventReminderEmail, uniqueEmails } from '../../shared/utils/email'
 
 // The email *builders* (subject/html/text) live in shared/utils/email.ts so the
 // admin UI can render a live preview with the exact same output. This server-only
@@ -271,6 +271,43 @@ export async function sendEventInvites(
     }
   }
   return { sent, failed: failures.length, error: failures[0]?.error ?? null }
+}
+
+/**
+ * Emails a run summary to every admin after the daily reminder cron sends nudges,
+ * so admins see the automated sends they never trigger by hand. Admins are BCC'd
+ * (a required `to` uses the sender address, keeping admin addresses hidden from one
+ * another). Returns how many admins were notified; sends nothing when there are no
+ * admin emails. The caller runs this best-effort — the reminders already went out,
+ * so a digest failure must not fail the cron.
+ */
+export async function sendAdminReminderDigest(
+  db: SupabaseClient<Database>,
+  opts: {
+    readonly apiKey: string
+    readonly from: string
+    readonly items: readonly AdminReminderDigestItem[]
+    readonly totalReminded: number
+    readonly adminUrl: string
+  }
+): Promise<{ notified: number }> {
+  const { data: admins } = await db.from('profiles').select('email').eq('is_admin', true)
+  const recipients = uniqueEmails((admins ?? []).map(a => a.email))
+  if (!recipients.length) return { notified: 0 }
+
+  const mail = buildAdminReminderDigestEmail({
+    items: opts.items,
+    totalReminded: opts.totalReminded,
+    adminUrl: opts.adminUrl
+  })
+  await sendEmail(opts.apiKey, opts.from, {
+    to: opts.from, // a `to` is required; admins are BCC'd so addresses stay hidden
+    bcc: recipients,
+    subject: mail.subject,
+    html: mail.html,
+    text: mail.text
+  })
+  return { notified: recipients.length }
 }
 
 // ── Reminder sends (shared by the daily cron + the manual "remind now" route) ──

--- a/shared/utils/email.ts
+++ b/shared/utils/email.ts
@@ -140,6 +140,65 @@ export function buildEventReminderEmail(opts: {
   return { subject, html, text }
 }
 
+/** One event's line in the admin reminder digest. `eventDate` is already
+ *  formatted (or null); `remindedCount` is how many non-responders were nudged. */
+export interface AdminReminderDigestItem {
+  readonly eventTitle: string
+  readonly eventDate: string | null
+  readonly daysLeft: number
+  readonly remindedCount: number
+}
+
+/** How far out an event is, in the digest's words. */
+function daysLeftPhrase(daysLeft: number): string {
+  if (daysLeft <= 0) return 'today'
+  if (daysLeft === 1) return 'tomorrow'
+  return `in ${daysLeft} days`
+}
+
+/**
+ * Admin-facing digest sent after the daily reminder cron nudges non-responders —
+ * one summary per run so admins can see the automated sends they never trigger by
+ * hand. Lists each event reminded and how many people it reached.
+ */
+export function buildAdminReminderDigestEmail(opts: {
+  items: readonly AdminReminderDigestItem[]
+  totalReminded: number
+  adminUrl: string
+}): BuiltEmail {
+  const people = opts.totalReminded === 1 ? 'person' : 'people'
+  const events = opts.items.length === 1 ? 'event' : 'events'
+  const subject = `Movie night reminders sent — ${opts.totalReminded} ${people} nudged`
+
+  const rowsHtml = opts.items
+    .map((it) => {
+      const date = it.eventDate ? ` &middot; ${escapeHtml(it.eventDate)}` : ''
+      const n = it.remindedCount === 1 ? 'person' : 'people'
+      return `<li style="margin:0 0 8px"><strong>${escapeHtml(it.eventTitle)}</strong>${date}`
+        + ` — reminded ${it.remindedCount} ${n} (${daysLeftPhrase(it.daysLeft)})</li>`
+    })
+    .join('')
+  const html = shell(
+    `<h1 style="font-size:20px;margin:0 0 12px">RSVP reminders went out 🎬</h1>`
+    + `<p>Today's reminder nudged <strong>${opts.totalReminded} ${people}</strong> who hadn't RSVP'd yet, across ${opts.items.length} ${events}:</p>`
+    + `<ul style="padding-left:20px;margin:0 0 16px">${rowsHtml}</ul>`
+    + `<p style="margin:20px 0">${ctaButton('Open the admin dashboard', opts.adminUrl)}</p>`
+    + `<p style="font-size:13px;color:#6b7280">You're getting this because you're an admin of Benteen Screen On The Green.</p>`
+  )
+
+  const rowsText = opts.items
+    .map((it) => {
+      const date = it.eventDate ? ` (${it.eventDate})` : ''
+      return `- ${it.eventTitle}${date} — reminded ${it.remindedCount} (${daysLeftPhrase(it.daysLeft)})`
+    })
+    .join('\n')
+  const text = `RSVP reminders went out.`
+    + `\n\nNudged ${opts.totalReminded} ${people} across ${opts.items.length} ${events}:\n${rowsText}`
+    + `\n\nAdmin dashboard: ${opts.adminUrl}`
+
+  return { subject, html, text }
+}
+
 // ---- Themeable per-event e-vite -------------------------------------------
 
 interface Palette {

--- a/shared/utils/weather.ts
+++ b/shared/utils/weather.ts
@@ -17,6 +17,32 @@ export function describeWeather(code: number): WeatherDescription {
   return { label: 'Thunderstorm', icon: 'i-lucide-cloud-lightning' }
 }
 
+/**
+ * Open-Meteo's geocoder resolves place *names*, not street addresses — the whole
+ * free-text location ("1900 Lakewood Ave SE, Atlanta, GA", "Benteen Park, Atlanta")
+ * usually returns no match, which is why the card's weather silently blanks out.
+ * Derive fallback candidates to try in order: the full string first, then each
+ * comma-separated segment left-to-right. Left-to-right keeps the most specific
+ * hit — a park/venue name beats the city, the city beats the state/ZIP — and the
+ * caller stops at the first that geocodes. Capped so a long address can't fan out
+ * into many upstream requests. Deduped case-insensitively.
+ */
+export function geocodeCandidates(location: string, limit = 4): string[] {
+  const seen = new Set<string>()
+  const candidates: string[] = []
+  const push = (value: string): void => {
+    const trimmed = value.trim()
+    const key = trimmed.toLowerCase()
+    if (trimmed && !seen.has(key) && candidates.length < limit) {
+      seen.add(key)
+      candidates.push(trimmed)
+    }
+  }
+  push(location)
+  for (const segment of location.split(',')) push(segment)
+  return candidates
+}
+
 /** Whole days from `now` until the event date (negative = past). */
 export function forecastDaysAway(eventDate: string, now: Date): number | null {
   const target = new Date(`${eventDate.slice(0, 10)}T00:00:00Z`)

--- a/test/email.test.ts
+++ b/test/email.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { InviteOptions } from '../shared/types/invite-options'
 import {
+  buildAdminReminderDigestEmail,
   buildAnnounceEmail,
   buildEventInviteEmail,
   buildEventReminderEmail,
@@ -103,6 +104,58 @@ describe('buildEventInviteEmail', () => {
     const m = buildEventInviteEmail({ eventTitle: 'Jaws', eventDate: null, inviterName: null, rsvpUrl: 'https://x/rsvp?token=abc', appUrl: 'https://x/overview', options: opts({}) })
     expect(m.html).toContain('https://x/overview')
     expect(m.text).toContain('https://x/overview')
+  })
+})
+
+describe('buildAdminReminderDigestEmail', () => {
+  const items = [
+    { eventTitle: 'Jaws', eventDate: 'Friday, July 17, 2026', daysLeft: 3, remindedCount: 4 },
+    { eventTitle: 'The Thing', eventDate: null, daysLeft: 1, remindedCount: 1 }
+  ]
+
+  it('summarizes the run in the subject with correct pluralization', () => {
+    const m = buildAdminReminderDigestEmail({ items, totalReminded: 5, adminUrl: 'https://x/admin' })
+    expect(m.subject).toBe('Movie night reminders sent — 5 people nudged')
+  })
+
+  it('says "person" (singular) when exactly one was nudged', () => {
+    const single = [{ eventTitle: 'Jaws', eventDate: null, daysLeft: 2, remindedCount: 1 }]
+    const m = buildAdminReminderDigestEmail({ items: single, totalReminded: 1, adminUrl: 'https://x/admin' })
+    expect(m.subject).toBe('Movie night reminders sent — 1 person nudged')
+  })
+
+  it('lists each event, its count, and how far out it is', () => {
+    const m = buildAdminReminderDigestEmail({ items, totalReminded: 5, adminUrl: 'https://x/admin' })
+    expect(m.html).toContain('Jaws')
+    expect(m.html).toContain('reminded 4 people (in 3 days)')
+    expect(m.html).toContain('reminded 1 person (tomorrow)')
+    expect(m.text).toContain('- Jaws (Friday, July 17, 2026) — reminded 4 (in 3 days)')
+    expect(m.text).toContain('- The Thing — reminded 1 (tomorrow)')
+  })
+
+  it('links to the admin dashboard', () => {
+    const m = buildAdminReminderDigestEmail({ items, totalReminded: 5, adminUrl: 'https://x/admin' })
+    expect(m.html).toContain('https://x/admin')
+    expect(m.text).toContain('https://x/admin')
+  })
+
+  it('escapes an event title so a crafted title cannot inject HTML', () => {
+    const m = buildAdminReminderDigestEmail({
+      items: [{ eventTitle: '<script>alert(1)</script>', eventDate: null, daysLeft: 0, remindedCount: 2 }],
+      totalReminded: 2,
+      adminUrl: 'https://x/admin'
+    })
+    expect(m.html).not.toContain('<script>')
+    expect(m.html).toContain('&lt;script&gt;')
+  })
+
+  it('says "today" for a same-day event', () => {
+    const m = buildAdminReminderDigestEmail({
+      items: [{ eventTitle: 'Alien', eventDate: null, daysLeft: 0, remindedCount: 2 }],
+      totalReminded: 2,
+      adminUrl: 'https://x/admin'
+    })
+    expect(m.html).toContain('(today)')
   })
 })
 

--- a/test/sendAdminReminderDigest.test.ts
+++ b/test/sendAdminReminderDigest.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock Resend's single-send endpoint — the digest is one BCC email to the admins.
+const { emailsSend } = vi.hoisted(() => ({ emailsSend: vi.fn() }))
+vi.mock('resend', () => ({
+  Resend: class {
+    emails = { send: emailsSend }
+  }
+}))
+
+const { sendAdminReminderDigest } = await import('../server/utils/email')
+
+// Minimal db stub: profiles.select('email').eq('is_admin', true) resolves to `adminRows`.
+let adminRows: Array<{ email: string | null }> = []
+const db = {
+  from() {
+    return {
+      select: () => ({
+        eq: (_col: string, _val: unknown) => Promise.resolve({ data: adminRows, error: null })
+      })
+    }
+  }
+} as never
+
+const baseOpts = {
+  apiKey: 'key',
+  from: 'movienight@x',
+  items: [{ eventTitle: 'Jaws', eventDate: 'Friday', daysLeft: 3, remindedCount: 4 }],
+  totalReminded: 4,
+  adminUrl: 'https://x/admin'
+}
+
+beforeEach(() => {
+  emailsSend.mockReset()
+  emailsSend.mockResolvedValue({ data: { id: 're_1' }, error: null })
+  adminRows = []
+})
+
+describe('sendAdminReminderDigest', () => {
+  it('BCCs every admin with the run summary, hiding addresses behind the sender', async () => {
+    adminRows = [{ email: 'a@x.com' }, { email: 'b@x.com' }]
+    const res = await sendAdminReminderDigest(db, baseOpts)
+
+    expect(emailsSend).toHaveBeenCalledTimes(1)
+    const sent = emailsSend.mock.calls[0]![0] as { to: string, bcc: string[], subject: string }
+    expect(sent.to).toBe('movienight@x') // real recipients stay in BCC
+    expect(sent.bcc).toEqual(['a@x.com', 'b@x.com'])
+    expect(sent.subject).toContain('4 people nudged')
+    expect(res).toEqual({ notified: 2 })
+  })
+
+  it('de-duplicates and normalizes admin emails before sending', async () => {
+    adminRows = [{ email: 'A@x.com' }, { email: 'a@x.com' }, { email: null }]
+    const res = await sendAdminReminderDigest(db, baseOpts)
+    const sent = emailsSend.mock.calls[0]![0] as { bcc: string[] }
+    expect(sent.bcc).toEqual(['a@x.com'])
+    expect(res).toEqual({ notified: 1 })
+  })
+
+  it('sends nothing when there are no admins', async () => {
+    adminRows = []
+    const res = await sendAdminReminderDigest(db, baseOpts)
+    expect(emailsSend).not.toHaveBeenCalled()
+    expect(res).toEqual({ notified: 0 })
+  })
+})

--- a/test/weather.test.ts
+++ b/test/weather.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { describeWeather, forecastDaysAway, withinForecastWindow } from '../shared/utils/weather'
+import { describeWeather, forecastDaysAway, geocodeCandidates, withinForecastWindow } from '../shared/utils/weather'
 
 describe('describeWeather', () => {
   it('maps representative WMO codes to labels', () => {
@@ -15,6 +15,46 @@ describe('describeWeather', () => {
     for (const code of [0, 2, 45, 61, 71, 82, 95]) {
       expect(describeWeather(code).icon).toMatch(/^i-lucide-/)
     }
+  })
+})
+
+describe('geocodeCandidates', () => {
+  it('tries the full location first, then each comma segment left-to-right', () => {
+    expect(geocodeCandidates('Benteen Park, Atlanta, GA')).toEqual([
+      'Benteen Park, Atlanta, GA',
+      'Benteen Park',
+      'Atlanta',
+      'GA'
+    ])
+  })
+
+  it('trims whitespace around each segment', () => {
+    expect(geocodeCandidates('1900 Lakewood Ave SE ,  Atlanta ')).toEqual([
+      '1900 Lakewood Ave SE ,  Atlanta',
+      '1900 Lakewood Ave SE',
+      'Atlanta'
+    ])
+  })
+
+  it('returns a single candidate when there are no commas', () => {
+    expect(geocodeCandidates('Atlanta')).toEqual(['Atlanta'])
+  })
+
+  it('dedupes segments case-insensitively so a place is not queried twice', () => {
+    // Both segments collapse to one candidate; only the full string differs.
+    expect(geocodeCandidates('Atlanta, ATLANTA')).toEqual(['Atlanta, ATLANTA', 'Atlanta'])
+  })
+
+  it('caps the number of candidates so a long address cannot fan out', () => {
+    expect(geocodeCandidates('a, b, c, d, e, f')).toEqual(['a, b, c, d, e, f', 'a', 'b', 'c'])
+  })
+
+  it('ignores empty segments from trailing or doubled commas', () => {
+    expect(geocodeCandidates('Benteen Park, Atlanta,')).toEqual([
+      'Benteen Park, Atlanta,',
+      'Benteen Park',
+      'Atlanta'
+    ])
   })
 })
 


### PR DESCRIPTION
## Scope

Four related event/reminder improvements:

1. **Weather was blank on the event card.** The card geocodes the event's free-text `location` through Open-Meteo, whose geocoder only resolves *bare place names*. `"Benteen Park"` resolves, but `"Benteen Park, Atlanta"` or any street address returns **no match** → the forecast came back unavailable and the weather line silently rendered nothing.

2. **Admins got no signal when automated reminders went out.** The daily RSVP-reminder cron emailed non-responders but nothing reached admins. Adds an admin digest after each cron run that sends nudges.

3. **A top-3 pick got knocked off the ballot when its author un-RSVP'd.** The lock-in that protects strong contenders only applied inside a 7-day window, so a #2 movie weeks out was hidden the moment its suggester left "going". Now a top-3 pick is protected at any time.

4. **No auditable record of automated reminders + their outcome.** The comms log recorded a bare recipient count with no success/failure status, silently mislabeled reminders as "announcements", and logged *nothing* when a run failed outright. Now every reminder run is logged with a Sent/Partial/Failed status, failed count, and error.

## Implementation

**Weather (`fix:`)**
- New pure helper `geocodeCandidates(location)` in `shared/utils/weather.ts`: full string first, then each comma-separated segment **left-to-right** (most specific first), deduped and capped. `server/api/weather.get.ts` walks the candidates and takes the first that geocodes — a park/venue name beats the city, the city beats the state/ZIP, and it avoids junk (lands on `Atlanta` before a bogus `GA` → "Gah, Maluku").

**Admin reminder digest (`feat:`)**
- Pure builder `buildAdminReminderDigestEmail()` (`shared/utils/email.ts`) + server wrapper `sendAdminReminderDigest()` (`server/utils/email.ts`): after a cron run that sent ≥1 reminder, BCC every `profiles.is_admin` a run summary (event list, counts, dashboard CTA). Event titles are escaped. Best-effort — a digest failure is logged, not fatal; the cron response reports `adminsNotified`.
- Defaults (easy to change): automated cron only, all admins, no on/off toggle.

**Top-3 lock-in at any time (`feat:`)**
- Migration `20260707000000_lockin_top3_any_time.sql` redefines `public.is_locked_in(sid)` to drop the `event_date <= now() + 7 days` gate. A suggestion is locked in purely on rank: **top 3 by live votes, ≥1 vote**, regardless of event distance. The ≥1-vote floor stays (a zero-vote suggestion can still be hidden on un-RSVP). Leave-confirmation copy in `overview.vue` reworded.

**Reminder audit log + status (`feat:`)**
- Migration `20260708000000_comms_log_status.sql` adds `status` (`sent`/`partial`/`failed`), `failed_count`, and `error` to `comms_log`. Defaults keep existing rows and the announce/invite routes unchanged; RLS is untouched (still admin-read / admin-insert).
- New pure helper `commsStatus(sent, failed)` derives the status. Both the daily cron and the manual "remind now" route now log **every** attempt (including a total failure, which previously logged nothing) with status/failed_count/error.
- `useCommsLog` gains `reminder` as a first-class kind (it was silently mislabeled `announcement`) plus `status`/`failedCount`/`error`; `CommsLog.vue` shows a Sent/Partial/Failed badge, the failed count, and the error on failure. Surfaces in the existing per-event **Comms** tab in the admin page.

## Screenshots

No new pages. Weather: the same line now populates for locations that previously resolved to nothing. Lock-in: leave-"Going" modal copy reworded. Comms log: each entry now carries a status badge (and error text on failure); reminders are labeled correctly. Admin digest is a new outbound email.

## How to Test

**Automated coverage (added/updated):**
- `test/weather.test.ts` — `geocodeCandidates` (ordering, trimming, dedupe, cap, empty segments).
- `test/email.test.ts` — `buildAdminReminderDigestEmail` (pluralization, per-event lines, dashboard link, title escaping).
- `test/sendAdminReminderDigest.test.ts` — BCC-all-admins, normalize/dedupe, no-admins → no send.
- `test/comms.test.ts` — `commsStatus` (sent/partial/failed/no-op).
- `test/useCommsLog.nuxt.test.ts` — reminder kind + status/failedCount/error mapping; legacy rows default to `sent`.
- `test/CommsLog.nuxt.test.ts` — reminder label, status badges, failed count, error rendering.
- `test/rls.integration.test.ts` — top-3 voted title stays on the ballot regardless of event distance; zero-vote titles still hide. (Supabase local via `SUPABASE_TEST_*`.)
- Full suite: **463 passed / 18 skipped**; `typecheck` + `lint` clean.

**Manual repro:**
- *Weather:* upcoming event (~≤15 days) with `"Benteen Park, Atlanta"` or a street address → weather line populates.
- *Digest:* `reminder_days` hitting a checkpoint with ≥1 non-responder → `GET /api/crons/reminders` (CRON_SECRET bearer) → admins receive the digest; response includes `adminsNotified`.
- *Lock-in:* event >7 days out, a top-3 suggestion with ≥1 vote, author RSVPs "no" → suggestion stays on the ballot.
- *Audit log:* after a reminder send (cron or manual), open the admin **Comms** tab for the event → the reminder appears with a status badge; force a failure (e.g. unverified sender) to see Failed + the error.

## Invariants & Risk

- **Two migrations**, both additive: a `create or replace` of the `SECURITY DEFINER` `is_locked_in` (re-issuing its grants), and three nullable/defaulted columns on `comms_log`. No table drops, no policy changes — `comms_log` stays admin-read/insert and the hide/restore trigger's RLS posture is unchanged (only the lock-in predicate widened).
- **Server-only keys stay server-only** (Invariant 2): TMDB/service-role untouched; digest + reminders run in the existing service-role cron / admin session.
- **Admin role (Invariant 4):** digest and comms log only *read* `profiles.is_admin`; never write it.
- **Rendered HTML (Invariant 5):** digest event titles are `escapeHtml`'d (tested). The comms log renders the Resend error as text (no `v-html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)