### PR TITLE
Top-3 lock-in any time, reminder audit log, and re-suggest/vote-restore fixes

### DIFF
--- a/app/components/CommsLog.vue
+++ b/app/components/CommsLog.vue
@@ -5,8 +5,15 @@ defineProps<{ entries: CommsLogEntry[] }>()
 
 const KIND = {
   announcement: { icon: 'i-lucide-megaphone', label: 'Announcement' },
-  invite: { icon: 'i-lucide-mail-plus', label: 'E-vite' }
+  invite: { icon: 'i-lucide-mail-plus', label: 'E-vite' },
+  reminder: { icon: 'i-lucide-alarm-clock', label: 'Reminder' }
 } as const
+
+const STATUS = {
+  sent: { label: 'Sent', color: 'success' },
+  partial: { label: 'Partial', color: 'warning' },
+  failed: { label: 'Failed', color: 'error' }
+} as const satisfies Record<CommsLogEntry['status'], { label: string, color: 'success' | 'warning' | 'error' }>
 </script>
 
 <template>
@@ -25,10 +32,17 @@ const KIND = {
             <p class="text-xs text-muted">
               {{ KIND[e.kind].label }}<span v-if="e.scope"> · {{ e.scope }}</span>
               · {{ e.recipientCount }} recipient{{ e.recipientCount === 1 ? '' : 's' }}
+              <span v-if="e.failedCount"> · {{ e.failedCount }} failed</span>
               <span v-if="e.sentByName"> · by {{ e.sentByName }}</span>
             </p>
+            <p v-if="e.error" class="text-xs text-error mt-1 break-words">
+              {{ e.error }}
+            </p>
           </div>
-          <time class="text-xs text-muted shrink-0">{{ formatDateTime(e.createdAt) }}</time>
+          <div class="flex flex-col items-end gap-1 shrink-0">
+            <UBadge :label="STATUS[e.status].label" :color="STATUS[e.status].color" variant="subtle" size="sm" />
+            <time class="text-xs text-muted">{{ formatDateTime(e.createdAt) }}</time>
+          </div>
         </div>
       </UCard>
     </div>

--- a/app/composables/useCommsLog.ts
+++ b/app/composables/useCommsLog.ts
@@ -1,15 +1,32 @@
 import type { MaybeRefOrGetter } from 'vue'
+import type { CommsStatus } from '#shared/utils/comms'
 import type { Database } from '~/types/database.types'
 
-/** One sent communication (announcement or invite blast) for an event. */
+export type CommsLogKind = 'announcement' | 'invite' | 'reminder'
+
+const KINDS: readonly CommsLogKind[] = ['announcement', 'invite', 'reminder']
+const STATUSES: readonly CommsStatus[] = ['sent', 'partial', 'failed']
+
+/** One sent communication (announcement, invite blast, or reminder) for an event. */
 export interface CommsLogEntry {
   id: string
-  kind: 'announcement' | 'invite'
+  kind: CommsLogKind
   scope: string | null
   subject: string | null
+  /** Recipients the send reached (Resend accepted). */
   recipientCount: number
+  /** Recipients Resend rejected (0 on a clean send). */
+  failedCount: number
+  status: CommsStatus
+  /** First failure message when status is partial/failed; null otherwise. */
+  error: string | null
   sentByName: string | null
   createdAt: string
+}
+
+/** Narrow a free-text DB value to a known member, falling back to `fallback`. */
+function oneOf<T extends string>(values: readonly T[], value: string, fallback: T): T {
+  return (values as readonly string[]).includes(value) ? value as T : fallback
 }
 
 /**
@@ -33,7 +50,7 @@ export function useCommsLog(eventId: MaybeRefOrGetter<string | null | undefined>
     load: async (id) => {
       const { data, error } = await supabase
         .from('comms_log')
-        .select('id, kind, scope, subject, recipient_count, sent_by, created_at')
+        .select('id, kind, scope, subject, recipient_count, failed_count, status, error, sent_by, created_at')
         .eq('event_id', id)
         .order('created_at', { ascending: false })
       if (error) throw error
@@ -47,11 +64,14 @@ export function useCommsLog(eventId: MaybeRefOrGetter<string | null | undefined>
 
       return rows.map(r => ({
         id: r.id,
-        // DB CHECK constrains kind to this set; narrow at the boundary.
-        kind: r.kind === 'invite' ? 'invite' : 'announcement',
+        // DB CHECK constrains kind/status to a known set; narrow at the boundary.
+        kind: oneOf(KINDS, r.kind, 'announcement'),
         scope: r.scope,
         subject: r.subject,
         recipientCount: r.recipient_count,
+        failedCount: r.failed_count ?? 0,
+        status: oneOf(STATUSES, r.status ?? 'sent', 'sent'),
+        error: r.error ?? null,
         sentByName: r.sent_by ? nameById.get(r.sent_by) ?? null : null,
         createdAt: r.created_at
       }))

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -400,7 +400,7 @@ async function onGuests(count: number): Promise<void> {
         <p class="text-sm text-muted">
           You won't be marked as going, so your <strong class="text-default">{{ leaveSummary }}</strong>
           for this movie night will be hidden. RSVP “Going” again and they'll come right back.
-          <span class="block mt-2 text-xs">A top-3 pick within a week of the night stays locked in.</span>
+          <span class="block mt-2 text-xs">A top-3 pick (with at least one vote) stays locked in.</span>
         </p>
       </template>
       <template #footer>

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -399,7 +399,9 @@ async function onGuests(count: number): Promise<void> {
       <template #body>
         <p class="text-sm text-muted">
           You won't be marked as going, so your <strong class="text-default">{{ leaveSummary }}</strong>
-          for this movie night will be hidden. RSVP “Going” again and they'll come right back.
+          for this movie night will be hidden. RSVP “Going” again to bring them back — but a movie
+          someone else re-suggested meanwhile stays theirs, and a freed vote returns only if it still
+          fits the voter's ballot.
           <span class="block mt-2 text-xs">A top-3 pick (with at least one vote) stays locked in.</span>
         </p>
       </template>

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -60,9 +60,9 @@ export interface Database {
         Relationships: []
       }
       comms_log: {
-        Row: { id: string, event_id: string | null, kind: string, scope: string | null, subject: string | null, recipient_count: number, sent_by: string | null, created_at: string }
-        Insert: { id?: string, event_id?: string | null, kind: string, scope?: string | null, subject?: string | null, recipient_count?: number, sent_by?: string | null, created_at?: string }
-        Update: { id?: string, event_id?: string | null, kind?: string, scope?: string | null, subject?: string | null, recipient_count?: number, sent_by?: string | null, created_at?: string }
+        Row: { id: string, event_id: string | null, kind: string, scope: string | null, subject: string | null, recipient_count: number, failed_count: number, status: string, error: string | null, sent_by: string | null, created_at: string }
+        Insert: { id?: string, event_id?: string | null, kind: string, scope?: string | null, subject?: string | null, recipient_count?: number, failed_count?: number, status?: string, error?: string | null, sent_by?: string | null, created_at?: string }
+        Update: { id?: string, event_id?: string | null, kind?: string, scope?: string | null, subject?: string | null, recipient_count?: number, failed_count?: number, status?: string, error?: string | null, sent_by?: string | null, created_at?: string }
         Relationships: []
       }
       vote_refund_acks: {

--- a/scripts/one-off/reassign-mario-votes.sql
+++ b/scripts/one-off/reassign-mario-votes.sql
@@ -1,0 +1,85 @@
+-- ============================================================================
+-- ONE-OFF DATA FIX — run manually in the Supabase SQL editor (or psql).
+--
+-- Scenario: a movie ("Mario") was suggested, its author left "going" so the
+-- suggestion was hidden, then another member re-suggested the same movie (now
+-- possible — see migration 20260709000000_resuggest_hidden_movie.sql). The votes
+-- the movie had are stranded on the old, hidden suggestion. This moves them onto
+-- the new, active suggestion so the movie regains its tally.
+--
+-- This is intentionally NOT a migration: it mutates votes (Product Invariant 3),
+-- targets one specific production row, and must run exactly once under review — so
+-- it stays out of the auto-running migration path. It is safe to run repeatedly:
+-- once the source votes are moved there is nothing left to move (idempotent), and
+-- with the two values below unset it does nothing at all.
+--
+-- HOW TO USE
+--   1. Find the event id and the movie's TMDB id. To confirm the exact rows:
+--        select s.id, s.user_id, s.deleted, s.rsvp_hidden_at, s.culled_at,
+--               s.tmdb_movie ->> 'id'    as tmdb_id,
+--               s.tmdb_movie ->> 'title' as title,
+--               count(v.*) filter (where v.hidden_at is null) as live_votes
+--        from public.suggestions s
+--        left join public.votes v on v.suggestion_id = s.id
+--        where lower(s.tmdb_movie ->> 'title') like '%mario%'
+--        group by s.id
+--        order by s.event_id, s.created_at;
+--      You should see two rows for the same event + tmdb_id: one hidden (source)
+--      and one active (target).
+--   2. Set v_event_id and v_tmdb_id below to that event and movie.
+--   3. Run it. It prints how many votes moved.
+-- ============================================================================
+
+do $$
+declare
+  v_event_id uuid := null;   -- TODO: the affected event's id
+  v_tmdb_id  text := null;   -- TODO: the movie's TMDB id as text, e.g. '502356'
+  v_target   uuid;
+  v_moved    int;
+  v_deduped  int;
+begin
+  if v_event_id is null or v_tmdb_id is null then
+    raise notice 'Set v_event_id and v_tmdb_id first — nothing done.';
+    return;
+  end if;
+
+  -- The single active, on-ballot suggestion of this movie that should own the votes.
+  select id into v_target
+  from public.suggestions
+  where event_id = v_event_id
+    and (tmdb_movie ->> 'id') = v_tmdb_id
+    and deleted = false and rsvp_hidden_at is null and culled_at is null;
+
+  if v_target is null then
+    raise exception 'No single active on-ballot suggestion for movie % in event % — resolve by hand.', v_tmdb_id, v_event_id;
+  end if;
+
+  -- A voter who already voted on the target would clash on the (suggestion_id,
+  -- user_id) primary key, so drop their now-redundant vote on the source row(s).
+  with sources as (
+    select id from public.suggestions
+    where event_id = v_event_id and (tmdb_movie ->> 'id') = v_tmdb_id and id <> v_target
+  )
+  delete from public.votes v
+  using sources s
+  where v.suggestion_id = s.id
+    and exists (select 1 from public.votes t where t.suggestion_id = v_target and t.user_id = v.user_id);
+  get diagnostics v_deduped = row_count;
+
+  -- Move the remaining votes onto the target. hidden_at is preserved on purpose:
+  -- a voter who has since un-RSVP'd keeps their vote hidden (it should not count),
+  -- while still-"going" voters' votes count again now that the target is on the
+  -- ballot. Each voter can have voted on this movie only once, so no voter ends up
+  -- with two Mario votes and nobody's per-event vote budget changes.
+  with sources as (
+    select id from public.suggestions
+    where event_id = v_event_id and (tmdb_movie ->> 'id') = v_tmdb_id and id <> v_target
+  )
+  update public.votes v
+    set suggestion_id = v_target
+  from sources s
+  where v.suggestion_id = s.id;
+  get diagnostics v_moved = row_count;
+
+  raise notice 'Reassigned % vote(s) onto suggestion % (dropped % duplicate(s)).', v_moved, v_target, v_deduped;
+end $$;

--- a/scripts/one-off/reassign-mario-votes.sql
+++ b/scripts/one-off/reassign-mario-votes.sql
@@ -66,20 +66,34 @@ begin
     and exists (select 1 from public.votes t where t.suggestion_id = v_target and t.user_id = v.user_id);
   get diagnostics v_deduped = row_count;
 
-  -- Move the remaining votes onto the target. hidden_at is preserved on purpose:
-  -- a voter who has since un-RSVP'd keeps their vote hidden (it should not count),
-  -- while still-"going" voters' votes count again now that the target is on the
-  -- ballot. Each voter can have voted on this movie only once, so no voter ends up
-  -- with two Mario votes and nobody's per-event vote budget changes.
+  -- Move a source vote onto the target ONLY when its owner still has an open slot —
+  -- same rule the restore trigger applies. A voter who re-spent their freed vote
+  -- while the movie was off the ballot is at their limit, so their old vote does not
+  -- come back (it stays on the hidden source, not counting). Only currently-live
+  -- votes (hidden_at is null) are candidates; a voter who has since un-RSVP'd keeps
+  -- their vote hidden and untouched.
   with sources as (
     select id from public.suggestions
     where event_id = v_event_id and (tmdb_movie ->> 'id') = v_tmdb_id and id <> v_target
+  ),
+  movable as (
+    select v.suggestion_id, v.user_id
+    from public.votes v
+    join sources s on s.id = v.suggestion_id
+    where v.hidden_at is null
+      and (
+        select count(*) from public.votes vv
+        join public.suggestions ss on ss.id = vv.suggestion_id
+        where vv.user_id = v.user_id and vv.hidden_at is null
+          and ss.event_id = v_event_id and ss.deleted = false
+          and ss.rsvp_hidden_at is null and ss.culled_at is null
+      ) < public.vote_limit()
   )
   update public.votes v
     set suggestion_id = v_target
-  from sources s
-  where v.suggestion_id = s.id;
+  from movable m
+  where v.suggestion_id = m.suggestion_id and v.user_id = m.user_id;
   get diagnostics v_moved = row_count;
 
-  raise notice 'Reassigned % vote(s) onto suggestion % (dropped % duplicate(s)).', v_moved, v_target, v_deduped;
+  raise notice 'Reassigned % vote(s) onto suggestion % (dropped % duplicate(s)); votes whose owner was at their limit were left behind.', v_moved, v_target, v_deduped;
 end $$;

--- a/server/api/crons/reminders.get.ts
+++ b/server/api/crons/reminders.get.ts
@@ -72,7 +72,7 @@ export default defineEventHandler(async (event) => {
     })
     // Log the outcome of every attempt — including a total failure (sent = 0) —
     // so the admin Comms log shows what the automated run actually did.
-    await admin.from('comms_log').insert({
+    const { error: logError } = await admin.from('comms_log').insert({
       event_id: d.eventId,
       kind: 'reminder',
       subject: `Reminder — ${d.eventTitle}`,
@@ -81,6 +81,7 @@ export default defineEventHandler(async (event) => {
       status: commsStatus(sent, failed),
       error
     })
+    if (logError) console.error('[crons/reminders] comms_log insert failed -', logError.message)
     if (sent > 0) {
       totalSent += sent
       digest.push({ eventTitle: d.eventTitle, eventDate, daysLeft: d.daysLeft, remindedCount: sent })

--- a/server/api/crons/reminders.get.ts
+++ b/server/api/crons/reminders.get.ts
@@ -60,7 +60,7 @@ export default defineEventHandler(async (event) => {
 
   for (const d of due) {
     const eventDate = formatEmailDate(d.eventDate) || null
-    const { sent } = await sendEventReminders(admin, {
+    const { sent, failed, error } = await sendEventReminders(admin, {
       apiKey: resendApiKey,
       from: resendFrom,
       eventTitle: d.eventTitle,
@@ -70,8 +70,18 @@ export default defineEventHandler(async (event) => {
       appUrl,
       invites: d.invites
     })
+    // Log the outcome of every attempt — including a total failure (sent = 0) —
+    // so the admin Comms log shows what the automated run actually did.
+    await admin.from('comms_log').insert({
+      event_id: d.eventId,
+      kind: 'reminder',
+      subject: `Reminder — ${d.eventTitle}`,
+      recipient_count: sent,
+      failed_count: failed,
+      status: commsStatus(sent, failed),
+      error
+    })
     if (sent > 0) {
-      await admin.from('comms_log').insert({ event_id: d.eventId, kind: 'reminder', subject: `Reminder — ${d.eventTitle}`, recipient_count: sent })
       totalSent += sent
       digest.push({ eventTitle: d.eventTitle, eventDate, daysLeft: d.daysLeft, remindedCount: sent })
     }

--- a/server/api/events/[id]/reminders/send.post.ts
+++ b/server/api/events/[id]/reminders/send.post.ts
@@ -45,16 +45,19 @@ export default defineEventHandler(async (event) => {
     invites: queue
   })
 
-  if (sent > 0) {
-    const { error: logError } = await db.from('comms_log').insert({
-      event_id: eventId,
-      kind: 'reminder',
-      subject: `Reminder — ${ev.title}`,
-      recipient_count: sent,
-      sent_by: userId
-    })
-    if (logError) console.error('[events/reminders/send] comms_log insert failed -', logError.message)
-  }
+  // An attempt was made (the empty-queue case returned above), so log the outcome
+  // — success, partial, or total failure — to the admin Comms log.
+  const { error: logError } = await db.from('comms_log').insert({
+    event_id: eventId,
+    kind: 'reminder',
+    subject: `Reminder — ${ev.title}`,
+    recipient_count: sent,
+    failed_count: failed,
+    status: commsStatus(sent, failed),
+    error,
+    sent_by: userId
+  })
+  if (logError) console.error('[events/reminders/send] comms_log insert failed -', logError.message)
 
   return { ok: true, sent, failed, error }
 })

--- a/shared/utils/comms.ts
+++ b/shared/utils/comms.ts
@@ -1,0 +1,12 @@
+/** Outcome of a comms send, recorded on `comms_log.status`. */
+export type CommsStatus = 'sent' | 'partial' | 'failed'
+
+/**
+ * Classify a send from its sent/failed counts: `partial` when some went out and
+ * some failed, `failed` when none went out, otherwise `sent`. Kept pure so the
+ * reminder cron + manual route derive the same status without duplicating logic.
+ */
+export function commsStatus(sent: number, failed: number): CommsStatus {
+  if (failed > 0) return sent > 0 ? 'partial' : 'failed'
+  return 'sent'
+}

--- a/shared/utils/comms.ts
+++ b/shared/utils/comms.ts
@@ -3,8 +3,10 @@ export type CommsStatus = 'sent' | 'partial' | 'failed'
 
 /**
  * Classify a send from its sent/failed counts: `partial` when some went out and
- * some failed, `failed` when none went out, otherwise `sent`. Kept pure so the
- * reminder cron + manual route derive the same status without duplicating logic.
+ * some failed, `failed` when none went out, otherwise `sent`. By convention
+ * (0, 0) is `sent` — nothing attempted is not a failure — though callers guard
+ * against logging empty sends. Kept pure so the reminder cron + manual route
+ * derive the same status without duplicating logic.
  */
 export function commsStatus(sent: number, failed: number): CommsStatus {
   if (failed > 0) return sent > 0 ? 'partial' : 'failed'

--- a/supabase/migrations/20260707000000_lockin_top3_any_time.sql
+++ b/supabase/migrations/20260707000000_lockin_top3_any_time.sql
@@ -1,0 +1,39 @@
+-- ============================================================================
+-- Broaden lock-in: a top-3 contender is protected from an un-RSVP hide at ANY
+-- time, not only in the final week.
+--
+-- The original lock-in (20260702) only shielded a top-3 suggestion once the event
+-- was within 7 days. In practice a strong pick got yanked off the ballot weeks out
+-- the moment its author left "going" — exactly the surprise we want to avoid. The
+-- rule people expect is simpler: if a movie is a top-3 vote-getter, the author
+-- bailing shouldn't remove it, whenever that happens.
+--
+-- So `is_locked_in` drops the event-date window. A suggestion is locked in when it
+-- ranks in the top 3 by live votes AND has at least one vote. The ≥1-vote floor is
+-- kept deliberately: a zero-vote suggestion isn't a contender, so the author's
+-- un-RSVP may still hide it (unchanged). The hide/restore trigger already calls
+-- this function by name, so replacing the body is all that's needed.
+-- ============================================================================
+
+create or replace function public.is_locked_in(sid uuid) returns boolean
+  language sql security definer set search_path = public stable as $$
+  with ranked as (
+    select s.id,
+      count(v.suggestion_id) filter (where v.hidden_at is null) as votes,
+      row_number() over (
+        order by count(v.suggestion_id) filter (where v.hidden_at is null) desc, s.created_at asc
+      ) as rk
+    from public.suggestions s
+    left join public.votes v on v.suggestion_id = s.id
+    where s.deleted = false and s.rsvp_hidden_at is null and s.culled_at is null
+      and s.event_id = (select event_id from public.suggestions where id = sid)
+    group by s.id, s.created_at
+  )
+  select exists (
+    select 1
+    from ranked r
+    where r.id = sid and r.rk <= 3 and r.votes > 0
+  );
+$$;
+revoke all on function public.is_locked_in(uuid) from public;
+grant execute on function public.is_locked_in(uuid) to authenticated;

--- a/supabase/migrations/20260708000000_comms_log_status.sql
+++ b/supabase/migrations/20260708000000_comms_log_status.sql
@@ -1,0 +1,22 @@
+-- ============================================================================
+-- Give the comms log an outcome, so admins can see whether a send succeeded.
+--
+-- Reminder batches (and every other blast) were logged as a bare "N recipients"
+-- row with no indication of whether Resend actually accepted them — a run that
+-- failed outright (e.g. an unverified sender domain) logged nothing at all. Add:
+--   * status       — 'sent' (all delivered), 'partial' (some failed), 'failed'
+--                    (none delivered). Defaults to 'sent' so existing rows and the
+--                    announce/invite routes (which log only their success path) are
+--                    unaffected.
+--   * failed_count — recipients Resend rejected, alongside recipient_count (sent).
+--   * error        — first failure message, for diagnostics; null on full success.
+--
+-- No policy change: comms_log stays admin-read / admin-insert, and the reminder
+-- cron keeps writing as the service role.
+-- ============================================================================
+
+alter table public.comms_log
+  add column if not exists status text not null default 'sent'
+    check (status in ('sent', 'partial', 'failed')),
+  add column if not exists failed_count int not null default 0,
+  add column if not exists error text;

--- a/supabase/migrations/20260709000000_resuggest_hidden_movie.sql
+++ b/supabase/migrations/20260709000000_resuggest_hidden_movie.sql
@@ -1,0 +1,74 @@
+-- ============================================================================
+-- Let a movie be re-suggested once the earlier suggestion is hidden by un-RSVP.
+--
+-- The per-event "one suggestion per movie" unique index only ignored admin-deleted
+-- rows (`where deleted = false`). A title whose author left "going" is soft-hidden
+-- (rsvp_hidden_at set, deleted still false), so it kept reserving the movie — nobody
+-- else could submit it and the insert failed with a unique violation. A hidden
+-- suggestion is off the ballot, so it should not hold the slot.
+--
+-- Narrow the index to on-ballot rows: deleted = false AND rsvp_hidden_at is null.
+-- Culled rows still hold their slot on purpose — a permanent cull must not be
+-- undone by re-suggesting the title, so culled_at is intentionally NOT excluded.
+--
+-- Guarded consequence: when the original author later returns to "going", restoring
+-- their hidden suggestion would collide with the newer active suggestion of the same
+-- movie (two on-ballot rows → unique violation, which would break the RSVP trigger).
+-- So the restore branch of sync_rsvp_visibility now skips any suggestion whose movie
+-- is already live on the ballot under another row — it stays hidden; the active one
+-- wins. (The hide branch and the vote hide/restore are unchanged.)
+-- ============================================================================
+
+drop index if exists public.suggestions_event_movie_unique;
+create unique index suggestions_event_movie_unique
+  on public.suggestions (event_id, ((tmdb_movie ->> 'id')))
+  where deleted = false and rsvp_hidden_at is null;
+
+create or replace function public.sync_rsvp_visibility() returns trigger
+  language plpgsql security definer set search_path = '' as $$
+declare
+  uid   uuid;
+  eid   uuid;
+  going boolean;
+begin
+  if tg_op = 'DELETE' then
+    uid := old.user_id; eid := old.event_id; going := false;
+  else
+    uid := new.user_id; eid := new.event_id; going := (new.status = 'going');
+  end if;
+
+  if going then
+    -- Restore this user's suggestions, EXCEPT any whose movie is already live on
+    -- the ballot under another row (re-suggested by someone else while they were
+    -- away). Un-hiding it would duplicate an on-ballot title, so it stays hidden.
+    update public.suggestions s
+      set rsvp_hidden_at = null
+      where s.user_id = uid and s.event_id = eid and s.rsvp_hidden_at is not null
+        and not exists (
+          select 1 from public.suggestions o
+          where o.event_id = s.event_id
+            and (o.tmdb_movie ->> 'id') = (s.tmdb_movie ->> 'id')
+            and o.id <> s.id
+            and o.deleted = false and o.rsvp_hidden_at is null
+        );
+    update public.votes v
+      set hidden_at = null
+      from public.suggestions s
+      where v.suggestion_id = s.id and s.event_id = eid
+        and v.user_id = uid and v.hidden_at is not null;
+  else
+    -- Hide this user's suggestions, EXCEPT any locked in for the home stretch.
+    update public.suggestions
+      set rsvp_hidden_at = now()
+      where user_id = uid and event_id = eid and rsvp_hidden_at is null
+        and not public.is_locked_in(id);
+    update public.votes v
+      set hidden_at = now()
+      from public.suggestions s
+      where v.suggestion_id = s.id and s.event_id = eid
+        and v.user_id = uid and v.hidden_at is null;
+  end if;
+
+  return null;
+end;
+$$;

--- a/supabase/migrations/20260710000000_restore_within_vote_budget.sql
+++ b/supabase/migrations/20260710000000_restore_within_vote_budget.sql
@@ -1,0 +1,106 @@
+-- ============================================================================
+-- Restoring state on re-RSVP must respect each voter's vote budget.
+--
+-- When an author left "going", their suggestions were hidden and the votes other
+-- members had cast on them stopped counting — freeing those members to re-spend
+-- that vote elsewhere. On the author's return the suggestions come back, and every
+-- vote on them silently started counting again with NO budget check. A member who
+-- had re-spent their freed vote could end up over their limit, and a returned vote
+-- would "come back" even though its owner had already moved on.
+--
+-- Desired rule (confirmed): a returned vote only stands if its owner still has an
+-- open slot. If they spent it on newer votes, the returned (older) one drops out —
+-- it is hidden, not deleted, so it can come back later if a slot frees up.
+--
+-- So the restore branch of sync_rsvp_visibility now, after un-hiding the author's
+-- suggestions + their own votes, reconciles every affected voter (anyone with a
+-- vote on a just-restored suggestion, plus the returning author) down to their
+-- vote limit: keep their newest `limit` live votes, hide the rest. Newest-wins, so
+-- a vote re-cast while the suggestion was away is kept and the stale returning vote
+-- yields. The hide branch and the re-suggest collision guard are unchanged.
+-- ============================================================================
+
+create or replace function public.sync_rsvp_visibility() returns trigger
+  language plpgsql security definer set search_path = '' as $$
+declare
+  uid          uuid;
+  eid          uuid;
+  going        boolean;
+  restored_ids uuid[];
+begin
+  if tg_op = 'DELETE' then
+    uid := old.user_id; eid := old.event_id; going := false;
+  else
+    uid := new.user_id; eid := new.event_id; going := (new.status = 'going');
+  end if;
+
+  if going then
+    -- 1. Restore this user's suggestions, EXCEPT any whose movie is already live on
+    --    the ballot under another row (re-suggested while they were away) — that one
+    --    stays hidden. Capture the ids actually un-hidden for the budget pass below.
+    with upd as (
+      update public.suggestions s
+        set rsvp_hidden_at = null
+        where s.user_id = uid and s.event_id = eid and s.rsvp_hidden_at is not null
+          and not exists (
+            select 1 from public.suggestions o
+            where o.event_id = s.event_id
+              and (o.tmdb_movie ->> 'id') = (s.tmdb_movie ->> 'id')
+              and o.id <> s.id
+              and o.deleted = false and o.rsvp_hidden_at is null
+          )
+        returning s.id
+    )
+    select coalesce(array_agg(id), array[]::uuid[]) into restored_ids from upd;
+
+    -- 2. Un-hide this user's own votes for the event (budget-reconciled in step 3).
+    update public.votes v
+      set hidden_at = null
+      from public.suggestions s
+      where v.suggestion_id = s.id and s.event_id = eid
+        and v.user_id = uid and v.hidden_at is not null;
+
+    -- 3. Budget reconciliation. Everyone with a vote on a just-restored suggestion
+    --    (plus this returning user) must not exceed their vote limit now that hidden
+    --    suggestions/votes are back. Keep each voter's newest `limit` live votes and
+    --    hide the rest: a returned vote only stands if its owner still has a slot;
+    --    if they re-spent it on newer votes, the stale returned one drops out.
+    with affected as (
+      select distinct v.user_id
+        from public.votes v
+        where v.suggestion_id = any(restored_ids) and v.hidden_at is null
+      union
+      select uid
+    ),
+    ranked as (
+      select v.suggestion_id, v.user_id,
+        row_number() over (
+          partition by v.user_id order by v.created_at desc, v.suggestion_id desc
+        ) as rk
+      from public.votes v
+      join public.suggestions s on s.id = v.suggestion_id
+      join affected a on a.user_id = v.user_id
+      where v.hidden_at is null and s.event_id = eid
+        and s.deleted = false and s.rsvp_hidden_at is null and s.culled_at is null
+    )
+    update public.votes v
+      set hidden_at = now()
+      from ranked r
+      where v.user_id = r.user_id and v.suggestion_id = r.suggestion_id
+        and v.hidden_at is null and r.rk > public.vote_limit();
+  else
+    -- Hide this user's suggestions, EXCEPT any locked in for the home stretch.
+    update public.suggestions
+      set rsvp_hidden_at = now()
+      where user_id = uid and event_id = eid and rsvp_hidden_at is null
+        and not public.is_locked_in(id);
+    update public.votes v
+      set hidden_at = now()
+      from public.suggestions s
+      where v.suggestion_id = s.id and s.event_id = eid
+        and v.user_id = uid and v.hidden_at is null;
+  end if;
+
+  return null;
+end;
+$$;

--- a/supabase/migrations/20260710000000_restore_within_vote_budget.sql
+++ b/supabase/migrations/20260710000000_restore_within_vote_budget.sql
@@ -54,6 +54,11 @@ begin
     select coalesce(array_agg(id), array[]::uuid[]) into restored_ids from upd;
 
     -- 2. Un-hide this user's own votes for the event (budget-reconciled in step 3).
+    --    Deliberately unconditional: this can leave a live vote on a suggestion that
+    --    step 1 kept rsvp-hidden (movie re-suggested by someone else). That state is
+    --    benign — vote counting and the vote-limit check both join through the
+    --    suggestion and require rsvp_hidden_at is null, so the vote is inert; a later
+    --    un-RSVP simply re-hides it.
     update public.votes v
       set hidden_at = null
       from public.suggestions s

--- a/test/CommsLog.nuxt.test.ts
+++ b/test/CommsLog.nuxt.test.ts
@@ -4,9 +4,15 @@ import { mountSuspended } from '@nuxt/test-utils/runtime'
 import CommsLog from '../app/components/CommsLog.vue'
 import type { CommsLogEntry } from '../app/composables/useCommsLog'
 
+const entry = (over: Partial<CommsLogEntry> = {}): CommsLogEntry => ({
+  id: 'c1', kind: 'announcement', scope: 'going', subject: 'See you Friday',
+  recipientCount: 12, failedCount: 0, status: 'sent', error: null,
+  sentByName: 'Pat', createdAt: '2026-06-20T18:00:00Z', ...over
+})
+
 const entries: CommsLogEntry[] = [
-  { id: 'c1', kind: 'announcement', scope: 'going', subject: 'See you Friday', recipientCount: 12, sentByName: 'Pat', createdAt: '2026-06-20T18:00:00Z' },
-  { id: 'c2', kind: 'invite', scope: null, subject: 'E-vite — Movie Night', recipientCount: 30, sentByName: null, createdAt: '2026-06-19T18:00:00Z' }
+  entry(),
+  entry({ id: 'c2', kind: 'invite', scope: null, subject: 'E-vite — Movie Night', recipientCount: 30, sentByName: null, createdAt: '2026-06-19T18:00:00Z' })
 ]
 
 describe('CommsLog', () => {
@@ -22,10 +28,35 @@ describe('CommsLog', () => {
   })
 
   it('singularizes one recipient', async () => {
-    const one: CommsLogEntry[] = [{ ...entries[0]!, recipientCount: 1 }]
+    const one: CommsLogEntry[] = [entry({ recipientCount: 1 })]
     const w = await mountSuspended(CommsLog, { props: { entries: one } })
     expect(w.text()).toContain('1 recipient')
     expect(w.text()).not.toContain('1 recipients')
+  })
+
+  it('labels an automated reminder', async () => {
+    const w = await mountSuspended(CommsLog, { props: { entries: [entry({ kind: 'reminder', subject: 'Reminder — Jaws' })] } })
+    expect(w.text()).toContain('Reminder')
+  })
+
+  it('shows the status for a successful send', async () => {
+    const w = await mountSuspended(CommsLog, { props: { entries: [entry()] } })
+    expect(w.text()).toContain('Sent')
+  })
+
+  it('shows failed count, the Failed status, and the error when a send fails', async () => {
+    const failed = entry({ kind: 'reminder', status: 'failed', recipientCount: 0, failedCount: 5, error: 'Unverified sender domain' })
+    const w = await mountSuspended(CommsLog, { props: { entries: [failed] } })
+    expect(w.text()).toContain('Failed')
+    expect(w.text()).toContain('5 failed')
+    expect(w.text()).toContain('Unverified sender domain')
+  })
+
+  it('flags a partial send', async () => {
+    const partial = entry({ kind: 'reminder', status: 'partial', recipientCount: 3, failedCount: 2, error: 'Some bounced' })
+    const w = await mountSuspended(CommsLog, { props: { entries: [partial] } })
+    expect(w.text()).toContain('Partial')
+    expect(w.text()).toContain('2 failed')
   })
 
   it('shows an empty state when nothing has been sent', async () => {

--- a/test/comms.test.ts
+++ b/test/comms.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { commsStatus } from '../shared/utils/comms'
+
+describe('commsStatus', () => {
+  it('is "sent" when everything went out', () => {
+    expect(commsStatus(5, 0)).toBe('sent')
+  })
+
+  it('is "partial" when some went out and some failed', () => {
+    expect(commsStatus(3, 2)).toBe('partial')
+  })
+
+  it('is "failed" when nothing went out', () => {
+    expect(commsStatus(0, 4)).toBe('failed')
+  })
+
+  it('treats a no-op (nothing attempted) as sent, not failed', () => {
+    expect(commsStatus(0, 0)).toBe('sent')
+  })
+})

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -429,6 +429,46 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('events').delete().eq('id', farId)
   })
 
+  it('lets another member re-suggest a movie whose earlier suggestion was hidden by un-RSVP', async () => {
+    const { data: ev } = await admin!
+      .from('events').insert({ title: 'Resuggest', event_date: new Date(stamp + 20 * 86_400_000).toISOString() })
+      .select('id').single()
+    const evId = ev!.id
+    const mario = { id: 502356, title: 'The Super Mario Bros. Movie' }
+
+    // Author A suggests Mario, then leaves "going" → A's Mario is hidden.
+    const emailA = `rls_resA_${stamp}@example.com`
+    const uidA = await makeUser(emailA)
+    await admin!.from('invites').insert({ email: emailA })
+    const clientA = await signInAs(emailA)
+    await clientA.from('rsvps').insert({ event_id: evId, user_id: uidA, status: 'going' })
+    const { data: sA } = await clientA.from('suggestions').insert({ event_id: evId, tmdb_movie: mario }).select('id').single()
+    await clientA.from('rsvps').update({ status: 'no' }).eq('event_id', evId).eq('user_id', uidA)
+
+    // Member B (going) can now submit the same movie — previously a unique violation.
+    const emailB = `rls_resB_${stamp}@example.com`
+    const uidB = await makeUser(emailB)
+    await admin!.from('invites').insert({ email: emailB })
+    const clientB = await signInAs(emailB)
+    await clientB.from('rsvps').insert({ event_id: evId, user_id: uidB, status: 'going' })
+    const reSuggest = await clientB.from('suggestions').insert({ event_id: evId, tmdb_movie: mario }).select('id').single()
+    expect(reSuggest.error, 'B can re-suggest the movie A hid by un-RSVPing').toBeNull()
+    const sBId = reSuggest.data!.id
+
+    // A returns to "going": their Mario must stay hidden (B's is live) — no collision.
+    const back = await clientA.from('rsvps').update({ status: 'going' }).eq('event_id', evId).eq('user_id', uidA)
+    expect(back.error, 're-RSVP does not error even though the movie is taken').toBeNull()
+    const aRow = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', sA!.id).single()
+    const bRow = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', sBId).single()
+    expect(aRow.data!.rsvp_hidden_at, 'A\'s original stays hidden — B\'s is on the ballot').not.toBeNull()
+    expect(bRow.data!.rsvp_hidden_at, 'B\'s re-suggestion is live').toBeNull()
+
+    await admin!.from('suggestions').delete().in('id', [sA!.id, sBId])
+    await admin!.from('rsvps').delete().in('user_id', [uidA, uidB])
+    await admin!.from('invites').delete().in('email', [emailA, emailB])
+    await admin!.from('events').delete().eq('id', evId)
+  })
+
   it('claim_freed_votes notifies a voter once when their pick leaves the ballot', async () => {
     await memberClient.from('rsvps').upsert({ event_id: eventId, user_id: memberId, status: 'going' }, { onConflict: 'event_id,user_id' })
     const { data: s } = await admin!

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -469,6 +469,94 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('events').delete().eq('id', evId)
   })
 
+  it('returns a freed vote on the author\'s re-RSVP when the voter still has an open slot', async () => {
+    const { data: ev } = await admin!
+      .from('events').insert({ title: 'BudgetOk', event_date: new Date(stamp + 21 * 86_400_000).toISOString() })
+      .select('id').single()
+    const evId = ev!.id
+
+    // Author A suggests a movie; member B votes for it (B: 1 of 3).
+    const emailA = `rls_budA_${stamp}@example.com`
+    const uidA = await makeUser(emailA)
+    await admin!.from('invites').insert({ email: emailA })
+    const clientA = await signInAs(emailA)
+    await clientA.from('rsvps').insert({ event_id: evId, user_id: uidA, status: 'going' })
+    const { data: sMovie } = await clientA.from('suggestions').insert({ event_id: evId, tmdb_movie: { id: 700, title: 'Pick' } }).select('id').single()
+
+    const emailB = `rls_budB_${stamp}@example.com`
+    const uidB = await makeUser(emailB)
+    await admin!.from('invites').insert({ email: emailB })
+    const clientB = await signInAs(emailB)
+    await clientB.from('rsvps').insert({ event_id: evId, user_id: uidB, status: 'going' })
+    await clientB.from('votes').insert({ suggestion_id: sMovie!.id })
+
+    // A leaves → the movie is hidden and B's vote on it stops counting (B frees a slot).
+    await clientA.from('rsvps').update({ status: 'no' }).eq('event_id', evId).eq('user_id', uidA)
+    // B spends the freed slot on one other title (B is now at 2 of 3 — still room).
+    const { data: filler } = await admin!.from('suggestions').insert({ event_id: evId, user_id: uidA, tmdb_movie: { id: 701, title: 'Filler' } }).select('id').single()
+    await clientB.from('votes').insert({ suggestion_id: filler!.id })
+
+    // A returns → the movie is back and B is under the cap, so B's original vote counts again.
+    await clientA.from('rsvps').update({ status: 'going' }).eq('event_id', evId).eq('user_id', uidA)
+    const bVote = await admin!.from('votes').select('hidden_at').eq('suggestion_id', sMovie!.id).eq('user_id', uidB).single()
+    expect(bVote.data!.hidden_at, 'the freed vote returns while the voter has an open slot').toBeNull()
+
+    await admin!.from('votes').delete().in('suggestion_id', [sMovie!.id, filler!.id])
+    await admin!.from('suggestions').delete().in('id', [sMovie!.id, filler!.id])
+    await admin!.from('rsvps').delete().in('user_id', [uidA, uidB])
+    await admin!.from('invites').delete().in('email', [emailA, emailB])
+    await admin!.from('events').delete().eq('id', evId)
+  })
+
+  it('does not return a freed vote on re-RSVP when the voter has since filled their budget', async () => {
+    const { data: ev } = await admin!
+      .from('events').insert({ title: 'BudgetFull', event_date: new Date(stamp + 22 * 86_400_000).toISOString() })
+      .select('id').single()
+    const evId = ev!.id
+
+    const emailA = `rls_bfA_${stamp}@example.com`
+    const uidA = await makeUser(emailA)
+    await admin!.from('invites').insert({ email: emailA })
+    const clientA = await signInAs(emailA)
+    await clientA.from('rsvps').insert({ event_id: evId, user_id: uidA, status: 'going' })
+    const { data: sMovie } = await clientA.from('suggestions').insert({ event_id: evId, tmdb_movie: { id: 800, title: 'Author Pick' } }).select('id').single()
+
+    // Three filler titles for B to spend votes on (default vote limit is 3).
+    const fillers: string[] = []
+    for (const fid of [801, 802, 803]) {
+      const { data } = await admin!.from('suggestions').insert({ event_id: evId, user_id: uidA, tmdb_movie: { id: fid, title: `F${fid}` } }).select('id').single()
+      fillers.push(data!.id)
+    }
+
+    const emailB = `rls_bfB_${stamp}@example.com`
+    const uidB = await makeUser(emailB)
+    await admin!.from('invites').insert({ email: emailB })
+    const clientB = await signInAs(emailB)
+    await clientB.from('rsvps').insert({ event_id: evId, user_id: uidB, status: 'going' })
+    // B votes the author's pick + two fillers → at the cap of 3.
+    await clientB.from('votes').insert({ suggestion_id: sMovie!.id })
+    await clientB.from('votes').insert({ suggestion_id: fillers[0]! })
+    await clientB.from('votes').insert({ suggestion_id: fillers[1]! })
+
+    // A leaves → the pick is hidden, freeing B's slot; B re-spends it on the third filler.
+    await clientA.from('rsvps').update({ status: 'no' }).eq('event_id', evId).eq('user_id', uidA)
+    const reSpend = await clientB.from('votes').insert({ suggestion_id: fillers[2]! })
+    expect(reSpend.error, 'B can re-spend the freed slot').toBeNull()
+
+    // A returns → B would be at 4; the oldest vote (the author's pick) drops out.
+    await clientA.from('rsvps').update({ status: 'going' }).eq('event_id', evId).eq('user_id', uidA)
+    const pickVote = await admin!.from('votes').select('hidden_at').eq('suggestion_id', sMovie!.id).eq('user_id', uidB).single()
+    const reSpendVote = await admin!.from('votes').select('hidden_at').eq('suggestion_id', fillers[2]!).eq('user_id', uidB).single()
+    expect(pickVote.data!.hidden_at, 'the returned vote drops out — B already re-spent that slot').not.toBeNull()
+    expect(reSpendVote.data!.hidden_at, 'the newer re-spent vote is kept').toBeNull()
+
+    await admin!.from('votes').delete().in('suggestion_id', [sMovie!.id, ...fillers])
+    await admin!.from('suggestions').delete().in('id', [sMovie!.id, ...fillers])
+    await admin!.from('rsvps').delete().in('user_id', [uidA, uidB])
+    await admin!.from('invites').delete().in('email', [emailA, emailB])
+    await admin!.from('events').delete().eq('id', evId)
+  })
+
   it('claim_freed_votes notifies a voter once when their pick leaves the ballot', async () => {
     await memberClient.from('rsvps').upsert({ event_id: eventId, user_id: memberId, status: 'going' }, { onConflict: 'event_id,user_id' })
     const { data: s } = await admin!

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -372,8 +372,7 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('suggestions').delete().in('id', ids)
   })
 
-  it('locks in a top-3 voted suggestion within a week so an un-RSVP can’t hide it', async () => {
-    // Event 3 days out — inside the lock-in window.
+  it('locks in a top-3 voted suggestion so an un-RSVP can’t hide it', async () => {
     const { data: ev } = await admin!
       .from('events').insert({ title: 'Soon', event_date: new Date(stamp + 3 * 86_400_000).toISOString() })
       .select('id').single()
@@ -394,7 +393,7 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
 
     const aRow = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', a!.id).single()
     const bRow = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', b!.id).single()
-    expect(aRow.data!.rsvp_hidden_at, 'a top-3 voted title within a week stays on the ballot').toBeNull()
+    expect(aRow.data!.rsvp_hidden_at, 'a top-3 voted title stays on the ballot').toBeNull()
     expect(bRow.data!.rsvp_hidden_at, 'a zero-vote title is still hidden on un-RSVP').not.toBeNull()
 
     await admin!.from('votes').delete().in('suggestion_id', [a!.id, b!.id])
@@ -404,7 +403,7 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('events').delete().eq('id', soonId)
   })
 
-  it('does not lock in a voted suggestion when the event is more than a week out', async () => {
+  it('locks in a top-3 voted suggestion even when the event is more than a week out', async () => {
     const { data: ev } = await admin!
       .from('events').insert({ title: 'Later', event_date: new Date(stamp + 30 * 86_400_000).toISOString() })
       .select('id').single()
@@ -421,7 +420,7 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await client.from('rsvps').update({ status: 'no' }).eq('event_id', farId).eq('user_id', uid)
 
     const aRow = await admin!.from('suggestions').select('rsvp_hidden_at').eq('id', a!.id).single()
-    expect(aRow.data!.rsvp_hidden_at, 'a top title >1 week out is still hidden on un-RSVP').not.toBeNull()
+    expect(aRow.data!.rsvp_hidden_at, 'a top-3 voted title stays on the ballot regardless of how far out the event is').toBeNull()
 
     await admin!.from('votes').delete().eq('suggestion_id', a!.id)
     await admin!.from('suggestions').delete().eq('id', a!.id)

--- a/test/useCommsLog.nuxt.test.ts
+++ b/test/useCommsLog.nuxt.test.ts
@@ -4,7 +4,7 @@ import { nextTick, ref } from 'vue'
 import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 import type { CommsLogEntry } from '../app/composables/useCommsLog'
 
-interface LogRow { id: string, kind: string, scope: string | null, subject: string | null, recipient_count: number, sent_by: string | null, created_at: string }
+interface LogRow { id: string, kind: string, scope: string | null, subject: string | null, recipient_count: number, failed_count?: number, status?: string, error?: string | null, sent_by: string | null, created_at: string }
 let logRows: LogRow[] = []
 const profiles = [{ id: 'pat', display_name: 'Pat' }]
 
@@ -50,5 +50,25 @@ describe('useCommsLog', () => {
     const { entries } = useCommsLog(ref('e1'))
     await settle(entries)
     expect(entries.value[0]!.kind).toBe('announcement')
+  })
+
+  it('surfaces a reminder with its failure status, failed count, and error', async () => {
+    logRows = [{
+      id: 'c4', kind: 'reminder', scope: null, subject: 'Reminder — Jaws',
+      recipient_count: 3, failed_count: 2, status: 'partial', error: 'Unverified domain',
+      sent_by: null, created_at: '2026-06-21T00:00:00Z'
+    }]
+    const { entries } = useCommsLog(ref('e1'))
+    await settle(entries)
+    expect(entries.value[0]).toMatchObject({
+      kind: 'reminder', status: 'partial', recipientCount: 3, failedCount: 2, error: 'Unverified domain'
+    })
+  })
+
+  it('defaults status to sent and failedCount to 0 for legacy rows without the columns', async () => {
+    logRows = [{ id: 'c5', kind: 'announcement', scope: null, subject: 'Legacy', recipient_count: 4, sent_by: null, created_at: '2026-06-22T00:00:00Z' }]
+    const { entries } = useCommsLog(ref('e1'))
+    await settle(entries)
+    expect(entries.value[0]).toMatchObject({ status: 'sent', failedCount: 0, error: null })
   })
 })


### PR DESCRIPTION
## Scope

Follow-up work after #164 merged (weather + admin digest are already on `main`; this branch was rebased onto latest `main`, so those merged commits are dropped and only the new work remains). Four changes:

1. **A top-3 pick got knocked off the ballot when its author un-RSVP'd.** The lock-in only applied inside a 7-day window, so a #2 movie weeks out was hidden the moment its suggester left "going". Now a top-3 pick is protected at any time.

2. **No auditable record of automated reminders + their outcome.** The comms log had no success/failure status, mislabeled reminders as "announcements", and logged *nothing* when a run failed. Now every reminder run is logged with a Sent/Partial/Failed status, failed count, and error.

3. **Submitting a movie errored if it had already been suggested and hidden by an un-RSVP.** The per-event unique index only ignored admin-deleted rows, so a hidden title kept reserving the movie. Now another member can re-suggest it — plus a one-off script to move the original's votes onto the new suggestion.

4. **Restoring on re-RSVP ignored vote budgets.** When an author returned to "going", every vote on their restored suggestions re-counted with no budget check — a member who'd re-spent their freed vote could land over their limit, and a stale vote came back even though its owner had moved on.

## Implementation

**Top-3 lock-in at any time (`feat:`)** — Migration `20260707…` redefines `is_locked_in(sid)` to drop the 7-day gate: locked in purely on rank (top 3 by live votes, ≥1 vote). `overview.vue` copy reworded.

**Reminder audit log + status (`feat:`)** — Migration `20260708…` adds `status`/`failed_count`/`error` to `comms_log` (defaults keep existing rows + announce/invite unchanged; RLS untouched). New `commsStatus(sent, failed)` helper; the cron and manual route log **every** attempt (including total failures). `useCommsLog`/`CommsLog.vue` gain `reminder` as a first-class kind plus a Sent/Partial/Failed badge, failed count, and error — in the existing per-event **Comms** tab.

**Re-suggest a hidden movie (`fix:`)** — Migration `20260709…` narrows `suggestions_event_movie_unique` to on-ballot rows (`deleted = false AND rsvp_hidden_at is null`); culled rows still hold their slot. The RSVP restore branch is guarded so a returning author's suggestion is not un-hidden when the movie is already live under another row (which would collide on the index). `scripts/one-off/reassign-mario-votes.sql` moves votes stranded on the old hidden suggestion onto the new active one.

**Budget-aware restore (`fix:`)** — Migration `20260710…` reconciles votes on re-RSVP. After un-hiding the author's suggestions + their own votes, every affected voter (anyone with a vote on a just-restored suggestion, plus the returning author) is clamped to their vote limit: **keep their newest `limit` live votes, hide the rest.** Newest wins, so a vote re-cast while the movie was away stands and the stale returned vote drops out — **hidden, not deleted**, so it can return later if a slot frees. The confirmed rule: *a freed vote comes back only if its owner still has an open slot.* The one-off script applies the same rule (only moves a vote whose owner has room). Leave-"Going" modal copy updated to explain this.

## How to Test

**Automated coverage (added/updated):**
- `test/comms.test.ts` — `commsStatus` (sent/partial/failed/no-op).
- `test/useCommsLog.nuxt.test.ts` / `test/CommsLog.nuxt.test.ts` — reminder kind, status/failedCount/error mapping + badges/error rendering; legacy rows default to `sent`.
- `test/rls.integration.test.ts` — top-3 lock-in regardless of distance; re-suggesting a movie hidden by un-RSVP (and the author's return not colliding); **freed vote returns when the voter has room, and stays out when they've re-spent their budget** (newest kept). (Supabase local via `SUPABASE_TEST_*`.)
- Full unit suite: **467 passed / 21 skipped**; `typecheck` + `lint` clean.

**Manual repro:**
- *Lock-in:* event >7 days out, a top-3 suggestion with ≥1 vote, author RSVPs "no" → stays on the ballot.
- *Audit log:* after a reminder send, open the admin **Comms** tab → status badge; force a failure to see Failed + error.
- *Re-suggest:* A suggests a movie, un-RSVPs; B submits the same movie → succeeds; A returns → A's original stays hidden, B's stays live.
- *Budget restore:* B votes on A's pick + fills the rest of their ballot; A un-RSVPs, B re-spends the freed slot; A returns → B's vote on A's pick drops out (newer re-spent vote kept). If B had room, the vote returns instead.
- *Vote reassignment:* fill the two ids in `scripts/one-off/reassign-mario-votes.sql` and run it in the Supabase SQL editor.

## Invariants & Risk

- **Four additive migrations:** `create or replace` of `is_locked_in`; three defaulted columns on `comms_log`; a re-created partial unique index; two `create or replace`s of the `sync_rsvp_visibility` trigger (collision guard, then budget reconciliation). No table drops.
- **RLS / authorization unchanged** (Invariant 1): `comms_log` stays admin-read/insert; the hide/restore trigger keeps its `SECURITY DEFINER` + only-own-rows-plus-affected-voters scope.
- **Vote integrity** (Invariant 3): the unique index still forbids two *on-ballot* rows per movie; restore now guarantees no voter exceeds their limit (keep-newest, hide-oldest — hidden, not deleted); the one-off is manual, self-guarding, idempotent, and budget-aware. No vote counter exists to drift.
- **Admin role (Invariant 4):** comms log only *reads* `profiles.is_admin`.
- **Rendered HTML (Invariant 5):** the comms log renders the Resend error as text (no `v-html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)