### PR TITLE
fix(ci): auto-repair Dependabot's broken npm lockfiles

### DIFF
--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -1,0 +1,64 @@
+name: Fix Dependabot lockfile
+
+# Dependabot's npm updater regenerates package-lock.json with its own tooling
+# and drops the nested dedup entries this lockfile needs (e.g.
+# node_modules/@nuxt/cli/node_modules/cac@6.7.14 — parents that require
+# versions conflicting with the hoisted root copies). The result fails
+# `npm ci` ("Missing: … from lock file") on every Dependabot npm PR.
+#
+# This job re-resolves the lockfile with the SAME npm that CI uses (via
+# .nvmrc), pushes the correction back to the Dependabot branch, and
+# re-dispatches CI (a push made with the workflow token doesn't retrigger
+# `pull_request` workflows on its own).
+#
+# Scope is deliberately tight: Dependabot-authored, same-repo branches only,
+# and the lockfile is regenerated with --ignore-scripts so no package code
+# runs. If Dependabot later force-pushes a rebase, the fix commit is dropped
+# and this workflow simply runs again.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths: [package-lock.json]
+
+permissions:
+  contents: write # push the corrected lockfile
+  actions: write # re-dispatch ci.yml on the branch
+
+concurrency:
+  group: dependabot-lockfile-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  fix-lockfile:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Re-resolve the lockfile
+        run: npm install --package-lock-only --ignore-scripts
+      - name: Verify the lockfile satisfies npm ci
+        run: npm ci --dry-run --ignore-scripts
+      - name: Push the correction and re-dispatch CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if git diff --quiet package-lock.json; then
+            echo "Lockfile already consistent — nothing to fix."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json
+          git commit -m "chore(deps): repair lockfile after Dependabot update"
+          git push origin "HEAD:$BRANCH"
+          gh workflow run ci.yml --ref "$BRANCH"


### PR DESCRIPTION
## Scope

Every Dependabot npm PR fails the `verify` check with:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Missing: cac@6.7.14 from lock file
npm error Missing: commander@13.1.0 from lock file
npm error Missing: crossws@0.4.9 from lock file
```

**Root cause:** our lockfile legitimately contains *nested* dedup entries — `node_modules/@nuxt/cli/node_modules/cac@6.7.14`, `…/commander@13.1.0` (required by `@bomb.sh/tab`, conflicting with the hoisted `cac@7`/`commander@11`), and `crossws@0.4.9` under `@nuxt/test-utils`/`devframe` (root has `0.3.5`). Dependabot's npm updater regenerates the lockfile with its own tooling and **silently deletes those nested entries**, producing an internally inconsistent lockfile. This is a known dependabot-core npm bug; nothing in `dependabot.yml` can turn it off, and `npm dedupe` can't help because the version conflicts are real.

## Implementation

New workflow `dependabot-lockfile-fix.yml`: on Dependabot-authored, same-repo PRs that touch `package-lock.json`, it re-resolves the lockfile with the same npm CI uses (`.nvmrc`, `--package-lock-only --ignore-scripts` so no package code executes), verifies `npm ci --dry-run` passes, pushes the correction to the PR branch, and re-dispatches `ci.yml` on the branch (pushes made with the workflow token don't retrigger `pull_request` runs; `ci.yml` already has `workflow_dispatch`). If Dependabot force-pushes a rebase later, the fix commit drops and the workflow just runs again.

## How to Test

Reproduced end-to-end locally on PR #162's branch: `npm ci --dry-run` fails with the exact CI error; `npm install --package-lock-only --ignore-scripts` restores the 56 missing lockfile lines; `npm ci --dry-run` then passes. Workflows have no unit-test surface — the live proof comes from commenting `@dependabot rebase` on any open Dependabot PR after this merges (the rebase force-push triggers a `synchronize` event and the repair runs).

## Invariants & Risk

- Gated to `dependabot[bot]` + same-repo head, so no fork code runs with the elevated token; the only elevated permissions are `contents: write` (push the lockfile) and `actions: write` (dispatch CI).
- `--ignore-scripts` everywhere — lockfile resolution never executes package lifecycle scripts.
- No app code, RLS, or keys touched.