### PR TITLE
fix: weather card blank for street-address locations — geocode via Nominatim

### DIFF
--- a/server/api/weather.get.ts
+++ b/server/api/weather.get.ts
@@ -1,4 +1,5 @@
 import type { Forecast } from '#shared/types/weather'
+import type { GeocodedPlace, NominatimResult } from '#shared/utils/weather'
 
 // Proxies Open-Meteo (free, no API key) so the client gets a small, predictable
 // forecast and we can defend against the upstream's full payload. Treats the
@@ -7,6 +8,30 @@ import type { Forecast } from '#shared/types/weather'
 
 interface GeoResponse {
   results?: Array<{ latitude: number, longitude: number, name: string }>
+}
+
+// Nominatim (OpenStreetMap) resolves street addresses ("1447 Benteen Ave SE"),
+// which Open-Meteo's name-only geocoder cannot — a comma-less address used to
+// produce zero usable candidates and the card silently blanked out. Their usage
+// policy requires an identifying User-Agent.
+async function geocode(location: string): Promise<GeocodedPlace | null> {
+  const nominatim = await $fetch<NominatimResult[]>('https://nominatim.openstreetmap.org/search', {
+    query: { q: location, format: 'jsonv2', limit: 1 },
+    headers: { 'User-Agent': 'benteen-screen-on-the-green/1.0 (event weather card)' }
+  }).catch(() => null)
+  const place = parseNominatimPlace(nominatim)
+  if (place) return place
+
+  // Fallback: Open-Meteo's place-name geocoder, trying the full location then
+  // progressively simpler comma segments (venue → city → state).
+  for (const candidate of geocodeCandidates(location)) {
+    const geo = await $fetch<GeoResponse>('https://geocoding-api.open-meteo.com/v1/search', {
+      query: { name: candidate, count: 1, language: 'en', format: 'json' }
+    })
+    const hit = geo.results?.[0]
+    if (hit) return { latitude: hit.latitude, longitude: hit.longitude, name: hit.name }
+  }
+  return null
 }
 interface ForecastResponse {
   daily?: {
@@ -28,16 +53,7 @@ export default defineEventHandler(async (event): Promise<Forecast> => {
   if (!withinForecastWindow(date, new Date())) return UNAVAILABLE
 
   try {
-    // Open-Meteo's geocoder only resolves place names, so try the full location
-    // then progressively simpler segments (see geocodeCandidates) until one hits.
-    let place: { latitude: number, longitude: number, name: string } | undefined
-    for (const candidate of geocodeCandidates(location)) {
-      const geo = await $fetch<GeoResponse>('https://geocoding-api.open-meteo.com/v1/search', {
-        query: { name: candidate, count: 1, language: 'en', format: 'json' }
-      })
-      place = geo.results?.[0]
-      if (place) break
-    }
+    const place = await geocode(location)
     if (!place) return UNAVAILABLE
 
     const fc = await $fetch<ForecastResponse>('https://api.open-meteo.com/v1/forecast', {

--- a/shared/utils/weather.ts
+++ b/shared/utils/weather.ts
@@ -17,15 +17,42 @@ export function describeWeather(code: number): WeatherDescription {
   return { label: 'Thunderstorm', icon: 'i-lucide-cloud-lightning' }
 }
 
+/** A resolved location, whichever geocoder produced it. */
+export interface GeocodedPlace {
+  latitude: number
+  longitude: number
+  name: string | null
+}
+
+/** Minimal shape of a Nominatim search hit. lat/lon arrive as strings. */
+export interface NominatimResult {
+  lat?: string
+  lon?: string
+  display_name?: string
+}
+
 /**
- * Open-Meteo's geocoder resolves place *names*, not street addresses — the whole
- * free-text location ("1900 Lakewood Ave SE, Atlanta, GA", "Benteen Park, Atlanta")
- * usually returns no match, which is why the card's weather silently blanks out.
- * Derive fallback candidates to try in order: the full string first, then each
- * comma-separated segment left-to-right. Left-to-right keeps the most specific
- * hit — a park/venue name beats the city, the city beats the state/ZIP — and the
- * caller stops at the first that geocodes. Capped so a long address can't fan out
- * into many upstream requests. Deduped case-insensitively.
+ * Parse the first Nominatim hit defensively — every field may be missing and
+ * lat/lon are strings that may not be numeric. Nominatim resolves street
+ * addresses ("1447 Benteen Ave SE"), which Open-Meteo's name-only geocoder
+ * can't, so it is the primary geocoder for event locations.
+ */
+export function parseNominatimPlace(results: readonly NominatimResult[] | null | undefined): GeocodedPlace | null {
+  const first = results?.[0]
+  if (!first) return null
+  const latitude = Number(first.lat)
+  const longitude = Number(first.lon)
+  if (!first.lat || !first.lon || !Number.isFinite(latitude) || !Number.isFinite(longitude)) return null
+  return { latitude, longitude, name: first.display_name?.trim() || null }
+}
+
+/**
+ * Fallback candidates for Open-Meteo's geocoder (used when Nominatim misses),
+ * which resolves place *names*, not street addresses. Try the full string
+ * first, then each comma-separated segment left-to-right — a park/venue name
+ * beats the city, the city beats the state/ZIP — and the caller stops at the
+ * first that geocodes. Capped so a long address can't fan out into many
+ * upstream requests. Deduped case-insensitively.
  */
 export function geocodeCandidates(location: string, limit = 4): string[] {
   const seen = new Set<string>()

--- a/test/weather.test.ts
+++ b/test/weather.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { describeWeather, forecastDaysAway, geocodeCandidates, withinForecastWindow } from '../shared/utils/weather'
+import { describeWeather, forecastDaysAway, geocodeCandidates, parseNominatimPlace, withinForecastWindow } from '../shared/utils/weather'
 
 describe('describeWeather', () => {
   it('maps representative WMO codes to labels', () => {
@@ -15,6 +15,39 @@ describe('describeWeather', () => {
     for (const code of [0, 2, 45, 61, 71, 82, 95]) {
       expect(describeWeather(code).icon).toMatch(/^i-lucide-/)
     }
+  })
+})
+
+describe('parseNominatimPlace', () => {
+  it('parses a street-address hit (lat/lon arrive as strings)', () => {
+    // The regression: "1447 Benteen Ave SE" has no commas, so the Open-Meteo
+    // candidate fallback had nothing to try — Nominatim resolves it directly.
+    expect(parseNominatimPlace([{
+      lat: '33.7146957',
+      lon: '-84.3669406',
+      display_name: '1447, Benteen Avenue Southeast, Atlanta, Georgia, United States'
+    }])).toEqual({
+      latitude: 33.7146957,
+      longitude: -84.3669406,
+      name: '1447, Benteen Avenue Southeast, Atlanta, Georgia, United States'
+    })
+  })
+
+  it('returns null when there are no results', () => {
+    expect(parseNominatimPlace([])).toBeNull()
+    expect(parseNominatimPlace(null)).toBeNull()
+    expect(parseNominatimPlace(undefined)).toBeNull()
+  })
+
+  it('returns null when lat/lon are missing or not numeric', () => {
+    expect(parseNominatimPlace([{ display_name: 'Somewhere' }])).toBeNull()
+    expect(parseNominatimPlace([{ lat: 'abc', lon: '-84.4' }])).toBeNull()
+    expect(parseNominatimPlace([{ lat: '33.7', lon: '' }])).toBeNull()
+  })
+
+  it('nulls out a missing or blank display name', () => {
+    expect(parseNominatimPlace([{ lat: '33.7', lon: '-84.4' }])?.name).toBeNull()
+    expect(parseNominatimPlace([{ lat: '33.7', lon: '-84.4', display_name: '  ' }])?.name).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Scope

PR #164 tried to fix the blank weather card by splitting the location on commas and geocoding each segment with Open-Meteo. The real event location is `1447 Benteen Ave SE` — **no commas** — so the fallback had exactly one candidate: a street address, which Open-Meteo's *place-name-only* geocoder can never resolve ("Benteen" alone resolves to Benteen, **Montana**). Production still returned `{ "available": false }`.

## Implementation

`/api/weather` now geocodes with **Nominatim** (OpenStreetMap — free, no API key, sends an identifying `User-Agent` per their usage policy), which resolves street addresses down to the individual building. The existing Open-Meteo comma-segment candidate loop is kept as a fallback if Nominatim misses or errors. Parsing of Nominatim's response (`lat`/`lon` arrive as strings, any field may be missing) lives in a pure, tested helper `parseNominatimPlace` in `shared/utils/weather.ts`.

## How to Test

**Automated:** `test/weather.test.ts` gains a `parseNominatimPlace` suite (street-address hit, empty/null results, non-numeric lat/lon, blank display name). Existing candidate/window/describe tests unchanged and passing (457 passed).

**Manual (verified against a local dev server):**
```
GET /api/weather?location=1447+Benteen+Ave+SE&date=2026-07-18
→ { "available": true, "high": 98, "low": 78, "precipProbability": 19, "code": 51, "place": "1447, Benteen Avenue Southeast, … Atlanta …" }
```
This is the exact request that returns `available: false` on production today. Also probed: place-name location (works), gibberish location, out-of-window date, malformed date (all degrade to `available: false`, HTTP 200).

## Invariants & Risk

- No keys involved — Nominatim and Open-Meteo are both keyless; nothing new reaches the client.
- Server route only; RLS, votes, admin, sanitization untouched.
- External responses treated as untrusted: parser is fully defensive, any failure degrades to `{ available: false }`.
- Nominatim's policy is max 1 req/s sustained; at this app's scale (a handful of users, one request per visible upcoming event card) that's comfortably within bounds.