### PR TITLE
fix: restore Super Mario Bros (1993) suggestion + historic votes for Ryan

### DIFF
--- a/supabase/migrations/20260711000000_restore_mario_bros_suggestion.sql
+++ b/supabase/migrations/20260711000000_restore_mario_bros_suggestion.sql
@@ -1,0 +1,83 @@
+-- ============================================================================
+-- Data fix: restore Super Mario Bros. (1993, Dennis Hopper) as a suggestion.
+--
+-- The movie was suggested on a past event and collected votes. Re-add it to
+-- the next upcoming event, attributed to Ryan Donald, and carry one vote over
+-- for every user who voted on it historically (any prior suggestion of it).
+--
+-- Runs as plain SQL, so auth.uid() is null and the set_user_id +
+-- participation-limit triggers deliberately don't apply — the same exemption
+-- the Firestore import relied on (see 20260623000000_restore_participation_limits.sql).
+--
+-- Idempotent: re-running reuses the existing suggestion and the vote copy
+-- upserts with `on conflict do nothing`. Fails loudly (aborting the whole
+-- migration) if the profile, the historic suggestion, or an upcoming event
+-- can't be found, rather than silently doing nothing.
+-- ============================================================================
+
+do $$
+declare
+  ryan_id      uuid;
+  target_event uuid;
+  target_title text;
+  movie        jsonb;
+  suggestion   uuid;
+  copied       int;
+begin
+  select id into ryan_id
+  from public.profiles
+  where lower(email) = 'ryanthomasdonald@gmail.com';
+  if ryan_id is null then
+    raise exception 'No profile found for ryanthomasdonald@gmail.com';
+  end if;
+
+  -- Copy the movie payload from the most recent historic suggestion of it.
+  -- TMDB id 9607 = Super Mario Bros. (1993); title+year fallback in case the
+  -- imported jsonb carries a different id shape.
+  select s.tmdb_movie into movie
+  from public.suggestions s
+  where s.tmdb_movie->>'id' = '9607'
+     or (s.tmdb_movie->>'title' ilike 'super mario bros%'
+         and s.tmdb_movie->>'release_date' like '1993%')
+  order by s.created_at desc
+  limit 1;
+  if movie is null then
+    raise exception 'No historic Super Mario Bros. (1993) suggestion found to copy from';
+  end if;
+
+  -- Attach to the next upcoming event.
+  select id, title into target_event, target_title
+  from public.events
+  where event_date >= current_date
+  order by event_date asc
+  limit 1;
+  if target_event is null then
+    raise exception 'No upcoming event to attach the suggestion to';
+  end if;
+  raise notice 'Attaching to event "%" (%)', target_title, target_event;
+
+  -- Reuse Ryan's existing suggestion of it on that event, else create one.
+  select id into suggestion
+  from public.suggestions
+  where event_id = target_event
+    and user_id = ryan_id
+    and tmdb_movie->>'id' = movie->>'id'
+    and deleted = false;
+  if suggestion is null then
+    insert into public.suggestions (event_id, user_id, tmdb_movie)
+    values (target_event, ryan_id, movie)
+    returning id into suggestion;
+  end if;
+
+  -- One vote per distinct historic voter, carried onto the new suggestion.
+  insert into public.votes (suggestion_id, user_id)
+  select distinct suggestion, v.user_id
+  from public.votes v
+  join public.suggestions s on s.id = v.suggestion_id
+  where s.tmdb_movie->>'id' = movie->>'id'
+    and s.id <> suggestion
+  on conflict (suggestion_id, user_id) do nothing;
+  get diagnostics copied = row_count;
+  raise notice 'Carried % historic vote(s) onto suggestion %', copied, suggestion;
+end;
+$$;

--- a/supabase/migrations/20260711000000_restore_mario_bros_suggestion.sql
+++ b/supabase/migrations/20260711000000_restore_mario_bros_suggestion.sql
@@ -9,8 +9,10 @@
 -- participation-limit triggers deliberately don't apply — the same exemption
 -- the Firestore import relied on (see 20260623000000_restore_participation_limits.sql).
 --
--- Idempotent: re-running reuses the existing suggestion and the vote copy
--- upserts with `on conflict do nothing`. Fails loudly (aborting the whole
+-- Idempotent: a live suggestion of the movie already on the event (any
+-- author, incl. rsvp-hidden/culled — the event+movie unique index counts
+-- those) is adopted and reassigned to Ryan rather than inserted again, and
+-- the vote copy upserts with `on conflict do nothing`. Fails loudly (aborting the whole
 -- migration) if the profile, the historic suggestion, or an upcoming event
 -- can't be found, rather than silently doing nothing.
 -- ============================================================================
@@ -56,14 +58,20 @@ begin
   end if;
   raise notice 'Attaching to event "%" (%)', target_title, target_event;
 
-  -- Reuse Ryan's existing suggestion of it on that event, else create one.
+  -- The suggestions_event_movie_unique index allows only one live suggestion
+  -- of a movie per event, whoever authored it. If one already exists (possibly
+  -- rsvp-hidden or culled), adopt it: reassign to Ryan and restore it to the
+  -- ballot. Only insert when there is none.
   select id into suggestion
   from public.suggestions
   where event_id = target_event
-    and user_id = ryan_id
     and tmdb_movie->>'id' = movie->>'id'
     and deleted = false;
-  if suggestion is null then
+  if suggestion is not null then
+    update public.suggestions
+    set user_id = ryan_id, rsvp_hidden_at = null, culled_at = null
+    where id = suggestion;
+  else
     insert into public.suggestions (event_id, user_id, tmdb_movie)
     values (target_event, ryan_id, movie)
     returning id into suggestion;


### PR DESCRIPTION
## Scope

Data migration only — no app code. Re-adds **Super Mario Bros. (1993, Dennis Hopper)** as a suggestion on the **next upcoming event**, attributed to **Ryan Donald** (`ryanthomasdonald@gmail.com`), and carries over one vote for every user who voted on it historically (any prior suggestion of the movie, matched by TMDB id 9607 with a title+year fallback).

## Implementation

Single `do $$` block in `supabase/migrations/20260711000000_restore_mario_bros_suggestion.sql`:

1. Look up Ryan's profile by email — abort loudly if missing.
2. Copy the `tmdb_movie` jsonb from the most recent historic suggestion of the movie (no hand-crafted payload) — abort if none found.
3. Target the soonest event with `event_date >= current_date` (the name is echoed via `raise notice` so you can confirm during `db push`).
4. Insert the suggestion for Ryan (reuses his existing one if re-run).
5. `insert … select distinct` historic voters onto the new suggestion, `on conflict do nothing`.

## How to Test

Data migration — no unit surface. Apply with `supabase db push` (or paste the block into the SQL editor); the `raise notice` lines report the target event and the number of votes carried. Re-running is a no-op. If any lookup misses, the whole block raises and nothing is written.

## Invariants & Risk

- **Vote integrity (Invariant 3):** votes stay normalized rows with the `(suggestion_id, user_id)` PK — one carried vote per historic voter, duplicates impossible. The participation-limit and `set_user_id` triggers are exempt for plain-SQL inserts (`auth.uid()` is null) **by design** — the documented import path. Note: carried votes may put some voters at/over the 3-vote UI cap for this event; the triggers only gate future INSERTs, matching how the Firestore history import behaved.
- No RLS policy, key, or client-code changes.