### PR TITLE
feat: rich text editor + reusable templates in the Comms tab

### DIFF
--- a/app/components/EventAnnounceComposer.vue
+++ b/app/components/EventAnnounceComposer.vue
@@ -36,9 +36,11 @@ const state = reactive<{ subject: string, message: string, scope: Scope }>({
 
 const messageHasText = computed(() => htmlToText(state.message).length > 0)
 
+// The subject always mirrors the chosen template — including clearing it for a
+// subject-less template — so the form never shows a stale draft as "applied".
 function applyTemplate(template: CommsTemplate): void {
   state.message = template.body
-  if (template.subject) state.subject = template.subject
+  state.subject = template.subject ?? ''
 }
 
 async function onSaveTemplate(): Promise<void> {
@@ -52,7 +54,9 @@ async function onSaveTemplate(): Promise<void> {
 }
 
 async function onRemoveTemplate(template: CommsTemplate): Promise<void> {
-  await run(() => removeTemplate(template), 'Could not delete the template')
+  if (await run(() => removeTemplate(template), 'Could not delete the template')) {
+    toast.add({ title: 'Template deleted', icon: 'i-lucide-check', color: 'success' })
+  }
 }
 
 function messageOf(error: unknown): string | undefined {

--- a/app/components/EventAnnounceComposer.vue
+++ b/app/components/EventAnnounceComposer.vue
@@ -1,11 +1,20 @@
 <script setup lang="ts">
 import { z } from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
+import type { CommsTemplate } from '#shared/types/comms-template'
 
 // Admin event blast composer → POST /api/events/announce (admin-gated server-side).
+// The message is rich text (tiptap); the server sanitizes it to a strict tag
+// allowlist before it goes into the email. Templates let a recurring blast
+// (e.g. the vote + bring-list nudge) be applied, tweaked, and re-sent later.
 const props = defineProps<{ eventId: string | undefined }>()
 const toast = useToast()
+const { run } = useToastAction()
 const sending = ref(false)
+
+const { templates, saveTemplate, removeTemplate } = useCommsTemplates()
+const savingTemplate = ref(false)
+const templateName = ref('')
 
 const scopeOptions = [
   { label: 'Everyone invited', value: 'invited' as const },
@@ -16,7 +25,7 @@ type Scope = (typeof scopeOptions)[number]['value']
 
 const schema = z.object({
   subject: z.string().trim().max(200).optional(),
-  message: z.string().trim().min(1, 'Write a message'),
+  message: z.string().max(10000).refine(m => htmlToText(m).length > 0, 'Write a message'),
   scope: z.enum(['invited', 'members', 'going'])
 })
 const state = reactive<{ subject: string, message: string, scope: Scope }>({
@@ -24,6 +33,27 @@ const state = reactive<{ subject: string, message: string, scope: Scope }>({
   message: '',
   scope: 'members'
 })
+
+const messageHasText = computed(() => htmlToText(state.message).length > 0)
+
+function applyTemplate(template: CommsTemplate): void {
+  state.message = template.body
+  if (template.subject) state.subject = template.subject
+}
+
+async function onSaveTemplate(): Promise<void> {
+  const name = templateName.value.trim()
+  if (!name || !messageHasText.value) return
+  if (await run(() => saveTemplate(name, state.subject || null, state.message), 'Could not save the template')) {
+    toast.add({ title: 'Template saved', icon: 'i-lucide-check', color: 'success' })
+    savingTemplate.value = false
+    templateName.value = ''
+  }
+}
+
+async function onRemoveTemplate(template: CommsTemplate): Promise<void> {
+  await run(() => removeTemplate(template), 'Could not delete the template')
+}
 
 function messageOf(error: unknown): string | undefined {
   if (error && typeof error === 'object' && 'statusMessage' in error) {
@@ -69,24 +99,60 @@ async function onSubmit(event: FormSubmitEvent<{ subject?: string, message: stri
 </script>
 
 <template>
-  <UForm :schema="schema" :state="state" class="space-y-3" @submit="onSubmit">
-    <UFormField label="Audience" name="scope">
-      <USelectMenu
-        v-model="state.scope"
-        :items="scopeOptions"
-        value-key="value"
-        :search-input="false"
-        class="w-full sm:max-w-xs"
-      />
-    </UFormField>
-    <UFormField label="Subject" name="subject" hint="Optional">
-      <UInput v-model="state.subject" placeholder="Movie night reminder" class="w-full" />
-    </UFormField>
-    <UFormField label="Message" name="message" required>
-      <UTextarea v-model="state.message" :rows="5" placeholder="Doors at 7, first film at 7:30…" class="w-full" />
-    </UFormField>
-    <div class="flex justify-end">
-      <UButton type="submit" label="Send blast" icon="i-lucide-megaphone" :loading="sending" :disabled="!eventId" />
+  <div class="space-y-3">
+    <div v-if="templates.length" class="space-y-1.5">
+      <p class="text-xs font-medium text-muted">
+        Templates
+      </p>
+      <div class="flex flex-wrap gap-2">
+        <UButtonGroup v-for="tpl in templates" :key="tpl.id" size="xs">
+          <UButton :label="tpl.name" icon="i-lucide-file-text" color="neutral" variant="outline" @click="applyTemplate(tpl)" />
+          <UButton
+            icon="i-lucide-x"
+            color="neutral"
+            variant="outline"
+            :aria-label="`Delete template ${tpl.name}`"
+            @click="onRemoveTemplate(tpl)"
+          />
+        </UButtonGroup>
+      </div>
     </div>
-  </UForm>
+
+    <UForm :schema="schema" :state="state" class="space-y-3" @submit="onSubmit">
+      <UFormField label="Audience" name="scope">
+        <USelectMenu
+          v-model="state.scope"
+          :items="scopeOptions"
+          value-key="value"
+          :search-input="false"
+          class="w-full sm:max-w-xs"
+        />
+      </UFormField>
+      <UFormField label="Subject" name="subject" hint="Optional">
+        <UInput v-model="state.subject" placeholder="Movie night reminder" class="w-full" />
+      </UFormField>
+      <UFormField label="Message" name="message" required>
+        <RichTextEditor v-model="state.message" />
+      </UFormField>
+
+      <div v-if="savingTemplate" class="flex gap-2">
+        <UInput v-model="templateName" placeholder="Template name" class="flex-1" @keydown.enter.prevent="onSaveTemplate" />
+        <UButton label="Save" :disabled="!templateName.trim()" @click="onSaveTemplate" />
+        <UButton label="Cancel" color="neutral" variant="ghost" @click="savingTemplate = false" />
+      </div>
+
+      <div class="flex flex-wrap justify-between gap-2">
+        <UButton
+          v-if="!savingTemplate"
+          label="Save as template"
+          icon="i-lucide-bookmark-plus"
+          color="neutral"
+          variant="outline"
+          :disabled="!messageHasText"
+          @click="savingTemplate = true"
+        />
+        <UButton type="submit" label="Send blast" icon="i-lucide-megaphone" :loading="sending" :disabled="!eventId" class="ml-auto" />
+      </div>
+    </UForm>
+  </div>
 </template>

--- a/app/composables/useCommsTemplates.ts
+++ b/app/composables/useCommsTemplates.ts
@@ -34,7 +34,8 @@ export function useCommsTemplates(): {
   // created_by is omitted (the DB defaults it to auth.uid()).
   async function saveTemplate(name: string, subject: string | null, body: string): Promise<void> {
     const trimmed = name.trim()
-    if (!trimmed || !body.trim()) return
+    // htmlToText, not trim: an empty editor emits markup like <p></p>.
+    if (!trimmed || htmlToText(body).length === 0) return
     const { error: saveError } = await supabase
       .from('comms_templates')
       .insert({ name: trimmed, subject: subject?.trim() || null, body })

--- a/app/composables/useCommsTemplates.ts
+++ b/app/composables/useCommsTemplates.ts
@@ -1,0 +1,54 @@
+import type { Database } from '~/types/database.types'
+import type { CommsTemplate } from '#shared/types/comms-template'
+
+/**
+ * Reusable announcement templates for the admin Comms tab. Admin-gated by RLS
+ * (the comms_templates policies) — a non-admin reads nothing. Loads once on
+ * setup; mutations refresh the list (no realtime — templates change rarely and
+ * only from this screen).
+ */
+export function useCommsTemplates(): {
+  templates: Ref<CommsTemplate[]>
+  error: Ref<string | null>
+  refresh: () => Promise<void>
+  saveTemplate: (name: string, subject: string | null, body: string) => Promise<void>
+  removeTemplate: (template: CommsTemplate) => Promise<void>
+} {
+  const supabase = useSupabaseClient<Database>()
+  const templates = ref<CommsTemplate[]>([])
+  const error = ref<string | null>(null)
+
+  async function refresh(): Promise<void> {
+    const { data, error: loadError } = await supabase
+      .from('comms_templates')
+      .select('id, name, subject, body')
+      .order('name')
+    if (loadError) {
+      error.value = 'Failed to load templates'
+      return
+    }
+    error.value = null
+    templates.value = data ?? []
+  }
+
+  // created_by is omitted (the DB defaults it to auth.uid()).
+  async function saveTemplate(name: string, subject: string | null, body: string): Promise<void> {
+    const trimmed = name.trim()
+    if (!trimmed || !body.trim()) return
+    const { error: saveError } = await supabase
+      .from('comms_templates')
+      .insert({ name: trimmed, subject: subject?.trim() || null, body })
+    if (saveError) throw saveError
+    await refresh()
+  }
+
+  async function removeTemplate(template: CommsTemplate): Promise<void> {
+    const { error: removeError } = await supabase.from('comms_templates').delete().eq('id', template.id)
+    if (removeError) throw removeError
+    await refresh()
+  }
+
+  void refresh()
+
+  return { templates, error, refresh, saveTemplate, removeTemplate }
+}

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -65,6 +65,12 @@ export interface Database {
         Update: { id?: string, event_id?: string | null, kind?: string, scope?: string | null, subject?: string | null, recipient_count?: number, failed_count?: number, status?: string, error?: string | null, sent_by?: string | null, created_at?: string }
         Relationships: []
       }
+      comms_templates: {
+        Row: { id: string, name: string, subject: string | null, body: string, created_by: string | null, created_at: string }
+        Insert: { id?: string, name: string, subject?: string | null, body: string, created_by?: string | null, created_at?: string }
+        Update: { id?: string, name?: string, subject?: string | null, body?: string, created_by?: string | null, created_at?: string }
+        Relationships: []
+      }
       vote_refund_acks: {
         Row: { user_id: string, suggestion_id: string, created_at: string }
         Insert: { user_id: string, suggestion_id: string, created_at?: string }

--- a/server/api/events/announce.post.ts
+++ b/server/api/events/announce.post.ts
@@ -5,7 +5,9 @@ import type { Database } from '~/types/database.types'
 const bodySchema = z.object({
   eventId: z.string().uuid(),
   subject: z.string().trim().max(200).optional(),
-  message: z.string().trim().min(1).max(5000),
+  // Rich HTML from the composer's editor (markup inflates length — hence 10k);
+  // must have actual text, not just empty tags. Sanitized in buildAnnounceEmail.
+  message: z.string().max(10000).refine(m => htmlToText(m).length > 0),
   scope: z.enum(['members', 'going', 'invited'])
 })
 

--- a/shared/types/comms-template.ts
+++ b/shared/types/comms-template.ts
@@ -1,0 +1,9 @@
+/** A reusable announcement template for the admin Comms tab. */
+export interface CommsTemplate {
+  id: string
+  name: string
+  /** Optional prefilled email subject; null keeps whatever the admin typed. */
+  subject: string | null
+  /** Rich HTML for the composer's editor (re-sanitized server-side at send time). */
+  body: string
+}

--- a/shared/utils/email.ts
+++ b/shared/utils/email.ts
@@ -46,6 +46,8 @@ export function sanitizeEmailHtml(html: string): string {
       .replaceAll(`&lt;${tag}&gt;`, `<${tag}>`)
       .replaceAll(`&lt;/${tag}&gt;`, `</${tag}>`)
   }
+  // The loop restores <br>; this handles the self-closing <br/> form tiptap
+  // sometimes emits. Raw newlines (plain-text callers) become breaks too.
   return out.replaceAll('&lt;br/&gt;', '<br>').replace(/\n/g, '<br>')
 }
 

--- a/shared/utils/email.ts
+++ b/shared/utils/email.ts
@@ -28,6 +28,27 @@ export function htmlToText(html: string): string {
     .trim()
 }
 
+// The attribute-less tags the announce composer's editor (tiptap StarterKit)
+// emits. Anything else — including any tag carrying an attribute — stays escaped.
+const ANNOUNCE_RICH_TAGS = ['p', 'br', 'h1', 'h2', 'h3', 'h4', 'strong', 'em', 's', 'ul', 'ol', 'li', 'blockquote', 'code', 'pre', 'hr'] as const
+
+/**
+ * Sanitize rich-text HTML for an email body: escape everything, then restore
+ * only the exact literal tags above. Safe by construction — a tag with any
+ * attribute (`onerror=`, `href=`, `style=`) never matches the exact escaped
+ * form, so no markup we didn't explicitly re-allow can survive. Plain text
+ * passes through unchanged apart from newlines becoming <br>.
+ */
+export function sanitizeEmailHtml(html: string): string {
+  let out = escapeHtml(html)
+  for (const tag of ANNOUNCE_RICH_TAGS) {
+    out = out
+      .replaceAll(`&lt;${tag}&gt;`, `<${tag}>`)
+      .replaceAll(`&lt;/${tag}&gt;`, `</${tag}>`)
+  }
+  return out.replaceAll('&lt;br/&gt;', '<br>').replace(/\n/g, '<br>')
+}
+
 export interface BuiltEmail {
   subject: string
   html: string
@@ -93,15 +114,16 @@ export function buildAnnounceEmail(opts: {
   subject?: string
 }): BuiltEmail {
   const subject = opts.subject?.trim() || `${opts.eventTitle} — Benteen Screen On The Green`
-  // The admin message is plain text; escape it and preserve line breaks.
-  const messageHtml = escapeHtml(opts.message).replace(/\n/g, '<br>')
+  // The admin message is rich text from the composer's editor; keep only its
+  // known tags (plain text still works — newlines become <br>).
+  const messageHtml = sanitizeEmailHtml(opts.message)
   const html = shell(
     `<h1 style="font-size:20px;margin:0 0 4px">${escapeHtml(opts.eventTitle)}</h1>`
     + (opts.eventDate ? `<p style="color:#6b7280;margin:0 0 16px">${escapeHtml(opts.eventDate)}</p>` : '')
-    + `<p>${messageHtml}</p>`
+    + `<div>${messageHtml}</div>`
     + `<p style="margin:20px 0">${ctaButton('View on Benteen Screen', opts.link)}</p>`
   )
-  const text = `${opts.eventTitle}${opts.eventDate ? ` — ${opts.eventDate}` : ''}\n\n${opts.message}\n\n${opts.link}`
+  const text = `${opts.eventTitle}${opts.eventDate ? ` — ${opts.eventDate}` : ''}\n\n${htmlToText(opts.message)}\n\n${opts.link}`
   return { subject, html, text }
 }
 

--- a/supabase/migrations/20260712000000_comms_templates.sql
+++ b/supabase/migrations/20260712000000_comms_templates.sql
@@ -1,0 +1,37 @@
+-- Reusable announcement templates for the admin Comms tab, so a recurring blast
+-- (e.g. the "log in and vote + check the bring list" nudge) is composed once and
+-- sent again later with one click.
+--
+-- `body` is rich HTML from the composer's editor. It is NOT rendered raw anywhere:
+-- the editor loads it as content, and the announce route re-sanitizes at send time
+-- (sanitizeEmailHtml), so a hand-crafted row can't inject markup into emails.
+
+create table public.comms_templates (
+  id         uuid primary key default gen_random_uuid(),
+  name       text not null unique,
+  subject    text,
+  body       text not null,
+  created_by uuid default auth.uid() references public.profiles (id) on delete set null,
+  created_at timestamptz not null default now()
+);
+
+alter table public.comms_templates enable row level security;
+grant select, insert, delete on public.comms_templates to authenticated;
+
+-- Admin-only in both directions: templates are an admin tool and can reveal
+-- upcoming comms before they're sent.
+create policy "comms_templates: admin read" on public.comms_templates
+  for select to authenticated using (public.is_admin());
+create policy "comms_templates: admin insert" on public.comms_templates
+  for insert to authenticated with check (public.is_admin());
+create policy "comms_templates: admin delete" on public.comms_templates
+  for delete to authenticated using (public.is_admin());
+
+-- Starter template: the recurring vote + bring-list reminder. The announce email
+-- wrapper already adds the event title/date and a "View on Benteen Screen" button,
+-- so the body stays event-agnostic.
+insert into public.comms_templates (name, subject, body) values (
+  'Vote & bring list reminder',
+  'Reminder: vote for the movie & check the bring list',
+  '<p>Hey folks! 🎬</p><p>Movie night is coming up — two quick things:</p><ul><li><strong>Vote for the movie</strong> — log in and cast your votes for what we watch.</li><li><strong>Check the bring list</strong> — claim an item or add what you''re bringing.</li></ul><p>See you on the green!</p>'
+);

--- a/test/EventAnnounceComposer.nuxt.test.ts
+++ b/test/EventAnnounceComposer.nuxt.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment nuxt
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, ref } from 'vue'
 import { flushPromises } from '@vue/test-utils'
 import { mockNuxtImport, mountSuspended } from '@nuxt/test-utils/runtime'
 import EventAnnounceComposer from '../app/components/EventAnnounceComposer.vue'
@@ -7,8 +8,43 @@ import EventAnnounceComposer from '../app/components/EventAnnounceComposer.vue'
 const calls: Array<{ url: string, body: unknown }> = []
 mockNuxtImport('useToast', () => () => ({ add: () => {} }))
 
+// The tiptap editor needs a real DOM selection model; stub it with a textarea
+// that honors the same v-model contract so tests drive the message like text.
+const RichTextEditorStub = defineComponent({
+  props: { modelValue: { type: String, default: '' } },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    return () => h('textarea', {
+      value: props.modelValue,
+      onInput: (e: Event) => emit('update:modelValue', (e.target as HTMLTextAreaElement).value)
+    })
+  }
+})
+
+const templates = ref([
+  { id: 't1', name: 'Vote & bring list reminder', subject: 'Vote + bring list', body: '<p>Go <strong>vote</strong>!</p>' }
+])
+const saveTemplate = vi.fn(() => Promise.resolve())
+const removeTemplate = vi.fn(() => Promise.resolve())
+mockNuxtImport('useCommsTemplates', () => () => ({
+  templates,
+  error: ref(null),
+  refresh: () => Promise.resolve(),
+  saveTemplate,
+  removeTemplate
+}))
+
+async function mountComposer() {
+  return await mountSuspended(EventAnnounceComposer, {
+    props: { eventId: 'e1' },
+    global: { stubs: { RichTextEditor: RichTextEditorStub } }
+  })
+}
+
 beforeEach(() => {
   calls.length = 0
+  saveTemplate.mockClear()
+  removeTemplate.mockClear()
   vi.stubGlobal('$fetch', (url: string, opts: { body: unknown }) => {
     calls.push({ url, body: opts.body })
     return Promise.resolve({ ok: true, count: 3 })
@@ -18,7 +54,7 @@ afterEach(() => vi.unstubAllGlobals())
 
 describe('EventAnnounceComposer', () => {
   it('posts the announcement for the selected event', async () => {
-    const w = await mountSuspended(EventAnnounceComposer, { props: { eventId: 'e1' } })
+    const w = await mountComposer()
     await w.find('textarea').setValue('Doors at 7')
     await w.find('form').trigger('submit')
     await flushPromises()
@@ -27,9 +63,50 @@ describe('EventAnnounceComposer', () => {
   })
 
   it('does not post an empty message', async () => {
-    const w = await mountSuspended(EventAnnounceComposer, { props: { eventId: 'e1' } })
+    const w = await mountComposer()
     await w.find('form').trigger('submit')
     await flushPromises()
     expect(calls).toHaveLength(0)
+  })
+
+  it('does not post markup with no text (an empty editor emits <p></p>)', async () => {
+    const w = await mountComposer()
+    await w.find('textarea').setValue('<p></p>')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(calls).toHaveLength(0)
+  })
+
+  it('applying a template fills the message and subject, then sends it', async () => {
+    const w = await mountComposer()
+    const pill = w.findAll('button').find(b => b.text().includes('Vote & bring list reminder'))
+    await pill?.trigger('click')
+    expect((w.find('textarea').element as HTMLTextAreaElement).value).toBe('<p>Go <strong>vote</strong>!</p>')
+    const subjectInput = w.findAll('input').find(i => i.attributes('placeholder') === 'Movie night reminder')
+    expect((subjectInput?.element as HTMLInputElement).value).toBe('Vote + bring list')
+    await w.find('form').trigger('submit')
+    await flushPromises()
+    expect(calls[0]?.body).toMatchObject({ message: '<p>Go <strong>vote</strong>!</p>', subject: 'Vote + bring list' })
+  })
+
+  it('saves the current draft as a named template', async () => {
+    const w = await mountComposer()
+    await w.find('textarea').setValue('<p>Weekly nudge body</p>')
+    const openBtn = w.findAll('button').find(b => b.text().includes('Save as template'))
+    await openBtn?.trigger('click')
+    const nameInput = w.findAll('input').find(i => i.attributes('placeholder') === 'Template name')
+    await nameInput?.setValue('Weekly nudge')
+    const saveBtn = w.findAll('button').find(b => b.text().trim() === 'Save')
+    await saveBtn?.trigger('click')
+    await flushPromises()
+    expect(saveTemplate).toHaveBeenCalledWith('Weekly nudge', null, '<p>Weekly nudge body</p>')
+  })
+
+  it('deletes a template from its pill', async () => {
+    const w = await mountComposer()
+    const delBtn = w.findAll('button').find(b => b.attributes('aria-label') === 'Delete template Vote & bring list reminder')
+    await delBtn?.trigger('click')
+    await flushPromises()
+    expect(removeTemplate).toHaveBeenCalledWith(templates.value[0])
   })
 })

--- a/test/EventAnnounceComposer.nuxt.test.ts
+++ b/test/EventAnnounceComposer.nuxt.test.ts
@@ -22,7 +22,8 @@ const RichTextEditorStub = defineComponent({
 })
 
 const templates = ref([
-  { id: 't1', name: 'Vote & bring list reminder', subject: 'Vote + bring list', body: '<p>Go <strong>vote</strong>!</p>' }
+  { id: 't1', name: 'Vote & bring list reminder', subject: 'Vote + bring list', body: '<p>Go <strong>vote</strong>!</p>' },
+  { id: 't2', name: 'Plain nudge', subject: null, body: '<p>Nudge</p>' }
 ])
 const saveTemplate = vi.fn(() => Promise.resolve())
 const removeTemplate = vi.fn(() => Promise.resolve())
@@ -87,6 +88,16 @@ describe('EventAnnounceComposer', () => {
     await w.find('form').trigger('submit')
     await flushPromises()
     expect(calls[0]?.body).toMatchObject({ message: '<p>Go <strong>vote</strong>!</p>', subject: 'Vote + bring list' })
+  })
+
+  it('applying a subject-less template clears a previously typed subject', async () => {
+    const w = await mountComposer()
+    const subjectInput = w.findAll('input').find(i => i.attributes('placeholder') === 'Movie night reminder')
+    await subjectInput?.setValue('My old draft subject')
+    const pill = w.findAll('button').find(b => b.text().includes('Plain nudge'))
+    await pill?.trigger('click')
+    expect((subjectInput?.element as HTMLInputElement).value).toBe('')
+    expect((w.find('textarea').element as HTMLTextAreaElement).value).toBe('<p>Nudge</p>')
   })
 
   it('saves the current draft as a named template', async () => {

--- a/test/email.test.ts
+++ b/test/email.test.ts
@@ -9,6 +9,7 @@ import {
   escapeHtml,
   formatEmailDate,
   htmlToText,
+  sanitizeEmailHtml,
   uniqueEmails
 } from '../shared/utils/email'
 
@@ -183,9 +184,32 @@ describe('email utils', () => {
     expect(m.html).toContain('&lt;img')
   })
 
+  it('buildAnnounceEmail preserves the editor\'s rich formatting', () => {
+    const message = '<p>Two things:</p><ul><li><strong>Vote</strong> for the movie</li><li>Check the <em>bring list</em></li></ul>'
+    const m = buildAnnounceEmail({ eventTitle: 'Movie', eventDate: null, message, link: 'https://x/overview' })
+    expect(m.html).toContain('<ul><li><strong>Vote</strong> for the movie</li>')
+    expect(m.html).toContain('<em>bring list</em>')
+    // The plain-text alternative strips the markup but keeps the content.
+    expect(m.text).toContain('Vote for the movie')
+    expect(m.text).not.toContain('<li>')
+  })
+
+  it('buildAnnounceEmail still renders plain-text messages with line breaks', () => {
+    const m = buildAnnounceEmail({ eventTitle: 'Movie', eventDate: null, message: 'Doors at 7\nFirst film at 7:30', link: 'l' })
+    expect(m.html).toContain('Doors at 7<br>First film at 7:30')
+  })
+
   it('buildAnnounceEmail honors a custom subject', () => {
     const m = buildAnnounceEmail({ eventTitle: 'Movie', eventDate: null, message: 'hi', link: 'l', subject: 'Reminder!' })
     expect(m.subject).toBe('Reminder!')
+  })
+
+  it('sanitizeEmailHtml keeps only exact attribute-less editor tags', () => {
+    expect(sanitizeEmailHtml('<p>hi</p><h2>head</h2>')).toBe('<p>hi</p><h2>head</h2>')
+    // A tag with any attribute is not the exact literal form — it stays escaped.
+    expect(sanitizeEmailHtml('<p onclick="x()">hi</p>')).toBe('&lt;p onclick=&quot;x()&quot;&gt;hi</p>')
+    expect(sanitizeEmailHtml('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(sanitizeEmailHtml('<a href="https://evil">x</a>')).not.toContain('<a')
   })
 
   it('uniqueEmails lowercases, trims, and de-duplicates', () => {

--- a/test/useCommsTemplates.nuxt.test.ts
+++ b/test/useCommsTemplates.nuxt.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment nuxt
+import { beforeEach, describe, expect, it } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
+
+const calls = {
+  inserts: [] as Array<Record<string, unknown>>,
+  deletes: [] as Array<Record<string, unknown>>
+}
+const rows = [
+  { id: 't1', name: 'Vote & bring list reminder', subject: 'Reminder!', body: '<p>Vote</p>' }
+]
+
+const supabase = {
+  from() {
+    return {
+      select: () => ({ order: () => Promise.resolve({ data: rows, error: null }) }),
+      insert: (payload: Record<string, unknown>) => {
+        calls.inserts.push(payload)
+        return Promise.resolve({ error: null })
+      },
+      delete: () => ({
+        eq: (col: string, val: unknown) => {
+          calls.deletes.push({ [col]: val })
+          return Promise.resolve({ error: null })
+        }
+      })
+    }
+  }
+}
+
+mockNuxtImport('useSupabaseClient', () => () => supabase)
+
+beforeEach(() => {
+  calls.inserts = []
+  calls.deletes = []
+})
+
+describe('useCommsTemplates', () => {
+  it('loads templates ordered by name', async () => {
+    const { templates } = useCommsTemplates()
+    await flushPromises()
+    expect(templates.value).toEqual(rows)
+  })
+
+  it('saveTemplate inserts trimmed name/subject and omits created_by (DB defaults it)', async () => {
+    const { saveTemplate } = useCommsTemplates()
+    await saveTemplate('  Weekly nudge ', '  Hello  ', '<p>hi</p>')
+    expect(calls.inserts).toHaveLength(1)
+    expect(calls.inserts[0]).toEqual({ name: 'Weekly nudge', subject: 'Hello', body: '<p>hi</p>' })
+    expect(calls.inserts[0]).not.toHaveProperty('created_by')
+  })
+
+  it('saveTemplate stores a null subject when blank', async () => {
+    const { saveTemplate } = useCommsTemplates()
+    await saveTemplate('Nudge', '   ', '<p>hi</p>')
+    expect(calls.inserts[0]).toMatchObject({ subject: null })
+  })
+
+  it('saveTemplate refuses a blank name or body', async () => {
+    const { saveTemplate } = useCommsTemplates()
+    await saveTemplate('   ', null, '<p>hi</p>')
+    await saveTemplate('Nudge', null, '  ')
+    expect(calls.inserts).toHaveLength(0)
+  })
+
+  it('removeTemplate deletes by id', async () => {
+    const { removeTemplate } = useCommsTemplates()
+    await removeTemplate({ id: 't1', name: 'x', subject: null, body: 'b' })
+    expect(calls.deletes[0]).toEqual({ id: 't1' })
+  })
+})

--- a/test/useCommsTemplates.nuxt.test.ts
+++ b/test/useCommsTemplates.nuxt.test.ts
@@ -61,6 +61,8 @@ describe('useCommsTemplates', () => {
     const { saveTemplate } = useCommsTemplates()
     await saveTemplate('   ', null, '<p>hi</p>')
     await saveTemplate('Nudge', null, '  ')
+    // Markup with no text (an empty editor emits <p></p>) is still blank.
+    await saveTemplate('Nudge', null, '<p></p>')
     expect(calls.inserts).toHaveLength(0)
   })
 


### PR DESCRIPTION
## Scope

The Comms tab gets a full upgrade in three steps:

1. **Rich text composer** — the announcement message field is the same tiptap editor used for event descriptions, and the email preserves the formatting through a strict tag allowlist.
2. **Reusable templates** — compose a blast once (e.g. the "log in and vote + check the bring list" nudge), save it, apply it later with one click, **edit it in place**, or delete it. A starter "Vote & bring list reminder" template is seeded by migration.
3. **Clickable comms log with engagement** — each sent entry opens a detail modal showing the full message that went out, sent / delivered / opened / clicked counts, and a per-recipient status list that updates live as Resend webhook events arrive.

## Implementation

**Email rendering** (`shared/utils/email.ts`): `buildAnnounceEmail` treats the message as rich HTML. `sanitizeEmailHtml` escapes the entire message and restores only the exact attribute-less tags tiptap StarterKit emits — a tag carrying any attribute (`onerror=`, `href=`, `style=`) never matches the escaped literal, so nothing un-allowlisted survives. Plain-text alternative via the existing `htmlToText`; legacy plain-text messages still render.

**Templates** (`20260712000000_comms_templates.sql`): `comms_templates(id, name unique, subject, body, created_by, created_at)`, admin-only select/insert/update/delete RLS, seeded starter. `useCommsTemplates` (list/save/update/remove). In the composer: template pills apply body+subject (clearing a stale subject), "Save as template" names the current draft, "Update ⟨name⟩" overwrites the applied template, ✕ deletes.

**Engagement** (`20260712010000_comms_engagement.sql`): announcements previously went out as 49-recipient BCC groups — one Resend id shared across hidden recipients, so engagement was untrackable, and the announce route never recorded failures or status at all. `sendAnnounce` now sends one email per recipient via Resend's batch endpoint (addresses stay private — each guest sees only their own copy) and returns per-recipient Resend ids. The route stores the message `body` on `comms_log`, finally records `failed_count`/`status`/`error` (using the existing `commsStatus` helper), and inserts a `comms_recipients` row per accepted send. The Resend webhook stamps delivered/opened/clicked/bounced on **both** `event_invites` and `comms_recipients` by message id (the non-matching table is an indexed no-op). `comms_recipients` is in the realtime publication, so an open detail modal updates itself.

**UI**: `CommsLog` entries are clickable → `CommsLogDetailModal` (stats tiles, sanitized message render, recipient list with status badges). Sends predating this PR have no body/recipients and fall back to the logged totals with an explanatory note.

## Screenshots

Composer: toolbar'd editor + template pills + save/update buttons. Comms log: clickable cards → detail modal with engagement tiles. Captures on request.

## How to Test

1. Automated: `email.test.ts` (sanitizer allowlist + injection), `sendAnnounce.test.ts` (per-recipient batches, ids returned, partial failure), `useCommsTemplates` (save/update/remove guards incl. blank-markup), `EventAnnounceComposer` (apply/save/update/delete template, blank `<p></p>` rejected), `useCommsRecipients` (mapping + stat counts), `CommsLog`/`CommsLogDetailModal` (click-through, sanitizer routing, legacy fallbacks). Full suite: 491 passed; typecheck + build clean.
2. Manual: Admin → Comms → apply the seeded template → send to yourself → entry appears in the log → click it: full message + stats. Open the email; the Opened tile ticks up live (see note below). Edit the draft → "Update ⟨name⟩" → re-apply to confirm the edit stuck.

## Invariants & Risk

- **RLS**: `comms_templates` and `comms_recipients` are admin-only; the webhook writes via service role (below RLS) as it already did for `event_invites`.
- **Rendered HTML** (Invariant 5): the stored body reaches `v-html` only through `sanitizeHtml`; outgoing email HTML passes through the `sanitizeEmailHtml` allowlist. (Test-env note: the nuxt vitest environment's DOM mis-parses for DOMPurify, so the modal test asserts the sanitizer is applied via a marker mock; DOMPurify behavior itself is covered by `sanitize.test.ts` in a working DOM.)
- **Behavior change**: announcements are per-recipient emails now, not BCC groups. Same privacy (better, arguably), but a blast of N costs ceil(N/100) Resend requests instead of ceil(N/49) sends — fewer requests, and each recipient's copy is individually tracked.
- ⚠️ **Opens/clicks require Resend tracking enabled** for the sending domain (Resend dashboard → domain → open/click tracking), and the existing webhook must be subscribed to `email.delivered/opened/clicked/bounced` — already required for e-vite engagement, so likely already on.