### PR TITLE
feat: members can add custom bring-list items (and still claim admin ones)

### DIFF
--- a/app/components/BringList.vue
+++ b/app/components/BringList.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { BringItem } from '#shared/types/bring'
 
-// `manage` = admin curation (add + edit + remove items); otherwise it's the
-// public claim view (volunteer for an open slot, or unclaim your own).
+// `manage` = admin curation (add + edit + remove any item); otherwise it's the
+// public view: volunteer for an open slot, unclaim your own, add a custom item
+// you're bringing, or remove an item you added (unless someone else claimed it).
 defineProps<{ items: BringItem[], manage?: boolean }>()
 const emit = defineEmits<{
   add: [label: string]
@@ -41,6 +42,11 @@ function saveEdit(item: BringItem): void {
 function mine(item: BringItem): boolean {
   return Boolean(item.user_id) && item.user_id === myId.value
 }
+
+// You may retract an item you added, but not out from under someone else's claim.
+function removableByMe(item: BringItem): boolean {
+  return item.created_by === myId.value && (!item.user_id || item.user_id === myId.value)
+}
 </script>
 
 <template>
@@ -76,6 +82,16 @@ function mine(item: BringItem): boolean {
         <template v-if="!manage">
           <UButton v-if="!item.user_id" label="I'll bring it" size="xs" class="shrink-0" @click="emit('claim', item)" />
           <UButton v-else-if="mine(item)" label="Unclaim" size="xs" color="neutral" variant="ghost" class="shrink-0" @click="emit('unclaim', item)" />
+          <UButton
+            v-if="removableByMe(item)"
+            icon="i-lucide-trash-2"
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            class="shrink-0"
+            aria-label="Remove item"
+            @click="emit('remove', item)"
+          />
         </template>
 
         <!-- Admin curation: edit / remove an item -->
@@ -90,12 +106,17 @@ function mine(item: BringItem): boolean {
       </li>
     </ul>
     <p v-else class="text-sm text-muted">
-      {{ manage ? 'Nothing on the list yet — add what the group needs.' : 'Nothing to bring yet — the organizer will add items.' }}
+      {{ manage ? 'Nothing on the list yet — add what the group needs.' : 'Nothing to bring yet — add something below.' }}
     </p>
 
-    <!-- Add an item (admin only) -->
-    <div v-if="manage" class="flex gap-2">
-      <UInput v-model="newItem" placeholder="e.g. pepperoni, drinks, plates…" class="flex-1" @keydown.enter="add" />
+    <!-- Add an item: admins curate open slots; members add what they're bringing -->
+    <div class="flex gap-2">
+      <UInput
+        v-model="newItem"
+        :placeholder="manage ? 'e.g. pepperoni, drinks, plates…' : 'Bringing something else? e.g. brownies'"
+        class="flex-1"
+        @keydown.enter="add"
+      />
       <UButton label="Add" icon="i-lucide-plus" :disabled="!newItem.trim()" @click="add" />
     </div>
   </div>

--- a/app/components/EventInfoModal.vue
+++ b/app/components/EventInfoModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { MovieEvent } from '#shared/types/event'
 import type { CalendarEvent } from '#shared/utils/calendar'
+import type { BringItem } from '#shared/types/bring'
 
 const open = defineModel<boolean>('open', { default: false })
 const props = defineProps<{ event: MovieEvent | null }>()
@@ -10,7 +11,27 @@ const { myStatus, myPlusOnes, counts, setStatus, setGuests } = useRsvp(eventId)
 // The merged "who's coming" roster (in-app + e-vite email replies). Members see
 // fellow members; admins also see email-only guests (event_invites is admin-only).
 const { roster } = useEventRsvps(eventId)
-const { items, claim, unclaim } = useBringList(eventId)
+const { items, addItem, claim, unclaim, remove } = useBringList(eventId)
+const { run } = useToastAction()
+const toast = useToast()
+
+// Members add items they're bringing themselves (claimSelf), unlike the admin
+// tab which curates open slots. Removal is limited in the UI (and by RLS) to
+// items you added.
+async function onAddBring(label: string): Promise<void> {
+  if (await run(() => addItem(label), 'Could not add your item')) {
+    toast.add({ title: 'Added to the bring list', icon: 'i-lucide-check', color: 'success' })
+  }
+}
+async function onRemoveBring(item: BringItem): Promise<void> {
+  await run(() => remove(item), 'Could not remove the item')
+}
+async function onClaim(item: BringItem): Promise<void> {
+  await run(() => claim(item), 'Could not claim the item')
+}
+async function onUnclaim(item: BringItem): Promise<void> {
+  await run(() => unclaim(item), 'Could not unclaim the item')
+}
 
 const calEvent = computed<CalendarEvent | null>(() => {
   const e = props.event
@@ -145,8 +166,10 @@ function downloadIcs(): void {
           </h3>
           <BringList
             :items="items"
-            @claim="claim"
-            @unclaim="unclaim"
+            @add="onAddBring"
+            @claim="onClaim"
+            @unclaim="onUnclaim"
+            @remove="onRemoveBring"
           />
         </div>
       </div>

--- a/test/BringList.nuxt.test.ts
+++ b/test/BringList.nuxt.test.ts
@@ -8,7 +8,9 @@ mockNuxtImport('useAuth', () => () => ({ myId: ref('me'), isAdmin: ref(false) })
 
 const items = [
   { id: 'b1', event_id: 'e1', label: 'Chips', note: null, user_id: null, created_by: 'x', bringer: null },
-  { id: 'b2', event_id: 'e1', label: 'Drinks', note: null, user_id: 'me', created_by: 'me', bringer: { display_name: 'Me' } }
+  { id: 'b2', event_id: 'e1', label: 'Drinks', note: null, user_id: 'me', created_by: 'me', bringer: { display_name: 'Me' } },
+  // My custom item that someone else has since claimed — no longer mine to remove.
+  { id: 'b3', event_id: 'e1', label: 'Salsa', note: null, user_id: 'other', created_by: 'me', bringer: { display_name: 'Ann' } }
 ]
 
 describe('BringList (public claim view)', () => {
@@ -37,9 +39,28 @@ describe('BringList (public claim view)', () => {
     expect(w.emitted('unclaim')?.[0]).toEqual([items[1]])
   })
 
-  it('has no add input — the list is admin-curated', async () => {
+  it('emits add for a custom item a member types in', async () => {
     const w = await mountSuspended(BringList, { props: { items } })
-    expect(w.find('input').exists()).toBe(false)
+    await w.find('input').setValue('Brownies')
+    const addBtn = w.findAll('button').find(b => b.text().trim() === 'Add')
+    await addBtn?.trigger('click')
+    expect(w.emitted('add')?.[0]).toEqual(['Brownies'])
+  })
+
+  it('does not emit add for a blank label', async () => {
+    const w = await mountSuspended(BringList, { props: { items } })
+    await w.find('input').setValue('   ')
+    await w.find('input').trigger('keydown.enter')
+    expect(w.emitted('add')).toBeUndefined()
+  })
+
+  it('emits remove only for an item I added and still hold', async () => {
+    const w = await mountSuspended(BringList, { props: { items } })
+    const removeBtns = w.findAll('button').filter(b => b.attributes('aria-label') === 'Remove item')
+    // b1 is admin-created and b3 is claimed by someone else — only b2 is removable.
+    expect(removeBtns).toHaveLength(1)
+    await removeBtns[0]!.trigger('click')
+    expect(w.emitted('remove')?.[0]).toEqual([items[1]])
   })
 })
 


### PR DESCRIPTION
## Scope

Members could previously only volunteer for bring-list slots the admin had curated. This PR opens the member-facing bring list (in the event info modal) so users can also add custom items they're bringing themselves — and retract an item they added — while admins keep full curation in the admin tab.

## Implementation

No schema or policy changes were needed: the existing `bring_items` RLS (`20260616030000_event_day.sql`) already permits create-as-self (`created_by = auth.uid()`, `user_id` null or self) and creator/claimer delete, and `useBringList.addItem()` already supports `claimSelf`. The work is UI + wiring:

- `BringList.vue`: the add input now renders in the public (non-`manage`) view with member-appropriate copy; items you created show a remove button, hidden once someone else claims the item (so you can't yank a slot out from under another volunteer — mirrors the polite subset of what RLS allows).
- `EventInfoModal.vue`: wires `@add` (claim-self insert) and `@remove` through `useToastAction` with success/error toasts, matching the admin page pattern. Claim/unclaim are now wrapped too, so their failures surface as error toasts instead of unhandled rejections.

## Screenshots

UI change is small: an add input below the bring list in the event modal, and a trash button on your own custom items. Happy to add before/after captures if wanted.

## How to Test

1. Automated: `test/BringList.nuxt.test.ts` — member add emits with the typed label, blank labels don't emit, remove renders only for items you created and still hold (admin-created and other-claimed items excluded). Existing `useBringList` tests already cover the claim-self insert payload. Full suite: 469 passed; lint/typecheck/build clean.
2. Manual: open an upcoming event's info modal as a non-admin → "Bring list" section. Type e.g. "Brownies" → Add. It appears claimed by you with a trash button. Claim an admin item ("I'll bring it") — no trash button on it. Remove your custom item. As a second user, claim someone else's custom item and confirm the creator no longer sees a remove button for it.

## Invariants & Risk

- No RLS, schema, or trigger changes; authorization was already enforced at the policy layer and the UI now exposes a subset of what it permits (Invariant 1 holds).
- No keys, vote paths, admin-role writes, or rendered HTML touched.