### PR TITLE
fix: stop RSVP reminders emailing members who already RSVP'd in-app

### DIFF
--- a/supabase/migrations/20260711020000_sync_evite_from_member_rsvp.sql
+++ b/supabase/migrations/20260711020000_sync_evite_from_member_rsvp.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Close the reminder gap for members who RSVP'd in the app.
+--
+-- 20260705000000_sync_member_rsvp_to_evite.sql mirrors rsvps → event_invites,
+-- but only from the moment it was created and only when the rsvps row changes.
+-- Two holes let already-RSVP'd members get "please RSVP" reminder emails:
+--
+--   1. No backfill: members who RSVP'd in-app before that trigger existed
+--      still have rsvp = null on their e-vite row.
+--   2. Invite created after the RSVP: the trigger watches rsvps, so an e-vite
+--      row added for a member who already responded starts null and never syncs.
+--
+-- Fix: a BEFORE INSERT trigger on event_invites that adopts the member's
+-- current in-app RSVP (matched by event + normalized email, same rule as the
+-- other direction), plus a one-time backfill for the rows already in the gap.
+-- Explicitly-set rsvp values (e.g. imports) are never clobbered. Email edits
+-- on an existing invite are not re-synced — invites are created, not re-keyed.
+-- ============================================================================
+
+create function public.sync_evite_from_member_rsvp() returns trigger
+  language plpgsql security definer set search_path = public as $$
+declare
+  member_status text;
+  member_since  timestamptz;
+begin
+  if new.rsvp is not null then
+    return new;
+  end if;
+  select r.status, r.updated_at into member_status, member_since
+  from public.rsvps r
+  join public.profiles p on p.id = r.user_id
+  where r.event_id = new.event_id
+    and lower(trim(p.email)) = lower(trim(new.email))
+  limit 1;
+  if member_status is not null then
+    new.rsvp := member_status;
+    new.rsvp_at := coalesce(member_since, now());
+  end if;
+  return new;
+end;
+$$;
+
+create trigger event_invites_sync_from_member_rsvp
+  before insert on public.event_invites
+  for each row execute function public.sync_evite_from_member_rsvp();
+
+-- One-time backfill for invites already out of sync (pre-trigger RSVPs and
+-- invites created after the member responded).
+update public.event_invites ei
+set rsvp    = r.status,
+    rsvp_at = coalesce(r.updated_at, now())
+from public.rsvps r
+join public.profiles p on p.id = r.user_id
+where ei.rsvp is null
+  and ei.event_id = r.event_id
+  and lower(trim(ei.email)) = lower(trim(p.email));

--- a/test/rls.integration.test.ts
+++ b/test/rls.integration.test.ts
@@ -520,3 +520,70 @@ describe.skipIf(!ready)('invite-only RLS boundary', () => {
     await admin!.from('invites').delete().eq('email', email)
   })
 })
+
+describe.skipIf(!ready)('e-vite adopts an existing in-app RSVP on insert', () => {
+  const stamp = Date.now()
+  const goingEmail = `evite_going_${stamp}@example.com`
+  const explicitEmail = `evite_explicit_${stamp}@example.com`
+  const myUserIds: string[] = []
+  let eventId = ''
+
+  beforeAll(async () => {
+    const goingId = await makeUser(goingEmail)
+    const explicitId = await makeUser(explicitEmail)
+    myUserIds.push(goingId, explicitId)
+    await admin!.from('invites').insert([{ email: goingEmail }, { email: explicitEmail }])
+    const { data: ev, error } = await admin!
+      .from('events')
+      .insert({ title: 'Sync-Back Night', event_date: new Date(stamp + 7 * 86_400_000).toISOString() })
+      .select('id')
+      .single()
+    if (error || !ev) throw error ?? new Error('event seed failed')
+    eventId = ev.id
+    // Both members RSVP in-app BEFORE any e-vite row exists — the reminder-gap
+    // scenario: the rsvps→evite trigger has nothing to update yet.
+    const { error: rsvpError } = await admin!.from('rsvps').insert([
+      { event_id: eventId, user_id: goingId, status: 'going' },
+      { event_id: eventId, user_id: explicitId, status: 'going' }
+    ])
+    if (rsvpError) throw rsvpError
+  }, 30_000)
+
+  afterAll(async () => {
+    if (!admin) return
+    await admin.from('events').delete().eq('id', eventId)
+    await admin.from('invites').delete().in('email', [goingEmail, explicitEmail])
+    for (const id of myUserIds) await admin.auth.admin.deleteUser(id)
+  })
+
+  it('an invite created after the member RSVP\'d in-app adopts their response (case-insensitive)', async () => {
+    const { data, error } = await admin!
+      .from('event_invites')
+      .insert({ event_id: eventId, email: goingEmail.toUpperCase() })
+      .select('rsvp, rsvp_at')
+      .single()
+    expect(error).toBeNull()
+    expect(data?.rsvp, 'invite adopts the in-app RSVP so reminders skip them').toBe('going')
+    expect(data?.rsvp_at).toBeTruthy()
+  })
+
+  it('an invite for an email with no in-app RSVP stays a non-responder', async () => {
+    const { data, error } = await admin!
+      .from('event_invites')
+      .insert({ event_id: eventId, email: `evite_quiet_${stamp}@example.com` })
+      .select('rsvp')
+      .single()
+    expect(error).toBeNull()
+    expect(data?.rsvp).toBeNull()
+  })
+
+  it('an explicitly-set rsvp on insert is not clobbered by the member\'s in-app response', async () => {
+    const { data, error } = await admin!
+      .from('event_invites')
+      .insert({ event_id: eventId, email: explicitEmail, rsvp: 'no' })
+      .select('rsvp')
+      .single()
+    expect(error).toBeNull()
+    expect(data?.rsvp).toBe('no')
+  })
+})


### PR DESCRIPTION
## Scope

The RSVP reminder went out to people already on the guest list. Reminders target `event_invites` rows with `rsvp = null`, relying on the `sync_member_rsvp_to_evite` trigger (added 2026-07-05) to mirror in-app RSVPs onto e-vite rows. Two holes defeat that:

1. **No backfill** — members who RSVP'd in-app *before* the trigger existed were never mirrored.
2. **Invite created after the RSVP** — the trigger watches `rsvps` changes only, so an e-vite row added for a member who had already responded starts `null` and never syncs.

Verified against prod: **5 invites** are `rsvp = null` while the same email has an in-app RSVP of `going` for the same event — all 5 were sent the reminder on 2026-07-11 14:48 UTC.

## Implementation

One migration (`20260711020000_sync_evite_from_member_rsvp.sql`):

- A `BEFORE INSERT` trigger on `event_invites` that adopts the member's current in-app RSVP, matched by event + normalized email (same rule as the existing mirror). It never clobbers an explicitly-set `rsvp`, and fires after the existing `event_invites_normalize_email` trigger (alphabetical BEFORE-trigger order), though it normalizes defensively anyway.
- A one-time backfill for the rows already in the gap — this immediately fixes the 5 prod rows.

No app-code changes: the reminder cron and the manual send both already skip `rsvp != null` rows.

## How to Test

Three new integration cases in `test/rls.integration.test.ts`, run against local Supabase with all migrations applied (`supabase db reset`) — **21/21 pass locally**:

- invite created after the member RSVP'd in-app adopts their response (case-insensitive email match)
- invite for an email with no in-app RSVP stays a non-responder
- explicitly-set `rsvp` on insert is not clobbered

Manual: RSVP as a member in-app, then add that email to the event's guest list — the new invite row shows the RSVP immediately and "remind non-responders" skips them.

## Invariants & Risk

- Trigger is `SECURITY DEFINER` with pinned `search_path`, matching the existing mirror trigger; RLS policies unchanged (members still have no write path to `event_invites`).
- Backfill only fills `rsvp IS NULL` rows — an explicit e-vite response is never overwritten.
- No keys, vote integrity, or rendered HTML touched.